### PR TITLE
Container look/discovery is configurable

### DIFF
--- a/src/TesApi.Tests/CachingWithRetriesAzureProxyTests.cs
+++ b/src/TesApi.Tests/CachingWithRetriesAzureProxyTests.cs
@@ -4,9 +4,6 @@
 
 using System;
 using System.Threading.Tasks;
-using LazyCache;
-using LazyCache.Providers;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Polly.Utilities;
@@ -74,62 +71,6 @@ namespace TesApi.Tests
             serviceProvider.AzureProxy.Verify(mock => mock.GetStorageAccountInfoAsync("defaultstorageaccount"), Times.Exactly(2));
             Assert.IsNull(info1);
             Assert.AreEqual(storageAccountInfo, info2);
-        }
-
-        [TestMethod]
-        public async Task GetContainerRegistryInfoAsync_UsesCache()
-        {
-            var containerRegistryInfo = new ContainerRegistryInfo { RegistryServer = "registryServer1", Username = "default", Password = "placeholder" };
-
-            using var serviceProvider = new TestServices.TestServiceProvider<CachingWithRetriesAzureProxy>(azureProxy: a =>
-            {
-                PrepareAzureProxy(a);
-                a.Setup(a => a.GetContainerRegistryInfoAsync(It.IsAny<string>())).Returns(Task.FromResult(containerRegistryInfo));
-            });
-            var cachingAzureProxy = serviceProvider.GetT();
-
-            var info1 = await cachingAzureProxy.GetContainerRegistryInfoAsync("registryServer1/imageName1:tag1");
-            var info2 = await cachingAzureProxy.GetContainerRegistryInfoAsync("registryServer1/imageName1:tag1");
-
-            serviceProvider.AzureProxy.Verify(mock => mock.GetContainerRegistryInfoAsync("registryServer1/imageName1:tag1"), Times.Once());
-            Assert.AreEqual(containerRegistryInfo, info1);
-            Assert.AreEqual(info1, info2);
-        }
-
-        [TestMethod]
-        public async Task GetContainerRegistryInfoAsync_NullInfo_DoesNotSetCache()
-        {
-            using var serviceProvider = new TestServices.TestServiceProvider<CachingWithRetriesAzureProxy>(azureProxy: a =>
-            {
-                PrepareAzureProxy(a);
-                a.Setup(a => a.GetContainerRegistryInfoAsync(It.IsAny<string>())).Returns(Task.FromResult((ContainerRegistryInfo)null));
-            });
-            var cachingAzureProxy = serviceProvider.GetT();
-            var info1 = await cachingAzureProxy.GetContainerRegistryInfoAsync("registryServer1/imageName1:tag1");
-
-            var containerRegistryInfo = new ContainerRegistryInfo { RegistryServer = "registryServer1", Username = "default", Password = "placeholder" };
-            serviceProvider.AzureProxy.Setup(a => a.GetContainerRegistryInfoAsync(It.IsAny<string>())).Returns(Task.FromResult(containerRegistryInfo));
-            var info2 = await cachingAzureProxy.GetContainerRegistryInfoAsync("registryServer1/imageName1:tag1");
-
-            serviceProvider.AzureProxy.Verify(mock => mock.GetContainerRegistryInfoAsync("registryServer1/imageName1:tag1"), Times.Exactly(2));
-            Assert.IsNull(info1);
-            Assert.AreEqual(containerRegistryInfo, info2);
-        }
-
-        [TestMethod]
-        public async Task GetContainerRegistryInfoAsync_ThrowsException_DoesNotSetCache()
-        {
-            SystemClock.SleepAsync = (_, __) => Task.FromResult(true);
-            SystemClock.Sleep = (_, __) => { };
-            using var serviceProvider = new TestServices.TestServiceProvider<CachingWithRetriesAzureProxy>(azureProxy: a =>
-            {
-                PrepareAzureProxy(a);
-                a.Setup(a => a.GetContainerRegistryInfoAsync("throw/exception:tag1")).Throws<Exception>();
-            });
-            var cachingAzureProxy = serviceProvider.GetT();
-
-            await Assert.ThrowsExceptionAsync<Exception>(async () => await cachingAzureProxy.GetContainerRegistryInfoAsync("throw/exception:tag1"));
-            serviceProvider.AzureProxy.Verify(mock => mock.GetContainerRegistryInfoAsync("throw/exception:tag1"), Times.Exactly(4));
         }
 
         [TestMethod]

