### PR TITLE
Output TES credentials to a JSON file on deployment

### DIFF
--- a/src/deploy-tes-on-azure/Configuration.cs
+++ b/src/deploy-tes-on-azure/Configuration.cs
@@ -74,6 +74,7 @@ namespace TesDeployer
         public bool UsePostgreSqlSingleServer { get; set; } = false;
         public string KeyVaultName { get; set; }
         public bool? EnableIngress { get; set; } = null;
+        public bool? OutputTesCredentialsJson { get; set; } = true;
         public string LetsEncryptEmail { get; set; } = null;
         public string TesUsername { get; set; } = "tes";
         public string TesPassword { get; set; }

--- a/src/deploy-tes-on-azure/Deployer.cs
+++ b/src/deploy-tes-on-azure/Deployer.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.WebSockets;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -502,9 +503,21 @@ namespace TesDeployer
 
                 if (configuration.EnableIngress.GetValueOrDefault())
                 {
-                    ConsoleEx.WriteLine($"TES ingress is enabled.");
+                    ConsoleEx.WriteLine($"TES ingress is enabled");
                     ConsoleEx.WriteLine($"TES is secured with basic auth at {kubernetesManager.TesHostname}");
-                    ConsoleEx.WriteLine($"TES username: '{configuration.TesUsername}' password: '{configuration.TesPassword}'");
+
+                    if (configuration.OutputTesCredentialsJson.GetValueOrDefault())
+                    {
+                        // Write credentials to JSON file in working directory
+                        var credentialsJson = System.Text.Json.JsonSerializer.Serialize(
+                            new { kubernetesManager.TesHostname, configuration.TesUsername, configuration.TesPassword });
+
+                        var credentialsPath = Path.Combine(Directory.GetCurrentDirectory(), "TesCredentials.json");
+                        await File.WriteAllTextAsync(credentialsPath, credentialsJson);
+                        ConsoleEx.WriteLine($"TES credentials file written to: {credentialsPath}");
+                    }
+
+
 
                     if (isBatchQuotaAvailable)
                     {


### PR DESCRIPTION
If ingress is enabled, output the TES credentials to a JSON file by default.  This will also enable the TES spec compliance tool to connect to TES 