### PR TITLE
Terra WSM API Client, SAS Token operation

### DIFF
--- a/src/TesApi.Tests/TerraApiStubData.cs
+++ b/src/TesApi.Tests/TerraApiStubData.cs
@@ -6,10 +6,14 @@ namespace TesApi.Tests;
 
 public class TerraApiStubData
 {
-    public string ApiHost => "https://landingzone.host";
+    public string LandingZoneApiHost => "https://landingzone.host";
+    public string WsmApiHost => "https://wsm.host";
+
     public string ResourceGroup => "mrg-terra-dev-previ-20191228";
     public Guid LandingZoneId { get; } = Guid.NewGuid();
     public Guid SubscriptionId { get; } = Guid.NewGuid();
+    public Guid WorkspaceId { get; } = Guid.NewGuid();
+    public Guid ContainerResourceId { get; } = Guid.NewGuid();
 
     public string BatchAccountId =>
         $"/subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroup}/providers/Microsoft.Batch/batchAccounts/lzee170c71b6cf678cfca744";
@@ -21,6 +25,19 @@ public class TerraApiStubData
     public QuotaApiResponse GetResourceQuotaApiResponse()
     {
         return JsonSerializer.Deserialize<QuotaApiResponse>(GetResourceQuotaApiResponseInJson());
+    }
+
+    public WsmSasTokenApiResponse GetWsmSasTokenApiResponse()
+    {
+        return JsonSerializer.Deserialize<WsmSasTokenApiResponse>(GetWsmSasTokenApiResponseInJson());
+    }
+
+    public string GetWsmSasTokenApiResponseInJson()
+    {
+        return @"{
+  ""token"": ""SASTOKENSTUB="",
+  ""url"": ""https://bloburl.org/container?sas=SASTOKENSUTB=""
+    }";
     }
 
     public string GetResourceApiResponseInJson()

--- a/src/TesApi.Tests/TerraLandingZoneApiClientTest.cs
+++ b/src/TesApi.Tests/TerraLandingZoneApiClientTest.cs
@@ -25,7 +25,7 @@ namespace TesApi.Tests
             terraApiStubData = new TerraApiStubData();
             tokenCredential = new Mock<TokenCredential>();
             cacheAndRetryHandler = new Mock<CacheAndRetryHandler>();
-            terraLandingZoneApiClient = new TerraLandingZoneApiClient(terraApiStubData.ApiHost, tokenCredential.Object, cacheAndRetryHandler.Object, NullLogger<TerraLandingZoneApiClient>.Instance);
+            terraLandingZoneApiClient = new TerraLandingZoneApiClient(terraApiStubData.LandingZoneApiHost, tokenCredential.Object, cacheAndRetryHandler.Object, NullLogger<TerraLandingZoneApiClient>.Instance);
         }
 
         [TestMethod]