--- a/src/TesApi.Tests/ContainerRegistryProviderTests.cs
+++ b/src/TesApi.Tests/ContainerRegistryProviderTests.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LazyCache;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using TesApi.Web;
+using TesApi.Web.Management;
+using TesApi.Web.Management.Configuration;
+
+namespace TesApi.Tests
+{
+    [TestClass]
+    [TestCategory("unit")]
+    public class ContainerRegistryProviderTests
+    {
+        private ContainerRegistryProvider containerRegistryProvider;
+        private ContainerRegistryOptions containerRegistryOptions;
+        private Mock<CacheAndRetryHandler> retryHandlerMock;
+        private Mock<IAppCache> appCacheMock;
+        private Mock<IOptions<ContainerRegistryOptions>> containerRegistryOptionsMock;
+        private Mock<AzureManagementClientsFactory> clientFactoryMock;
+
+
+
+        [TestInitialize]
+        public void Setup()
+        {
+            appCacheMock = new Mock<IAppCache>();
+            retryHandlerMock = new Mock<CacheAndRetryHandler>();
+            retryHandlerMock.Setup(r => r.AppCache).Returns(appCacheMock.Object);
+            clientFactoryMock = new Mock<AzureManagementClientsFactory>();
+            containerRegistryOptionsMock = new Mock<IOptions<ContainerRegistryOptions>>();
+            containerRegistryOptions = new ContainerRegistryOptions();
+            containerRegistryOptionsMock.Setup(o => o.Value).Returns(containerRegistryOptions);
+            containerRegistryProvider = new ContainerRegistryProvider(containerRegistryOptionsMock.Object,
+                retryHandlerMock.Object, clientFactoryMock.Object, new NullLogger<ContainerRegistryProvider>());
+        }
+
+        [TestMethod]
+        public async Task GetContainerRegistryInfoAsync_ServerIsAccessible_ReturnsAndAddsToCacheRegistryInformation()
+        {
+            var server = "registry";
+            var image = $"{server}/image";
+            retryHandlerMock.Setup(r =>
+                    r.ExecuteWithRetryAsync(It.IsAny<Func<Task<IEnumerable<ContainerRegistryInfo>>>>()))
+                .ReturnsAsync(new List<ContainerRegistryInfo>()
+                {
+                    new ContainerRegistryInfo() { RegistryServer = server }
+                });
+
+            var container = await containerRegistryProvider.GetContainerRegistryInfoAsync(image);
+
+            Assert.IsNotNull(container);
+            Assert.AreEqual(server, container.RegistryServer);
+            appCacheMock.Verify(
+                c => c.Add(It.Is<string>(v => v.Equals(image)), It.IsAny<ContainerRegistryInfo>(),
+                    It.IsAny<MemoryCacheEntryOptions>()), Times.Once());
+        }
+
+        [TestMethod]
+        public async Task GetContainerRegistryInfoAsync_ServerInCache_ReturnsRegistryInformationFromCacheAndNoListingOfRegistries()
+        {
+            var server = "registry";
+            var image = $"{server}/image";
+            appCacheMock.Setup(c => c.Get<ContainerRegistryInfo>(It.Is<string>(v => v.Equals(image))))
+                .Returns(new ContainerRegistryInfo() { RegistryServer = server });
+
+            var container = await containerRegistryProvider.GetContainerRegistryInfoAsync(image);
+
+            Assert.IsNotNull(container);
+            Assert.AreEqual(server, container.RegistryServer);
+            appCacheMock.Verify(c => c.Get<ContainerRegistryInfo>(It.Is<string>(v => v.Equals(image))), Times.Once());
+            retryHandlerMock.Verify(r =>
+                r.ExecuteWithRetryAsync(It.IsAny<Func<Task<IEnumerable<ContainerRegistryInfo>>>>()), Times.Never);
+
+        }
+
+        [TestMethod]
+        public async Task GetContainerRegistryInfoAsync_NoAccessibleServerNoServerCached_ReturnsNullNotAddedToCache()
+        {
+            var server = "registry";
+            var image = $"{server}_other/image";
+            retryHandlerMock.Setup(r =>
+                    r.ExecuteWithRetryAsync(It.IsAny<Func<Task<IEnumerable<ContainerRegistryInfo>>>>()))
+                .ReturnsAsync(new List<ContainerRegistryInfo>()
+                {
+                    new ContainerRegistryInfo() { RegistryServer = server }
+                });
+
+            var container = await containerRegistryProvider.GetContainerRegistryInfoAsync(image);
+
+            Assert.IsNull(container);
+            appCacheMock.Verify(
+                c => c.Add(It.Is<string>(v => v.Equals(image)), It.IsAny<ContainerRegistryInfo>(),
+                    It.IsAny<MemoryCacheEntryOptions>()), Times.Never);
+        }
+    }
+}

