### PR TITLE
Add an option to pass through a custom connection string to TES

### DIFF
--- a/src/deploy-tes-on-azure/Configuration.cs
+++ b/src/deploy-tes-on-azure/Configuration.cs
@@ -53,6 +53,7 @@ namespace TesDeployer
         public string ApplicationInsightsAccountName { get; set; }
         public string VmName { get; set; }
         public bool UseAks { get; set; } = true;
+        public string AzureServicesAuthConnectionString { get; set; }
         public string AksClusterName { get; set; }
         public string AksCoANamespace { get; set; } = "coa";
         public bool ManualHelmDeployment { get; set; }

--- a/src/deploy-tes-on-azure/Deployer.cs
+++ b/src/deploy-tes-on-azure/Deployer.cs
@@ -744,7 +744,7 @@ namespace TesDeployer
                 UpdateSetting(settings, defaults, "BatchAccountName", configuration.BatchAccountName, ignoreDefaults: true);
                 UpdateSetting(settings, defaults, "ApplicationInsightsAccountName", configuration.ApplicationInsightsAccountName, ignoreDefaults: true);
                 UpdateSetting(settings, defaults, "ManagedIdentityClientId", managedIdentityClientId, ignoreDefaults: true);
-                UpdateSetting(settings, defaults, "AzureServicesAuthConnectionString", managedIdentityClientId, s => $"RunAs=App;AppId={s}", ignoreDefaults: true);
+                UpdateSetting(settings, defaults, "AzureServicesAuthConnectionString", configuration.AzureServicesAuthConnectionString, defaultValue: $"RunAs=App;AppId={managedIdentityClientId}", ignoreDefaults: true);
                 UpdateSetting(settings, defaults, "KeyVaultName", configuration.KeyVaultName, ignoreDefaults: true);
                 UpdateSetting(settings, defaults, "AksCoANamespace", configuration.AksCoANamespace, ignoreDefaults: true);
                 var provisionPostgreSqlOnAzure = configuration.ProvisionPostgreSqlOnAzure.GetValueOrDefault();


### PR DESCRIPTION
Resolves https://github.com/microsoft/CromwellOnAzure/issues/457, TES already supports auth with Azure without managed identity with the AzureServicesAuthConnectionString environment variable, this adds the option to pass that through from the deployer. Tested by passing an app key from my aad account of the form RunAs=App;AppId={AppId};TenantId={TenantId};AppKey={ClientSecret} instead of the managed app id. https://learn.microsoft.com/en-us/dotnet/api/overview/azure/service-to-service-authentication?view=azure-dotnet#use-a-shared-secret-credential-to-sign-into-azure-ad