@@ -79,7 +79,7 @@ namespace TesApi.Tests
         {
             var url = terraLandingZoneApiClient.GetLandingZoneResourcesApiUrl(terraApiStubData.LandingZoneId);
 
-            var expectedUrl = $"{terraApiStubData.ApiHost}/api/landingzones/v1/azure/{terraApiStubData.LandingZoneId}/resources";
+            var expectedUrl = $"{terraApiStubData.LandingZoneApiHost}/api/landingzones/v1/azure/{terraApiStubData.LandingZoneId}/resources";
 
             Assert.AreEqual(expectedUrl, url.ToString());
 
@@ -90,7 +90,7 @@ namespace TesApi.Tests
         {
             var url = terraLandingZoneApiClient.GetQuotaApiUrl(terraApiStubData.LandingZoneId, terraApiStubData.BatchAccountId);
 
-            var expectedUrl = $"{terraApiStubData.ApiHost}/api/landingzones/v1/azure/{terraApiStubData.LandingZoneId}/resource-quota?azureResourceId={Uri.EscapeDataString(terraApiStubData.BatchAccountId)}";
+            var expectedUrl = $"{terraApiStubData.LandingZoneApiHost}/api/landingzones/v1/azure/{terraApiStubData.LandingZoneId}/resource-quota?azureResourceId={Uri.EscapeDataString(terraApiStubData.BatchAccountId)}";
 
             Assert.AreEqual(expectedUrl, url.ToString());
 

--- a/src/TesApi.Tests/TerraQuotaProviderTests.cs
+++ b/src/TesApi.Tests/TerraQuotaProviderTests.cs
@@ -28,7 +28,7 @@ namespace TesApi.Tests
             quotaApiResponse = terraApiStubData.GetResourceQuotaApiResponse();
 
             var optionsMock = new Mock<IOptions<TerraOptions>>();
-            optionsMock.Setup(o => o.Value).Returns(new TerraOptions() { LandingZoneApiHost = terraApiStubData.ApiHost, LandingZoneId = terraApiStubData.LandingZoneId.ToString() });
+            optionsMock.Setup(o => o.Value).Returns(new TerraOptions() { LandingZoneApiHost = terraApiStubData.LandingZoneApiHost, LandingZoneId = terraApiStubData.LandingZoneId.ToString() });
 
             terraLandingZoneApiClientMock
                 .Setup(t => t.GetLandingZoneResourcesAsync(It.Is<Guid>(g => g.Equals(terraApiStubData.LandingZoneId)), It.Is<bool>(c => c == true)))

--- a/src/TesApi.Tests/TerraWsmApiClientTests.cs
+++ b/src/TesApi.Tests/TerraWsmApiClientTests.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web;
+using Azure.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using TesApi.Web.Management;
+using TesApi.Web.Management.Clients;
+using TesApi.Web.Management.Models.Terra;
+
+namespace TesApi.Tests
+{
+    [TestClass]
+    public class TerraWsmApiClientTests
+    {
+        private TerraWsmApiClient terraWsmApiClient;
+        private Mock<TokenCredential> tokenCredential;
+        private Mock<CacheAndRetryHandler> cacheAndRetryHandler;
+        private TerraApiStubData terraApiStubData;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            terraApiStubData = new TerraApiStubData();
+            tokenCredential = new Mock<TokenCredential>();
+            cacheAndRetryHandler = new Mock<CacheAndRetryHandler>();
+            terraWsmApiClient = new TerraWsmApiClient(tokenCredential.Object, terraApiStubData.WsmApiHost,
+                cacheAndRetryHandler.Object, NullLogger<TerraWsmApiClient>.Instance);
+        }
+
+        [TestMethod]
+        public void GetContainerSasTokenApiUri_NoSasParameters_ReturnsExpectedUriWithoutQueryString()
+        {
+            var uri = terraWsmApiClient.GetContainerSasTokenApiUri(terraApiStubData.WorkspaceId,
+                terraApiStubData.ContainerResourceId, null);
+
+            var expectedUri =
+                $"{terraApiStubData.WsmApiHost}/api/workspaces/v1/{terraApiStubData.WorkspaceId}/resources/controlled/azure/storageContainer/{terraApiStubData.ContainerResourceId}/getSasToken";
+            Assert.AreEqual(expectedUri, uri.ToString());
+            Assert.AreEqual(string.Empty, uri.Query);
+        }
+
+        [TestMethod]
+        public void GetContainerSasTokenApiUri_WithAllSasParameters_ReturnsExpectedUriWithQueryString()
+        {
+            var sasParams = new SasTokenApiParameters("ipRange", 10, "rwdl", "blobName");
+
+            var uri = terraWsmApiClient.GetContainerSasTokenApiUri(terraApiStubData.WorkspaceId,
+                terraApiStubData.ContainerResourceId, sasParams);
+
+            var expectedUri =
+                $"{terraApiStubData.WsmApiHost}/api/workspaces/v1/{terraApiStubData.WorkspaceId}/resources/controlled/azure/storageContainer/{terraApiStubData.ContainerResourceId}/getSasToken"
+                + $"?sasIpRange={sasParams.SasIpRange}&sasExpirationDuration={sasParams.SasExpirationInSeconds}&sasPermissions={sasParams.SasPermission}&sasBlobName={sasParams.SasBlobName}";
+
+            var parsedQs = HttpUtility.ParseQueryString(uri.Query);
+
+            Assert.AreEqual(expectedUri, uri.ToString());
+            Assert.AreEqual(parsedQs["sasIpRange"], sasParams.SasIpRange);
+            Assert.AreEqual(parsedQs["sasExpirationDuration"], sasParams.SasExpirationInSeconds.ToString());
+            Assert.AreEqual(parsedQs["sasPermissions"], sasParams.SasPermission);
+            Assert.AreEqual(parsedQs["sasBlobName"], sasParams.SasBlobName);
+        }
+
+        [TestMethod]
+        public void GetContainerSasTokenApiUri_WithSomeSasParameters_ReturnsExpectedUriWithQueryString()
+        {
+            var sasParams = new SasTokenApiParameters("ipRange", 10, null, null);
+
+            var uri = terraWsmApiClient.GetContainerSasTokenApiUri(terraApiStubData.WorkspaceId,
+                terraApiStubData.ContainerResourceId, sasParams);
+
+            var expectedUri =
+                $"{terraApiStubData.WsmApiHost}/api/workspaces/v1/{terraApiStubData.WorkspaceId}/resources/controlled/azure/storageContainer/{terraApiStubData.ContainerResourceId}/getSasToken"
+                + $"?sasIpRange={sasParams.SasIpRange}&sasExpirationDuration={sasParams.SasExpirationInSeconds}";
+
+            var parsedQs = HttpUtility.ParseQueryString(uri.Query);
+
+            Assert.AreEqual(expectedUri, uri.ToString());
+            Assert.AreEqual(parsedQs["sasIpRange"], sasParams.SasIpRange);
+            Assert.AreEqual(parsedQs["sasExpirationDuration"], sasParams.SasExpirationInSeconds.ToString());
+        }
+
+        [TestMethod]
+        public async Task GetSasTokenAsync_ValidRequest_ReturnsPayload()
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+            response.Content = new StringContent(terraApiStubData.GetWsmSasTokenApiResponseInJson());
+
+            cacheAndRetryHandler.Setup(c => c.ExecuteWithRetryAsync(It.IsAny<Func<Task<HttpResponseMessage>>>()))
+                .ReturnsAsync(response);
+
+            var apiResponse = await terraWsmApiClient.GetSasTokenAsync(terraApiStubData.WorkspaceId,
+                terraApiStubData.ContainerResourceId, null);
+
+            Assert.IsNotNull(apiResponse);
+            Assert.IsTrue(!string.IsNullOrEmpty(apiResponse.Token));
+            Assert.IsTrue(!string.IsNullOrEmpty(apiResponse.Url));
+        }
+    }
+}