--- a/src/TesApi.Tests/TestServices/TestServiceProvider.cs
+++ b/src/TesApi.Tests/TestServices/TestServiceProvider.cs
@@ -39,8 +39,10 @@ namespace TesApi.Tests.TestServices
             Action<Mock<IBatchSkuInformationProvider>> batchSkuInformationProvider = default,
             Action<Mock<IBatchQuotaProvider>> batchQuotaProvider = default,
             (Func<IServiceProvider, System.Linq.Expressions.Expression<Func<ArmBatchQuotaProvider>>> expression, Action<Mock<ArmBatchQuotaProvider>> action) armBatchQuotaProvider = default, //added so config utils gets the arm implementation, to be removed once config utils is refactored.
+            Action<Mock<ContainerRegistryProvider>> containerRegistryProviderSetup = default,
             Action<IServiceCollection> additionalActions = default)
             => provider = new ServiceCollection()
+                .AddSingleton(_ => GetContainerRegisterProvider(containerRegistryProviderSetup).Object)
                 .AddSingleton(_ => GetConfiguration(configuration))
                 .AddSingleton(s => wrapAzureProxy ? ActivatorUtilities.CreateInstance<CachingWithRetriesAzureProxy>(s, GetAzureProxy(azureProxy).Object) : GetAzureProxy(azureProxy).Object)
                 .AddSingleton(_ => GetTesTaskRepository(tesTaskRepository).Object)
@@ -69,6 +71,7 @@ namespace TesApi.Tests.TestServices
                 .IfThenElse(additionalActions is null, s => s, s => { additionalActions(s); return s; })
             .BuildServiceProvider();
 
+
         internal IConfiguration Configuration { get; private set; }
         internal Mock<IAzureProxy> AzureProxy { get; private set; }
         internal Mock<IBatchSkuInformationProvider> BatchSkuInformationProvider { get; private set; }
@@ -76,6 +79,7 @@ namespace TesApi.Tests.TestServices
         internal Mock<ArmBatchQuotaProvider> ArmBatchQuotaProvider { get; private set; } //added so config utils gets the arm implementation, to be removed once config utils is refactored.
         internal Mock<IRepository<TesTask>> TesTaskRepository { get; private set; }
         internal Mock<IStorageAccessProvider> StorageAccessProvider { get; private set; }
