### PR TITLE
Change Azure Batch image to use HPC image

### DIFF
--- a/src/deploy-tes-on-azure/scripts/env-04-settings.txt
+++ b/src/deploy-tes-on-azure/scripts/env-04-settings.txt
@@ -1,9 +1,9 @@
 ﻿UsePreemptibleVmsOnly=false
 DisableBatchScheduling=false
 AzureOfferDurableId=MS-AZR-0003p
-BatchImageOffer=ubuntu-server-container
-BatchImagePublisher=microsoft-azure-batch
-BatchImageSku=20-04-lts
+BatchImageOffer=ubuntu-hpc
+BatchImagePublisher=microsoft-dsvm
+BatchImageSku=2004
 BatchImageVersion=latest
 BatchNodeAgentSkuId=batch.node.ubuntu 20.04
 MarthaUrl=

--- a/src/deploy-tes-on-azure/scripts/helm/templates/tes-deployment.yaml
+++ b/src/deploy-tes-on-azure/scripts/helm/templates/tes-deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: BatchImagePublisher
               value: {{ .Values.config.batchImagePublisher }}
             - name: BatchImageSku
-              value: {{ .Values.config.batchImageSku }}
+              value: {{ .Values.config.batchImageSku | quote }}
             - name: BatchImageVersion
               value: {{ .Values.config.batchImageVersion }}
             - name: BatchNodeAgentSkuId


### PR DESCRIPTION
This image is functionally equivalent to the previous and passes all integration tests
This image is available in Azure China
This image is the new best practice and LTS image according to the Azure Batch team