--- a/src/TesApi.Web/Management/Clients/HttpApiClient.cs
+++ b/src/TesApi.Web/Management/Clients/HttpApiClient.cs
@@ -23,7 +23,6 @@ namespace TesApi.Web.Management.Clients
         private readonly SHA256 sha256 = SHA256.Create();
         private readonly ILogger logger;
         private readonly string tokenScope;
-        private readonly object lockObject = new object();
         private readonly SemaphoreSlim semaphore = new SemaphoreSlim(1, 1);
         private AccessToken accessToken;
 
@@ -68,10 +67,11 @@ namespace TesApi.Web.Management.Clients
         protected HttpApiClient() { }
 
         /// <summary>
-        /// Sends request with a retry policy.
+        /// Sends request with a retry policy
         /// </summary>
-        /// <param name="httpRequest"></param>
-        /// <param name="setAuthorizationHeader"></param>
+        /// <param name="httpRequestFactory">Factory that creates new http requests, in the event of retry the factory is called again
+        /// and must be idempotent</param>
+        /// <param name="setAuthorizationHeader">If true, the authentication header is set with an authentication token </param>
         /// <returns></returns>
         protected async Task<HttpResponseMessage> HttpSendRequestWithRetryPolicyAsync(Func<HttpRequestMessage> httpRequestFactory, bool setAuthorizationHeader = false)
         {
@@ -177,6 +177,11 @@ namespace TesApi.Web.Management.Clients
 
         }
 