+        internal Mock<ContainerRegistryProvider> ContainerRegistryProvider { get; private set; }
 
         internal T GetT()
             => GetT(Array.Empty<Type>(), Array.Empty<object>());
@@ -129,6 +133,13 @@ namespace TesApi.Tests.TestServices
             var proxy = new Mock<IAzureProxy>();
             action?.Invoke(proxy);
             return AzureProxy = proxy;
+        }
+
+        private Mock<ContainerRegistryProvider> GetContainerRegisterProvider(Action<Mock<ContainerRegistryProvider>> action)
+        {
+            var proxy = new Mock<ContainerRegistryProvider>();
+            action?.Invoke(proxy);
+            return ContainerRegistryProvider = proxy;
         }
 
         private Mock<IBatchSkuInformationProvider> GetBatchSkuInformationProvider(Action<Mock<IBatchSkuInformationProvider>> action)

--- a/src/TesApi.Web/CachingWithRetriesAzureProxy.cs
+++ b/src/TesApi.Web/CachingWithRetriesAzureProxy.cs
@@ -75,24 +75,6 @@ namespace TesApi.Web
         public Task<AzureBatchJobAndTaskState> GetBatchJobAndTaskStateAsync(string tesTaskId) => asyncRetryPolicy.ExecuteAsync(() => azureProxy.GetBatchJobAndTaskStateAsync(tesTaskId));
 
         /// <inheritdoc/>
-        //public async Task<ContainerRegistryInfo> GetContainerRegistryInfoAsync(string imageName)
-        //{
-        //    var containerRegistryInfo = cache.Get<ContainerRegistryInfo>(imageName);
-
-        //    if (containerRegistryInfo is null)
-        //    {
-        //        containerRegistryInfo = await asyncRetryPolicy.ExecuteAsync(() => azureProxy.GetContainerRegistryInfoAsync(imageName));
-
-        //        if (containerRegistryInfo is not null)
-        //        {
-        //            cache.Add(imageName, containerRegistryInfo, DateTimeOffset.Now.AddHours(1));
-        //        }
-        //    }
-
-        //    return containerRegistryInfo;
-        //}
-
-        /// <inheritdoc/>
         public Task<string> GetNextBatchJobIdAsync(string tesTaskId) => asyncRetryPolicy.ExecuteAsync(() => azureProxy.GetNextBatchJobIdAsync(tesTaskId));
 
         /// <inheritdoc/>

--- a/src/TesApi.Web/CachingWithRetriesAzureProxy.cs
+++ b/src/TesApi.Web/CachingWithRetriesAzureProxy.cs
@@ -75,22 +75,22 @@ namespace TesApi.Web
         public Task<AzureBatchJobAndTaskState> GetBatchJobAndTaskStateAsync(string tesTaskId) => asyncRetryPolicy.ExecuteAsync(() => azureProxy.GetBatchJobAndTaskStateAsync(tesTaskId));
 
         /// <inheritdoc/>
-        public async Task<ContainerRegistryInfo> GetContainerRegistryInfoAsync(string imageName)
-        {
-            var containerRegistryInfo = cache.Get<ContainerRegistryInfo>(imageName);
+        //public async Task<ContainerRegistryInfo> GetContainerRegistryInfoAsync(string imageName)
+        //{
+        //    var containerRegistryInfo = cache.Get<ContainerRegistryInfo>(imageName);
 
-            if (containerRegistryInfo is null)
-            {
-                containerRegistryInfo = await asyncRetryPolicy.ExecuteAsync(() => azureProxy.GetContainerRegistryInfoAsync(imageName));
+        //    if (containerRegistryInfo is null)
+        //    {
+        //        containerRegistryInfo = await asyncRetryPolicy.ExecuteAsync(() => azureProxy.GetContainerRegistryInfoAsync(imageName));
 
-                if (containerRegistryInfo is not null)
-                {
-                    cache.Add(imageName, containerRegistryInfo, DateTimeOffset.Now.AddHours(1));
-                }
-            }
+        //        if (containerRegistryInfo is not null)
+        //        {
+        //            cache.Add(imageName, containerRegistryInfo, DateTimeOffset.Now.AddHours(1));
+        //        }
+        //    }
 
-            return containerRegistryInfo;
-        }
+        //    return containerRegistryInfo;
+        //}
 
         /// <inheritdoc/>
         public Task<string> GetNextBatchJobIdAsync(string tesTaskId) => asyncRetryPolicy.ExecuteAsync(() => azureProxy.GetNextBatchJobIdAsync(tesTaskId));

