### PR TITLE
Remove periods from TES hostname

### DIFF
--- a/src/deploy-tes-on-azure/Deployer.cs
+++ b/src/deploy-tes-on-azure/Deployer.cs
@@ -874,7 +874,7 @@ namespace TesDeployer
 
                 UpdateSetting(settings, defaults, "EnableIngress", configuration.EnableIngress);
                 UpdateSetting(settings, defaults, "LetsEncryptEmail", configuration.LetsEncryptEmail);
-                UpdateSetting(settings, defaults, "TesHostname", $"{configuration.ResourceGroupName}.{configuration.RegionName}.cloudapp.azure.com", ignoreDefaults: true);
+                UpdateSetting(settings, defaults, "TesHostname", $"{configuration.ResourceGroupName.Replace(".", "")}.{configuration.RegionName}.cloudapp.azure.com", ignoreDefaults: true);
             }
 
             //if (installedVersion is null || installedVersion < new Version(3, 3))


### PR DESCRIPTION
When the resource group contains a period, it breaks the tes hostname