+        /// <summary>
+        /// Creates a query string with from an array of arguments.
+        /// </summary>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
         protected string AppendQueryStringParams(params string[] arguments)
         {
             if (arguments is null || arguments.Length == 0)

--- a/src/TesApi.Web/Management/Clients/TerraApiClient.cs
+++ b/src/TesApi.Web/Management/Clients/TerraApiClient.cs
@@ -1,0 +1,29 @@
+﻿using Azure.Core;
+using Microsoft.Extensions.Logging;
+
+namespace TesApi.Web.Management.Clients
+{
+    /// <summary>
+    /// Base client for Terra API clients
+    /// </summary>
+    public abstract class TerraApiClient : HttpApiClient
+    {
+        private const string TokenScope = @"https://management.azure.com/.default";
+
+
+        /// <summary>
+        /// Protected parameter-less constructor
+        /// </summary>
+        protected TerraApiClient() { }
+
+        /// <summary>
+        /// Protected constructor of TerraApiClient
+        /// </summary>
+        /// <param name="tokenCredential"><see cref="TokenCredential"/></param>
+        /// <param name="cacheAndRetryHandler"><see cref="CacheAndRetryHandler"/></param>
+        /// <param name="logger"><see cref="ILogger{TCategoryName}"/></param>
+        protected TerraApiClient(TokenCredential tokenCredential, CacheAndRetryHandler cacheAndRetryHandler, ILogger logger) : base(tokenCredential, TokenScope, cacheAndRetryHandler, logger)
+        {
+        }
+    }
+}

--- a/src/TesApi.Web/Management/Clients/TerraLandingZoneApiClient.cs
+++ b/src/TesApi.Web/Management/Clients/TerraLandingZoneApiClient.cs
@@ -9,10 +9,9 @@ namespace TesApi.Web.Management.Clients
     /// <summary>
     /// Terra Landing Zone api client. 
     /// </summary>
-    public class TerraLandingZoneApiClient : HttpApiClient
+    public class TerraLandingZoneApiClient : TerraApiClient
     {
         private const string LandingZonesApiSegments = @"/api/landingzones/v1/azure/";
-        private const string TokenScope = @"https://management.azure.com/.default";
 
         private readonly string baseApiUrl;
 
@@ -23,7 +22,7 @@ namespace TesApi.Web.Management.Clients
         /// <param name="tokenCredential"></param>
         /// <param name="cacheAndRetryHandler"></param>
         /// <param name="logger"></param>
-        public TerraLandingZoneApiClient(string apiHost, TokenCredential tokenCredential, CacheAndRetryHandler cacheAndRetryHandler, ILogger<TerraLandingZoneApiClient> logger) : base(tokenCredential, TokenScope, cacheAndRetryHandler, logger)
+        public TerraLandingZoneApiClient(string apiHost, TokenCredential tokenCredential, CacheAndRetryHandler cacheAndRetryHandler, ILogger<TerraLandingZoneApiClient> logger) : base(tokenCredential, cacheAndRetryHandler, logger)
         {
             ArgumentException.ThrowIfNullOrEmpty(apiHost);
             ArgumentNullException.ThrowIfNull(tokenCredential);

--- a/src/TesApi.Web/Management/Clients/TerraWsmApiClient.cs
+++ b/src/TesApi.Web/Management/Clients/TerraWsmApiClient.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Azure.Core;
+using Microsoft.Extensions.Logging;
+using TesApi.Web.Management.Models.Terra;
+
+namespace TesApi.Web.Management.Clients
+{
+    /// <summary>
+    /// Terra Workspace Manager api client
+    /// </summary>
+    public class TerraWsmApiClient : TerraApiClient
+    {
+        private const string WsmApiSegments = @"/api/workspaces/v1/";
+
+        private readonly string baseApiUrl;
+
+        /// <summary>
+        /// Constructor of TerraWsmApiClient
+        /// </summary>
+        /// <param name="tokenCredential"></param>
+        /// <param name="apiHost">Api Host</param>
+        /// <param name="cacheAndRetryHandler"></param>
+        /// <param name="logger"></param>
+        public TerraWsmApiClient(TokenCredential tokenCredential, string apiHost, CacheAndRetryHandler cacheAndRetryHandler, ILogger<TerraWsmApiClient> logger) : base(tokenCredential, cacheAndRetryHandler, logger)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(apiHost);
+
+            this.baseApiUrl = apiHost.TrimEnd('/') + WsmApiSegments;
+        }
+
+        /// <summary>
+        /// Returns the SAS token of a container or blob for WSM managed storage account.
+        /// </summary>
+        /// <param name="workspaceId">Terra workspace id</param>
+        /// <param name="resourceId">Terra resource id</param>
+        /// <param name="sasTokenApiParameters">Sas token parameters</param>
+        /// <returns></returns>
+        public async Task<WsmSasTokenApiResponse> GetSasTokenAsync(Guid workspaceId, Guid resourceId, SasTokenApiParameters sasTokenApiParameters)
+        {
+            var uri = GetContainerSasTokenApiUri(workspaceId, resourceId, sasTokenApiParameters);
+
+            var response = await HttpSendRequestWithRetryPolicyAsync(() => new HttpRequestMessage(HttpMethod.Post, uri),
+                setAuthorizationHeader: true);
+
+            response.EnsureSuccessStatusCode();
+
+            return JsonSerializer.Deserialize<WsmSasTokenApiResponse>(await response.Content.ReadAsStringAsync());
+        }
+
+        private string ToQueryString(SasTokenApiParameters sasTokenApiParameters)
+        {
+            return AppendQueryStringParams(
+                ParseQueryStringParameter("sasIpRange", sasTokenApiParameters.SasIpRange),
+                ParseQueryStringParameter("sasExpirationDuration", sasTokenApiParameters.SasExpirationInSeconds.ToString()),
+                ParseQueryStringParameter("sasPermissions", sasTokenApiParameters.SasPermission),
+                ParseQueryStringParameter("sasBlobName", sasTokenApiParameters.SasBlobName));
+        }
+
+        /// <summary>
+        /// Gets the Api Url to get a container sas token
+        /// </summary>
+        /// <param name="workspaceId">Workspace Id</param>
+        /// <param name="resourceId">WSM resource Id of the container</param>
+        /// <param name="sasTokenApiParameters"><see cref="SasTokenApiParameters"/></param>
+        /// <returns></returns>
+        public Uri GetContainerSasTokenApiUri(Guid workspaceId, Guid resourceId, SasTokenApiParameters sasTokenApiParameters)
+        {
+            var segments = $"/resources/controlled/azure/storageContainer/{resourceId}/getSasToken";
+
+            var builder = GetWsmUriBuilder(workspaceId, segments);
+
+            if (sasTokenApiParameters != null)
+            {
+                builder.Query = ToQueryString(sasTokenApiParameters);
+            }
+
+            return builder.Uri;
+        }
+
+        private UriBuilder GetWsmUriBuilder(Guid workspaceId, string pathSegments)
+        {
+            //This is okay given the perf expectations of service  - no current need to optimize string allocations.
+            var apiRequestUrl = $"{baseApiUrl}{workspaceId}{pathSegments}";
+
+            var uriBuilder = new UriBuilder(apiRequestUrl);
+
+            return uriBuilder;
+        }
+    }
+}

--- a/src/TesApi.Web/Management/Configuration/TerraOptions.cs
+++ b/src/TesApi.Web/Management/Configuration/TerraOptions.cs
@@ -17,4 +17,8 @@ public class TerraOptions
     /// Landing zone api host. 
     /// </summary>
     public string LandingZoneApiHost { get; set; }
+    /// <summary>
+    /// Wsm api host. 
+    /// </summary>
+    public string WsmApiHost { get; set; }
 }

--- a/src/TesApi.Web/Management/Models/Terra/SasTokenApiParameters.cs
+++ b/src/TesApi.Web/Management/Models/Terra/SasTokenApiParameters.cs
@@ -1,0 +1,12 @@
+﻿namespace TesApi.Web.Management.Models.Terra
+{
+    /// <summary>
+    /// Sas Token Api Parameters
+    /// </summary>
+    /// <param name="SasIpRange"></param>
+    /// <param name="SasExpirationInSeconds"></param>
+    /// <param name="SasPermission"></param>
+    /// <param name="SasBlobName"></param>
+    public record SasTokenApiParameters(string SasIpRange,
+        int SasExpirationInSeconds, string SasPermission, string SasBlobName);
+}

--- a/src/TesApi.Web/Management/Models/Terra/WsmSasTokenApiResponse.cs
+++ b/src/TesApi.Web/Management/Models/Terra/WsmSasTokenApiResponse.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.Json.Serialization;
+
+namespace TesApi.Web.Management.Models.Terra;
+
+/// <summary>
+/// Wsm Get SasToken Api response
+/// </summary>
+public class WsmSasTokenApiResponse
+{
+    /// <summary>
+    /// Access token.
+    /// </summary>
+    [JsonPropertyName("token")]
+    public string Token { get; set; }
+
+    /// <summary>
+    /// Storage resource Url.
+    /// </summary>
+    [JsonPropertyName("url")]
+    public string Url { get; set; }
+}

--- a/src/TesApi.Web/TesApi.Web.csproj
+++ b/src/TesApi.Web/TesApi.Web.csproj
@@ -55,8 +55,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Tes\Tes.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Management\Clients\" />
-    <Folder Include="Management\Models\Terra\" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
- New API client, for the Terra WSM `TerraWsmApiClient`
  - The client can be used to get the SAS tokens from Terra.  
- Refactored token locking code to use `SemaphoreSlim`, instead of `lock`.