--- a/src/TesApi.Web/IAzureProxy.cs
+++ b/src/TesApi.Web/IAzureProxy.cs
@@ -38,13 +38,6 @@ namespace TesApi.Web
         Task CreateBatchJobAsync(string jobId, CloudTask cloudTask, PoolInformation poolInformation);
 
         /// <summary>
-        /// Gets the <see cref="ContainerRegistryInfo"/> for the given image name
-        /// </summary>
-        /// <param name="imageName">Image name</param>
-        /// <returns><see cref="ContainerRegistryInfo"/></returns>
-      //  Task<ContainerRegistryInfo> GetContainerRegistryInfoAsync(string imageName);
-
-        /// <summary>
         /// Gets the <see cref="StorageAccountInfo"/> for the given storage account name
         /// </summary>
         /// <param name="storageAccountName">Storage account name</param>
@@ -89,12 +82,6 @@ namespace TesApi.Web
         /// </summary>
         /// <returns>Count of active batch jobs</returns>
         int GetBatchActiveJobCount();
-
-        ///// <summary>
-        ///// Get/sets cached value for the price and resource summary of all available VMs in a region for the <see cref="BatchModels.BatchAccount"/>.
-        ///// </summary>
-        ///// <returns><see cref="VirtualMachineInformation"/> for available VMs in a region.</returns>
-        //Task<List<VirtualMachineInformation>> GetVmSizesAndPricesAsync();
 
         /// <summary>
         /// Gets the primary key of the given storage account.

--- a/src/TesApi.Web/IAzureProxy.cs
+++ b/src/TesApi.Web/IAzureProxy.cs
@@ -42,7 +42,7 @@ namespace TesApi.Web
         /// </summary>
         /// <param name="imageName">Image name</param>
         /// <returns><see cref="ContainerRegistryInfo"/></returns>
-        Task<ContainerRegistryInfo> GetContainerRegistryInfoAsync(string imageName);
+      //  Task<ContainerRegistryInfo> GetContainerRegistryInfoAsync(string imageName);
 
         /// <summary>
         /// Gets the <see cref="StorageAccountInfo"/> for the given storage account name

--- a/src/TesApi.Web/Management/AzureManagementClientsFactory.cs
+++ b/src/TesApi.Web/Management/AzureManagementClientsFactory.cs
@@ -49,6 +49,11 @@ namespace TesApi.Web.Management
             this.batchAccountInformation = batchAccountInformation;
         }
 
+        /// <summary>
+        /// Protected constructor.
+        /// </summary>
+        protected AzureManagementClientsFactory() { }
+
         private static Task<string> GetAzureAccessTokenAsync(string resource = "https://management.azure.com/")
             => new AzureServiceTokenProvider().GetAccessTokenAsync(resource);
 
@@ -60,6 +65,15 @@ namespace TesApi.Web.Management
         public async Task<BatchManagementClient> CreateBatchAccountManagementClient()
         {
             return new BatchManagementClient(new TokenCredentials(await GetAzureAccessTokenAsync())) { SubscriptionId = batchAccountInformation.SubscriptionId };
+        }
+
+        /// <summary>
+        /// Creates a new instance of Azure Management Client with the default credentials and subscription.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<FluentAzure.IAuthenticated> CreateAzureManagementClientAsync()
+        {
+            return await AzureManagementClientsFactory.GetAzureManagementClientAsync();
         }
 
         /// <summary>
@@ -83,7 +97,6 @@ namespace TesApi.Web.Management
                 var batchAccount = (await batchClient.BatchAccount.ListAsync())
                     .FirstOrDefault(a => a.Name.Equals(batchAccountName, StringComparison.OrdinalIgnoreCase));
 
-
                 if (batchAccount is not null)
                 {
                     return BatchAccountResourceInformation.FromBatchResourceId(batchAccount.Id, batchAccount.Location);
@@ -93,7 +106,7 @@ namespace TesApi.Web.Management
             return null;
         }
 
-        private static async Task<FluentAzure.IAuthenticated> GetAzureManagementClientAsync()
+        public static async Task<FluentAzure.IAuthenticated> GetAzureManagementClientAsync()
         {
             var accessToken = await GetAzureAccessTokenAsync();
             var azureCredentials = new AzureCredentials(new TokenCredentials(accessToken), null, null, AzureEnvironment.AzureGlobalCloud);

--- a/src/TesApi.Web/Management/AzureProvider.cs
+++ b/src/TesApi.Web/Management/AzureProvider.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+
+namespace TesApi.Web.Management
+{
+    /// <summary>
+    /// Base class of providers that require access to Azure management API with retry an caching capabilities 
+    /// </summary>
+    public abstract class AzureProvider
+    {
+        private protected readonly CacheAndRetryHandler CacheAndRetryHandler;
+        private protected readonly AzureManagementClientsFactory ManagementClientsFactory;
+        private protected readonly ILogger Logger;
+
+        /// <summary>
+        /// Protected constructor AzureProvider
+        /// </summary>
+        /// <param name="cacheAndRetryHandler"><see cref="CacheAndRetryHandler"/></param>
+        /// <param name="managementClientsFactory"><see cref="ManagementClientsFactory"/></param>
+        /// <param name="logger"><see cref="ILogger{TCategoryName}"/>></param>
+        protected AzureProvider(CacheAndRetryHandler cacheAndRetryHandler, AzureManagementClientsFactory managementClientsFactory, ILogger logger)
+        {
+            ArgumentNullException.ThrowIfNull(cacheAndRetryHandler);
+            ArgumentNullException.ThrowIfNull(managementClientsFactory);
+            ArgumentNullException.ThrowIfNull(logger);
+
+            this.CacheAndRetryHandler = cacheAndRetryHandler;
+            this.ManagementClientsFactory = managementClientsFactory;
+            this.Logger = logger;
+        }
+
+        /// <summary>
+        /// Protected parameter-less constructor 
+        /// </summary>
+        protected AzureProvider() { }
+    }
+}

--- a/src/TesApi.Web/Management/Configuration/ContainerRegistryOptions.cs
+++ b/src/TesApi.Web/Management/Configuration/ContainerRegistryOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace TesApi.Web.Management.Configuration;
+
+public class ContainerRegistryOptions
+{
+    public const string ContainerRegistrySection = "ContainerRegistry";
+    public bool AutoDiscoveryEnabled { get; set; } = true;
+    public int RegistryInfoCacheExpirationInHours { get; set; } = 1;
+}

--- a/src/TesApi.Web/Management/Configuration/ContainerRegistryOptions.cs
+++ b/src/TesApi.Web/Management/Configuration/ContainerRegistryOptions.cs
@@ -1,8 +1,20 @@
 ﻿namespace TesApi.Web.Management.Configuration;
 
+/// <summary>
+/// Configuration options for container registries
+/// </summary>
 public class ContainerRegistryOptions
 {
+    /// <summary>
+    /// Configuration section.
+    /// </summary>
     public const string ContainerRegistrySection = "ContainerRegistry";
+    /// <summary>
+    /// Enables/disables auto-discovery features 
+    /// </summary>
     public bool AutoDiscoveryEnabled { get; set; } = true;
+    /// <summary>
+    /// Controls for how long registry information is cached
+    /// </summary>
     public int RegistryInfoCacheExpirationInHours { get; set; } = 1;
 }

--- a/src/TesApi.Web/Management/ContainerRegistryProvider.cs
+++ b/src/TesApi.Web/Management/ContainerRegistryProvider.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Management.ContainerRegistry.Fluent;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using TesApi.Web.Management.Configuration;
+
+namespace TesApi.Web.Management
+{
+    /// <summary>
+    /// Provides container registry information 
+    /// </summary>
+    public class ContainerRegistryProvider : AzureProvider
+    {
+        private readonly ContainerRegistryOptions options;
+
+        /// <summary>
+        /// If true the auto-discovery is enabled. 
+        /// </summary>
+        public bool IsAutoDiscoveryEnabled => options.AutoDiscoveryEnabled;
+
+        /// <summary>
+        /// Provides resource information about the container registries the TES service has access. 
+        /// </summary>
+        /// <param name="containerRegistryOptions"></param>
+        /// <param name="cacheAndRetryHandler"></param>
+        /// <param name="logger"></param>
+        /// <param name="azureManagementClientsFactory"></param>
+        public ContainerRegistryProvider(IOptions<ContainerRegistryOptions> containerRegistryOptions, CacheAndRetryHandler cacheAndRetryHandler, AzureManagementClientsFactory azureManagementClientsFactory, ILogger<ContainerRegistryProvider> logger)
+            : base(cacheAndRetryHandler, azureManagementClientsFactory, logger)
+        {
+            ArgumentNullException.ThrowIfNull(containerRegistryOptions);
+            ArgumentNullException.ThrowIfNull(containerRegistryOptions.Value);
+
+            this.options = containerRegistryOptions.Value;
+        }
+
+        /// <summary>
+        /// Protected constructor
+        /// </summary>
+        protected ContainerRegistryProvider() { }
+
+        /// <summary>
+        /// Looks for the container registry information from the image name.  
+        /// </summary>
+        /// <param name="imageName">Container image name</param>
+        /// <returns>Container registry information, or null if auto-discovery is disabled or the repository was not found</returns>
+        public virtual async Task<ContainerRegistryInfo> GetContainerRegistryInfoAsync(string imageName)
+        {
+            if (!options.AutoDiscoveryEnabled)
+            {
+                return null;
+            }
+
+            var containerRegistryInfo = CacheAndRetryHandler.AppCache.Get<ContainerRegistryInfo>(imageName);
+
+            if (containerRegistryInfo is not null)
+            {
+                return containerRegistryInfo;
+            }
+
+            return await LookUpAndAddToCacheContainerRegistryInfoAsync(imageName);
+
+        }
+
+        private async Task<ContainerRegistryInfo> LookUpAndAddToCacheContainerRegistryInfoAsync(string imageName)
+        {
+            var repositories = await CacheAndRetryHandler.ExecuteWithRetryAsync(GetAccessibleContainerRegistriesAsync);
+
+            var requestedRepo = repositories.FirstOrDefault(reg =>
+                reg.RegistryServer.Equals(imageName.Split('/').FirstOrDefault(), StringComparison.OrdinalIgnoreCase));
+
+            if (requestedRepo is not null)
+            {
+                Logger.LogInformation($"Requested repository: {imageName} was found.");
+
+                CacheAndRetryHandler.AppCache.Add<ContainerRegistryInfo>(imageName, requestedRepo,
+                    //I find kind of odd the Add method of the cache does not exposes the expiration directly as param as the GetOrAdd method does.
+                    new MemoryCacheEntryOptions()
+                    {
+                        AbsoluteExpiration = DateTimeOffset.UtcNow.AddHours(options.RegistryInfoCacheExpirationInHours)
+                    });
+
+                return requestedRepo;
+            }
+
+            Logger.LogWarning($"The TES service did not find the requested repository: {imageName}");
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the list of container registries the TES service has access to
+        /// </summary>
+        /// <returns>List of container registries. null if the TES service does not have access if auto-discovery is enabled </returns>
+        private async Task<IEnumerable<ContainerRegistryInfo>> GetAccessibleContainerRegistriesAsync()
+        {
+            if (!options.AutoDiscoveryEnabled)
+            {
+                return null;
+            }
+
+            var azureClient = await ManagementClientsFactory.CreateAzureManagementClientAsync();
+
+            var subscriptionIds = (await azureClient.Subscriptions.ListAsync()).Select(s => s.SubscriptionId);
+
+            var infos = new List<ContainerRegistryInfo>();
+
+            Logger.LogInformation(@"GetAccessibleContainerRegistriesAsync() called.");
+
+            foreach (var subId in subscriptionIds)
+            {
+                try
+                {
+                    var registries = (await azureClient.WithSubscription(subId).ContainerRegistries.ListAsync()).ToList();
+
+                    Logger.LogInformation(@$"Searching {subId} for container registries.");
+
+                    foreach (var r in registries)
+                    {
+                        Logger.LogInformation(@$"Found {r.Name}. AdminUserEnabled: {r.AdminUserEnabled}");
+
+                        try
+                        {
+                            var server = await r.GetCredentialsAsync();
+
+                            var info = new ContainerRegistryInfo { RegistryServer = r.LoginServerUrl, Username = server.Username, Password = server.AccessKeys[AccessKeyType.Primary] };
+
+                            infos.Add(info);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.LogWarning($"TES service doesn't have permission to get credentials for registry {r.LoginServerUrl}.  Please verify that 'Admin user' is enabled in the 'Access Keys' area in the Azure Portal for this container registry.  Exception: {ex}");
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning($"TES service doesn't have permission to list container registries in subscription {subId}.  Exception: {ex}");
+                }
+            }
+
+            Logger.LogInformation(@"GetAccessibleContainerRegistriesAsync() returning {Count} registries.", infos.Count);
+
+            return infos;
+        }
+
+    }
+}

--- a/src/TesApi.Web/Startup.cs
+++ b/src/TesApi.Web/Startup.cs
@@ -80,6 +80,7 @@ namespace TesApi.Web
                 .AddSingleton<IStorageAccessProvider, StorageAccessProvider>()
 
                 .AddLogging()
+                .AddSingleton<ContainerRegistryProvider, ContainerRegistryProvider>()
                 .AddSingleton<CacheAndRetryHandler, CacheAndRetryHandler>()
                 .AddSingleton<IBatchQuotaVerifier, BatchQuotaVerifier>()
                 .AddSingleton<IBatchScheduler, BatchScheduler>()

--- a/src/TesApi.Web/TesApi.Web.csproj
+++ b/src/TesApi.Web/TesApi.Web.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.8.1" />
+    <PackageReference Include="Azure.ResourceManager" Version="1.3.2" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />

--- a/src/TesApi.Web/appsettings.json
+++ b/src/TesApi.Web/appsettings.json
@@ -22,5 +22,9 @@
   "RetryPolicyOptions": {
     "MaxRetryCount": 5,
     "ExponentialBackOffExponent": 2
+  },
+  "ContainerRegistryOptions": {
+    "AutoDiscoveryEnabled": true,
+    "RegistryInfoCacheExpirationInHour": 1
   }
 }


### PR DESCRIPTION
- Refactored the Container registry look-up process into its own class - `ContainerRegistryProvider`
- New configuration section for Container registry information: `ContainerRegistryOptiopns`
  -  The `AutoDiscoveryEnabled` option controls if container discovery is attempted or not. Default is `true`  
 
Closes #39 