### PR TITLE
Terra Storage Provider

### DIFF
--- a/src/TesApi.Tests/BatchSchedulerTests.cs
+++ b/src/TesApi.Tests/BatchSchedulerTests.cs
@@ -18,6 +18,7 @@ using Tes.Models;
 using TesApi.Web;
 using TesApi.Web.Management;
 using TesApi.Web.Management.Models.Quotas;
+using TesApi.Web.Storage;
 
 namespace TesApi.Tests
 {

--- a/src/TesApi.Tests/CachingWithRetriesAzureProxyTests.cs
+++ b/src/TesApi.Tests/CachingWithRetriesAzureProxyTests.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Polly.Utilities;
 using TesApi.Web;
+using TesApi.Web.Storage;
 
 namespace TesApi.Tests
 {

--- a/src/TesApi.Tests/ConfigurationUtilsTests.cs
+++ b/src/TesApi.Tests/ConfigurationUtilsTests.cs
@@ -14,6 +14,7 @@ using Tes.Models;
 using TesApi.Web;
 using TesApi.Web.Management;
 using TesApi.Web.Management.Models.Quotas;
+using TesApi.Web.Storage;
 
 namespace TesApi.Tests
 {

--- a/src/TesApi.Tests/TerraApiStubData.cs
+++ b/src/TesApi.Tests/TerraApiStubData.cs
@@ -36,7 +36,7 @@ public class TerraApiStubData
     {
         return @"{
   ""token"": ""SASTOKENSTUB="",
-  ""url"": ""https://bloburl.org/container?sas=SASTOKENSUTB=""
+  ""url"": ""https://bloburl.foo/container?sas=SASTOKENSTUB=""
     }";
     }
 

--- a/src/TesApi.Tests/TerraLandingZoneApiClientTest.cs
+++ b/src/TesApi.Tests/TerraLandingZoneApiClientTest.cs
@@ -4,10 +4,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using TesApi.Web.Management;
 using TesApi.Web.Management.Clients;
+using TesApi.Web.Management.Configuration;
 
 namespace TesApi.Tests
 {
@@ -25,7 +27,10 @@ namespace TesApi.Tests
             terraApiStubData = new TerraApiStubData();
             tokenCredential = new Mock<TokenCredential>();
             cacheAndRetryHandler = new Mock<CacheAndRetryHandler>();
-            terraLandingZoneApiClient = new TerraLandingZoneApiClient(terraApiStubData.LandingZoneApiHost, tokenCredential.Object, cacheAndRetryHandler.Object, NullLogger<TerraLandingZoneApiClient>.Instance);
+            var terraOptions = new Mock<IOptions<TerraOptions>>();
+            terraOptions.Setup(o => o.Value)
+                .Returns(new TerraOptions() { LandingZoneApiHost = terraApiStubData.LandingZoneApiHost });
+            terraLandingZoneApiClient = new TerraLandingZoneApiClient(terraOptions.Object, tokenCredential.Object, cacheAndRetryHandler.Object, NullLogger<TerraLandingZoneApiClient>.Instance);
         }
 
         [TestMethod]

--- a/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
+++ b/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using TesApi.Web;
+using TesApi.Web.Management;
+using TesApi.Web.Management.Clients;
+using TesApi.Web.Management.Configuration;
+using TesApi.Web.Management.Models.Terra;
+using TesApi.Web.Storage;
+
+namespace TesApi.Tests
+{
+    [TestClass]
+    [TestCategory("unit")]
+    public class TerraStorageAccessProviderTests
+    {
+        private const string WorkspaceStorageAccountName = "terraAccount";
+        private const string WorkspaceStorageContainerName = "terraContainer";
+
+        private Mock<CacheAndRetryHandler> cacheAndRetryHandlerMock;
+        private Mock<TerraWsmApiClient> wsmApiClientMock;
+        private Mock<IAzureProxy> azureProxyMock;
+        private TerraStorageAccessProvider terraStorageAccessProvider;
+        private TerraApiStubData terraApiStubData;
+        private Mock<IOptions<TerraOptions>> optionsMock;
+        private TerraOptions terraOptions;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            terraApiStubData = new TerraApiStubData();
+            cacheAndRetryHandlerMock = new Mock<CacheAndRetryHandler>();
+            wsmApiClientMock = new Mock<TerraWsmApiClient>();
+            optionsMock = new Mock<IOptions<TerraOptions>>();
+            terraOptions = CreateTerraOptionsFromStubData();
+            optionsMock.Setup(o => o.Value).Returns(terraOptions);
+            azureProxyMock = new Mock<IAzureProxy>();
+            terraStorageAccessProvider = new TerraStorageAccessProvider(NullLogger<TerraStorageAccessProvider>.Instance,
+                optionsMock.Object, azureProxyMock.Object, wsmApiClientMock.Object);
+        }
+
+        [TestMethod]
+        [DataRow("http://foo.bar", true)]
+        [DataRow("https://foo.bar", true)]
+        [DataRow("sb://foo.bar", false)]
+        [DataRow("/foo/bar", false)]
+        [DataRow("foo/bar", false)]
+        public async Task IsHttpPublicAsync_StringScenario(string input, bool expectedResult)
+        {
+            var result = await terraStorageAccessProvider.IsPublicHttpUrlAsync(input);
+
+            Assert.AreEqual(expectedResult, result);
+        }
+
+        [TestMethod]
+        [DataRow($"{WorkspaceStorageAccountName}/{WorkspaceStorageContainerName}")]
+        [DataRow($"/{WorkspaceStorageAccountName}/{WorkspaceStorageContainerName}")]
+        [DataRow($"/{WorkspaceStorageAccountName}/{WorkspaceStorageContainerName}/")]
+        [DataRow($"/{WorkspaceStorageAccountName}/{WorkspaceStorageContainerName}/dir/blobName")]
+        public async Task MapLocalPathToSasUrlAsync_ValidInput(string input)
+        {
+
+
+            wsmApiClientMock.Setup(a => a.GetSasTokenAsync(terraApiStubData.WorkspaceId,
+                    terraApiStubData.ContainerResourceId, It.IsAny<SasTokenApiParameters>()))
+                .ReturnsAsync(terraApiStubData.GetWsmSasTokenApiResponse());
+
+            var result = await terraStorageAccessProvider.MapLocalPathToSasUrlAsync(input);
+
+            Assert.IsNotNull(terraApiStubData.GetWsmSasTokenApiResponse().Url, result);
+
+        }
+
+        [TestMethod]
+        [DataRow($"{WorkspaceStorageAccountName}/foo")]
+        [DataRow($"/bar/{WorkspaceStorageContainerName}")]
+        [DataRow($"/foo/bar/")]
+        [DataRow($"/foo/bar/dir/blobName")]
+
+        [ExpectedException(typeof(Exception))]
+        public async Task MapLocalPathToSasUrlAsync_InvalidInputs(string input)
+        {
+            var result = await terraStorageAccessProvider.MapLocalPathToSasUrlAsync(input);
+        }
+        private TerraOptions CreateTerraOptionsFromStubData()
+        {
+            return new TerraOptions()
+            {
+                WsmApiHost = terraApiStubData.WsmApiHost,
+                WorkspaceStorageAccountName = WorkspaceStorageAccountName,
+                WorkspaceStorageContainerName = WorkspaceStorageContainerName,
+                WorkspaceId = terraApiStubData.WorkspaceId.ToString(),
+                WorkspaceStorageContainerResourceId = terraApiStubData.ContainerResourceId.ToString(),
+                SasTokenExpirationInSeconds = 60,
+                SasAllowedIpRange = "169.0.0.1"
+            };
+        }
+    }
+}

--- a/src/TesApi.Tests/TerraWsmApiClientTests.cs
+++ b/src/TesApi.Tests/TerraWsmApiClientTests.cs
@@ -5,10 +5,12 @@ using System.Threading.Tasks;
 using System.Web;
 using Azure.Core;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using TesApi.Web.Management;
 using TesApi.Web.Management.Clients;
+using TesApi.Web.Management.Configuration;
 using TesApi.Web.Management.Models.Terra;
 
 namespace TesApi.Tests
@@ -27,7 +29,10 @@ namespace TesApi.Tests
             terraApiStubData = new TerraApiStubData();
             tokenCredential = new Mock<TokenCredential>();
             cacheAndRetryHandler = new Mock<CacheAndRetryHandler>();
-            terraWsmApiClient = new TerraWsmApiClient(tokenCredential.Object, terraApiStubData.WsmApiHost,
+            var terraOptions = new Mock<IOptions<TerraOptions>>();
+            terraOptions.Setup(o => o.Value)
+                .Returns(new TerraOptions() { WsmApiHost = terraApiStubData.WsmApiHost });
+            terraWsmApiClient = new TerraWsmApiClient(tokenCredential.Object, terraOptions.Object,
                 cacheAndRetryHandler.Object, NullLogger<TerraWsmApiClient>.Instance);
         }
 

--- a/src/TesApi.Tests/TestServices/TestServiceProvider.cs
+++ b/src/TesApi.Tests/TestServices/TestServiceProvider.cs
@@ -19,6 +19,7 @@ using Tes.Repository;
 using TesApi.Web;
 using TesApi.Web.Management;
 using TesApi.Web.Management.Clients;
+using TesApi.Web.Storage;
 
 namespace TesApi.Tests.TestServices
 {
@@ -47,11 +48,11 @@ namespace TesApi.Tests.TestServices
                 .AddSingleton(s => wrapAzureProxy ? ActivatorUtilities.CreateInstance<CachingWithRetriesAzureProxy>(s, GetAzureProxy(azureProxy).Object) : GetAzureProxy(azureProxy).Object)
                 .AddSingleton(_ => GetTesTaskRepository(tesTaskRepository).Object)
                 //.AddSingleton(_ => new CosmosCredentials(batchPoolRepositoryArgs.endpoint ?? "endpoint", batchPoolRepositoryArgs.key ?? "key"))
-                .AddSingleton(s => mockStorageAccessProvider ? GetStorageAccessProvider(storageAccessProvider).Object : ActivatorUtilities.CreateInstance<StorageAccessProvider>(s))
+                .AddSingleton(s => mockStorageAccessProvider ? GetStorageAccessProvider(storageAccessProvider).Object : ActivatorUtilities.CreateInstance<DefaultStorageAccessProvider>(s))
                 .AddSingleton<IAppCache>(_ => new CachingService(new MemoryCacheProvider(new MemoryCache(new MemoryCacheOptions()))))
                 .IfThenElse(accountResourceInformation is null, s => s, s => s.AddSingleton(accountResourceInformation))
                 .AddTransient<ILogger<T>>(_ => NullLogger<T>.Instance)
-                .IfThenElse(mockStorageAccessProvider, s => s, s => s.AddTransient<ILogger<StorageAccessProvider>>(_ => NullLogger<StorageAccessProvider>.Instance))
+                .IfThenElse(mockStorageAccessProvider, s => s, s => s.AddTransient<ILogger<DefaultStorageAccessProvider>>(_ => NullLogger<DefaultStorageAccessProvider>.Instance))
                 .IfThenElse(batchSkuInformationProvider is null,
                     s => s.AddSingleton<IBatchSkuInformationProvider>(sp => ActivatorUtilities.CreateInstance<PriceApiBatchSkuInformationProvider>(sp))
                         .AddSingleton(sp => new PriceApiBatchSkuInformationProvider(sp.GetRequiredService<PriceApiClient>(), sp.GetRequiredService<ILogger<PriceApiBatchSkuInformationProvider>>())),

--- a/src/TesApi.Web/AzureProxy.cs
+++ b/src/TesApi.Web/AzureProxy.cs
@@ -26,6 +26,7 @@ using Newtonsoft.Json;
 using Polly;
 using Polly.Retry;
 using TesApi.Web.Management.Configuration;
+using TesApi.Web.Storage;
 using BatchModels = Microsoft.Azure.Management.Batch.Models;
 using CloudTask = Microsoft.Azure.Batch.CloudTask;
 using ComputeNodeState = Microsoft.Azure.Batch.Common.ComputeNodeState;

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -18,6 +18,7 @@ using Tes.Extensions;
 using Tes.Models;
 using TesApi.Web.Management;
 using TesApi.Web.Management.Models.Quotas;
+using TesApi.Web.Storage;
 using BatchModels = Microsoft.Azure.Management.Batch.Models;
 using TesException = Tes.Models.TesException;
 using TesFileType = Tes.Models.TesFileType;

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -925,7 +925,7 @@ namespace TesApi.Web
                 inputFileUrl = await this.storageAccessProvider.MapLocalPathToSasUrlAsync(inputFile.Path);
                 await this.storageAccessProvider.UploadBlobFromFileAsync(inputFile.Path, localPath);
             }
-            else if (await this.storageAccessProvider.IsPublicHttpUrl(inputFile.Url))
+            else if (await this.storageAccessProvider.IsPublicHttpUrlAsync(inputFile.Url))
             {
                 inputFileUrl = inputFile.Url;
             }

--- a/src/TesApi.Web/CachingWithRetriesAzureProxy.cs
+++ b/src/TesApi.Web/CachingWithRetriesAzureProxy.cs
@@ -9,6 +9,7 @@ using LazyCache;
 using Microsoft.Azure.Batch;
 using Polly;
 using Polly.Retry;
+using TesApi.Web.Storage;
 using BatchModels = Microsoft.Azure.Management.Batch.Models;
 
 namespace TesApi.Web

--- a/src/TesApi.Web/ConfigurationUtils.cs
+++ b/src/TesApi.Web/ConfigurationUtils.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Tes.Models;
 using TesApi.Web.Management;
 using TesApi.Web.Management.Models.Quotas;
+using TesApi.Web.Storage;
 
 namespace TesApi.Web
 {

--- a/src/TesApi.Web/IAzureProxy.cs
+++ b/src/TesApi.Web/IAzureProxy.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Batch;
+using TesApi.Web.Storage;
 using BatchModels = Microsoft.Azure.Management.Batch.Models;
 
 namespace TesApi.Web

--- a/src/TesApi.Web/Management/AzureManagementClientsFactory.cs
+++ b/src/TesApi.Web/Management/AzureManagementClientsFactory.cs
@@ -106,6 +106,10 @@ namespace TesApi.Web.Management
             return null;
         }
 
+        /// <summary>
+        /// Creates a new instance of Azure Management client
+        /// </summary>
+        /// <returns></returns>
         public static async Task<FluentAzure.IAuthenticated> GetAzureManagementClientAsync()
         {
             var accessToken = await GetAzureAccessTokenAsync();

--- a/src/TesApi.Web/Management/Batch/ArmBatchPoolManager.cs
+++ b/src/TesApi.Web/Management/Batch/ArmBatchPoolManager.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Batch;
+using Microsoft.Azure.Management.Batch;
+using Microsoft.Azure.Management.Batch.Models;
+using Microsoft.Extensions.Logging;
+
+namespace TesApi.Web.Management.Batch
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class ArmBatchPoolManager : IBatchPoolManager
+    {
+
+        private readonly ILogger<ArmBatchPoolManager> logger;
+        private readonly AzureManagementClientsFactory azureClientsFactory;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="azureClientsFactory"></param>
+        /// <param name="logger"></param>
+        public ArmBatchPoolManager(AzureManagementClientsFactory azureClientsFactory,
+            ILogger<ArmBatchPoolManager> logger)
+        {
+            ArgumentNullException.ThrowIfNull(logger);
+            ArgumentNullException.ThrowIfNull(azureClientsFactory);
+
+            this.logger = logger;
+            this.azureClientsFactory = azureClientsFactory;
+        }
+
+        /// <inheritdoc />
+        public async Task<PoolInformation> CreateBatchPoolAsync(Pool poolInfo, bool isPreemptable)
+        {
+            try
+            {
+                var batchManagementClient = await azureClientsFactory.CreateBatchAccountManagementClient();
+
+                logger.LogInformation($"Creating manual batch pool named {poolInfo.Name} with vmSize {poolInfo.VmSize} and low priority {isPreemptable}");
+
+                var pool = await batchManagementClient.Pool.CreateAsync(azureClientsFactory.BatchAccountInformation.ResourceGroupName, azureClientsFactory.BatchAccountInformation.Name, poolInfo.Name, poolInfo);
+
+                logger.LogInformation($"Successfully created manual batch pool named {poolInfo.Name} with vmSize {poolInfo.VmSize} and low priority {isPreemptable}");
+
+                return new PoolInformation() { PoolId = pool.Name };
+            }
+            catch (Exception exc)
+            {
+                logger.LogError(exc, $"Error trying to create manual batch pool named {poolInfo.Name} with vmSize {poolInfo.VmSize} and low priority {isPreemptable}");
+                throw;
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task DeleteBatchPoolAsync(string poolId, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var batchManagementClient = await azureClientsFactory.CreateBatchAccountManagementClient();
+
+                logger.LogInformation(
+                    $"Deleting pool with the id/name:{poolId} in Batch account:{azureClientsFactory.BatchAccountInformation.Name}");
+
+                await batchManagementClient.Pool.DeleteWithHttpMessagesAsync(
+                    azureClientsFactory.BatchAccountInformation.ResourceGroupName,
+                    azureClientsFactory.BatchAccountInformation.Name, poolId, cancellationToken: cancellationToken);
+
+                logger.LogInformation(
+                    $"Successfully deleted pool with the id/name:{poolId} in Batch account:{azureClientsFactory.BatchAccountInformation.Name}");
+
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, $"Error trying to delete pool named {poolId}");
+
+                throw;
+            }
+        }
+    }
+}

--- a/src/TesApi.Web/Management/Batch/IBatchPoolManager.cs
+++ b/src/TesApi.Web/Management/Batch/IBatchPoolManager.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Batch;
+using BatchModels = Microsoft.Azure.Management.Batch.Models;
+
+namespace TesApi.Web.Management.Batch
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface IBatchPoolManager
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="poolInfo"></param>
+        /// <param name="isPreemptable"></param>
+        /// <returns></returns>
+        Task<PoolInformation> CreateBatchPoolAsync(BatchModels.Pool poolInfo, bool isPreemptable);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="poolName"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task DeleteBatchPoolAsync(string poolName, CancellationToken cancellationToken = default);
+
+    }
+}

--- a/src/TesApi.Web/Management/CacheAndRetryHandler.cs
+++ b/src/TesApi.Web/Management/CacheAndRetryHandler.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/src/TesApi.Web/Management/Clients/HttpApiClient.cs
+++ b/src/TesApi.Web/Management/Clients/HttpApiClient.cs
@@ -1,9 +1,14 @@
 ﻿using System;
 using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
+using Microsoft.Extensions.Logging;
 
 namespace TesApi.Web.Management.Clients
 {

--- a/src/TesApi.Web/Management/Clients/HttpApiClient.cs
+++ b/src/TesApi.Web/Management/Clients/HttpApiClient.cs
@@ -1,14 +1,9 @@
 ﻿using System;
 using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
-using Microsoft.Extensions.Logging;
 
 namespace TesApi.Web.Management.Clients
 {

--- a/src/TesApi.Web/Management/Clients/TerraLandingZoneApiClient.cs
+++ b/src/TesApi.Web/Management/Clients/TerraLandingZoneApiClient.cs
@@ -2,6 +2,8 @@
 using System.Threading.Tasks;
 using Azure.Core;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using TesApi.Web.Management.Configuration;
 using TesApi.Web.Management.Models.Terra;
 
 namespace TesApi.Web.Management.Clients
@@ -18,17 +20,17 @@ namespace TesApi.Web.Management.Clients
         /// <summary>
         /// Constructor of TerraLandingZoneApiClient
         /// </summary>
-        /// <param name="apiHost"></param>
+        /// <param name="terraOptions"></param>
         /// <param name="tokenCredential"></param>
         /// <param name="cacheAndRetryHandler"></param>
         /// <param name="logger"></param>
-        public TerraLandingZoneApiClient(string apiHost, TokenCredential tokenCredential, CacheAndRetryHandler cacheAndRetryHandler, ILogger<TerraLandingZoneApiClient> logger) : base(tokenCredential, cacheAndRetryHandler, logger)
+        public TerraLandingZoneApiClient(IOptions<TerraOptions> terraOptions, TokenCredential tokenCredential, CacheAndRetryHandler cacheAndRetryHandler, ILogger<TerraLandingZoneApiClient> logger) : base(tokenCredential, cacheAndRetryHandler, logger)
         {
-            ArgumentException.ThrowIfNullOrEmpty(apiHost);
+            ArgumentException.ThrowIfNullOrEmpty(terraOptions.Value.LandingZoneApiHost, nameof(terraOptions.Value.LandingZoneApiHost));
             ArgumentNullException.ThrowIfNull(tokenCredential);
             ArgumentNullException.ThrowIfNull(cacheAndRetryHandler);
 
-            this.baseApiUrl = apiHost.TrimEnd('/') + LandingZonesApiSegments;
+            this.baseApiUrl = terraOptions.Value.LandingZoneApiHost.TrimEnd('/') + LandingZonesApiSegments;
         }
 
         /// <summary>

--- a/src/TesApi.Web/Management/Clients/TerraWsmApiClient.cs
+++ b/src/TesApi.Web/Management/Clients/TerraWsmApiClient.cs
@@ -34,13 +34,18 @@ namespace TesApi.Web.Management.Clients
         }
 
         /// <summary>
+        /// Protected parameter-less constructor
+        /// </summary>
+        protected TerraWsmApiClient() { }
+
+        /// <summary>
         /// Returns the SAS token of a container or blob for WSM managed storage account.
         /// </summary>
         /// <param name="workspaceId">Terra workspace id</param>
         /// <param name="resourceId">Terra resource id</param>
         /// <param name="sasTokenApiParameters">Sas token parameters</param>
         /// <returns></returns>
-        public async Task<WsmSasTokenApiResponse> GetSasTokenAsync(Guid workspaceId, Guid resourceId, SasTokenApiParameters sasTokenApiParameters)
+        public virtual async Task<WsmSasTokenApiResponse> GetSasTokenAsync(Guid workspaceId, Guid resourceId, SasTokenApiParameters sasTokenApiParameters)
         {
             var uri = GetContainerSasTokenApiUri(workspaceId, resourceId, sasTokenApiParameters);
 
@@ -68,7 +73,7 @@ namespace TesApi.Web.Management.Clients
         /// <param name="resourceId">WSM resource Id of the container</param>
         /// <param name="sasTokenApiParameters"><see cref="SasTokenApiParameters"/></param>
         /// <returns></returns>
-        public Uri GetContainerSasTokenApiUri(Guid workspaceId, Guid resourceId, SasTokenApiParameters sasTokenApiParameters)
+        public virtual Uri GetContainerSasTokenApiUri(Guid workspaceId, Guid resourceId, SasTokenApiParameters sasTokenApiParameters)
         {
             var segments = $"/resources/controlled/azure/storageContainer/{resourceId}/getSasToken";
 

--- a/src/TesApi.Web/Management/Clients/TerraWsmApiClient.cs
+++ b/src/TesApi.Web/Management/Clients/TerraWsmApiClient.cs
@@ -4,6 +4,8 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Azure.Core;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using TesApi.Web.Management.Configuration;
 using TesApi.Web.Management.Models.Terra;
 
 namespace TesApi.Web.Management.Clients
@@ -21,14 +23,14 @@ namespace TesApi.Web.Management.Clients
         /// Constructor of TerraWsmApiClient
         /// </summary>
         /// <param name="tokenCredential"></param>
-        /// <param name="apiHost">Api Host</param>
+        /// <param name="terraOptions"></param>
         /// <param name="cacheAndRetryHandler"></param>
         /// <param name="logger"></param>
-        public TerraWsmApiClient(TokenCredential tokenCredential, string apiHost, CacheAndRetryHandler cacheAndRetryHandler, ILogger<TerraWsmApiClient> logger) : base(tokenCredential, cacheAndRetryHandler, logger)
+        public TerraWsmApiClient(TokenCredential tokenCredential, IOptions<TerraOptions> terraOptions, CacheAndRetryHandler cacheAndRetryHandler, ILogger<TerraWsmApiClient> logger) : base(tokenCredential, cacheAndRetryHandler, logger)
         {
-            ArgumentException.ThrowIfNullOrEmpty(apiHost);
+            ArgumentException.ThrowIfNullOrEmpty(terraOptions.Value.WsmApiHost, nameof(terraOptions.Value.WsmApiHost));
 
-            this.baseApiUrl = apiHost.TrimEnd('/') + WsmApiSegments;
+            this.baseApiUrl = terraOptions.Value.WsmApiHost.TrimEnd('/') + WsmApiSegments;
         }
 
         /// <summary>

--- a/src/TesApi.Web/Management/Configuration/TerraOptions.cs
+++ b/src/TesApi.Web/Management/Configuration/TerraOptions.cs
@@ -9,6 +9,9 @@ public class TerraOptions
     /// Terra configuration section
     /// </summary>
     public const string Terra = "Terra";
+
+    private const int DefaultSasTokenExpirationInSeconds = 60 * 24 * 3; // 3 days
+
     /// <summary>
     /// Landing zone id containing the Tes back-end resources
     /// </summary>
@@ -21,4 +24,34 @@ public class TerraOptions
     /// Wsm api host. 
     /// </summary>
     public string WsmApiHost { get; set; }
+
+    /// <summary>
+    /// Workspace storage container resource id
+    /// </summary>
+    public string WorkspaceStorageContainerResourceId { get; set; }
+
+    /// <summary>
+    /// Workspace storage container name
+    /// </summary>
+    public string WorkspaceStorageContainerName { get; set; }
+
+    /// <summary>
+    /// Workspace storage account name
+    /// </summary>
+    public string WorkspaceStorageAccountName { get; set; }
+
+    /// <summary>
+    /// Workspace Id
+    /// </summary>
+    public string WorkspaceId { get; set; }
+
+    /// <summary>
+    /// Sas token expiration in seconds
+    /// </summary>
+    public int SasTokenExpirationInSeconds { get; set; } = DefaultSasTokenExpirationInSeconds;
+
+    /// <summary>
+    /// Sas token allowed Ip ranges
+    /// </summary>
+    public string SasAllowedIpRange { get; set; }
 }

--- a/src/TesApi.Web/Management/ContainerRegistryProvider.cs
+++ b/src/TesApi.Web/Management/ContainerRegistryProvider.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/TesApi.Web/Management/TerraQuotaProvider.cs
+++ b/src/TesApi.Web/Management/TerraQuotaProvider.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/TesApi.Web/Startup.cs
+++ b/src/TesApi.Web/Startup.cs
@@ -22,6 +22,7 @@ using TesApi.Filters;
 using TesApi.Web.Management;
 using TesApi.Web.Management.Clients;
 using TesApi.Web.Management.Configuration;
+using TesApi.Web.Storage;
 
 namespace TesApi.Web
 {
@@ -77,7 +78,7 @@ namespace TesApi.Web
                 }).Services
 
                 .AddSingleton<IBatchScheduler, BatchScheduler>()
-                .AddSingleton<IStorageAccessProvider, StorageAccessProvider>()
+                .AddSingleton<IStorageAccessProvider, DefaultStorageAccessProvider>()
 
                 .AddLogging()
                 .AddSingleton<ContainerRegistryProvider, ContainerRegistryProvider>()

--- a/src/TesApi.Web/Storage/DefaultStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/DefaultStorageAccessProvider.cs
@@ -91,7 +91,7 @@ namespace TesApi.Web.Storage
             // This would allow the user to omit the account name for files stored in the default storage account
 
             // /cromwell-executions/... URLs become /defaultStorageAccountName/cromwell-executions/... to unify how URLs starting with /acct/container/... pattern are handled.
-            if (IsItKnownFilePath(path))
+            if (IsItKnownExecutionFilePath(path))
             {
                 path = $"/{defaultStorageAccountName}{path}";
             }

--- a/src/TesApi.Web/Storage/DefaultStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/DefaultStorageAccessProvider.cs
@@ -19,8 +19,7 @@ namespace TesApi.Web.Storage
     /// </summary>
     public class DefaultStorageAccessProvider : StorageAccessProvider
     {
-        private const string CromwellPathPrefix = "/cromwell-executions/";
-        private const string BatchPathPrefix = "/executions/";
+
         private static readonly TimeSpan SasTokenDuration = TimeSpan.FromDays(3); //TODO: refactor this to drive it from configuration. 
         private readonly string defaultStorageAccountName;
         private readonly List<ExternalStorageContainerInfo> externalStorageContainers;
@@ -92,7 +91,7 @@ namespace TesApi.Web.Storage
             // This would allow the user to omit the account name for files stored in the default storage account
 
             // /cromwell-executions/... URLs become /defaultStorageAccountName/cromwell-executions/... to unify how URLs starting with /acct/container/... pattern are handled.
-            if (path.StartsWith(CromwellPathPrefix, StringComparison.OrdinalIgnoreCase) || path.StartsWith(BatchPathPrefix, StringComparison.OrdinalIgnoreCase))
+            if (IsItKnownFilePath(path))
             {
                 path = $"/{defaultStorageAccountName}{path}";
             }

--- a/src/TesApi.Web/Storage/DefaultStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/DefaultStorageAccessProvider.cs
@@ -55,7 +55,7 @@ namespace TesApi.Web.Storage
         }
 
         /// <inheritdoc />
-        public override async Task<bool> IsPublicHttpUrl(string uriString)
+        public override async Task<bool> IsPublicHttpUrlAsync(string uriString)
         {
             var isHttpUrl = TryParseHttpUrlFromInput(uriString, out var uri);
 

--- a/src/TesApi.Web/Storage/ExternalStorageContainerInfo.cs
+++ b/src/TesApi.Web/Storage/ExternalStorageContainerInfo.cs
@@ -1,4 +1,7 @@
-﻿namespace TesApi.Web.Storage;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace TesApi.Web.Storage;
 
 /// <summary>
 /// External storage container information

--- a/src/TesApi.Web/Storage/ExternalStorageContainerInfo.cs
+++ b/src/TesApi.Web/Storage/ExternalStorageContainerInfo.cs
@@ -1,0 +1,24 @@
+﻿namespace TesApi.Web.Storage;
+
+/// <summary>
+/// External storage container information
+/// </summary>
+public class ExternalStorageContainerInfo
+{
+    /// <summary>
+    /// Account name
+    /// </summary>
+    public string AccountName { get; set; }
+    /// <summary>
+    /// Container name
+    /// </summary>
+    public string ContainerName { get; set; }
+    /// <summary>
+    /// Blob endpoint
+    /// </summary>
+    public string BlobEndpoint { get; set; }
+    /// <summary>
+    /// Sas Token
+    /// </summary>
+    public string SasToken { get; set; }
+}

--- a/src/TesApi.Web/Storage/IStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/IStorageAccessProvider.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace TesApi.Web
+namespace TesApi.Web.Storage
 {
     /// <summary>
     /// Provides methods for abstracting storage access by using local path references in form of /storageaccount/container/blobpath

--- a/src/TesApi.Web/Storage/IStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/IStorageAccessProvider.cs
@@ -47,7 +47,7 @@ namespace TesApi.Web.Storage
         /// </summary>
         /// <param name="uriString">URI string</param>
         /// <returns>True if the URL can be used as is, without adding SAS token to it</returns>
-        public Task<bool> IsPublicHttpUrl(string uriString);
+        public Task<bool> IsPublicHttpUrlAsync(string uriString);
 
         /// <summary>
         /// Returns an Azure Storage Blob or Container URL with SAS token given a path that uses one of the following formats: 

--- a/src/TesApi.Web/Storage/StorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/StorageAccessProvider.cs
@@ -10,6 +10,15 @@ namespace TesApi.Web.Storage;
 public abstract class StorageAccessProvider : IStorageAccessProvider
 {
     /// <summary>
+    /// Cromwell path prefix
+    /// </summary>
+    protected const string CromwellPathPrefix = "/cromwell-executions/";
+    /// <summary>
+    /// Executions path prefix
+    /// </summary>
+    protected const string BatchPathPrefix = "/executions/";
+
+    /// <summary>
     /// Logger instance. 
     /// </summary>
     protected readonly ILogger logger;
@@ -81,5 +90,17 @@ public abstract class StorageAccessProvider : IStorageAccessProvider
     protected static bool TryParseHttpUrlFromInput(string input, out Uri uri)
     {
         return Uri.TryCreate(input, UriKind.Absolute, out uri) && (uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) || uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// True if the path is the cromwell or executions folder
+    /// </summary>
+    /// <param name="path"></param>
+    /// <returns></returns>
+    protected bool IsItKnownFilePath(string path)
+    {
+        return path.StartsWith(CromwellPathPrefix, StringComparison.OrdinalIgnoreCase)
+               || path.StartsWith(BatchPathPrefix, StringComparison.OrdinalIgnoreCase);
+
     }
 }

--- a/src/TesApi.Web/Storage/StorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/StorageAccessProvider.cs
@@ -67,7 +67,7 @@ public abstract class StorageAccessProvider : IStorageAccessProvider
         => await this.azureProxy.UploadBlobFromFileAsync(new Uri(await MapLocalPathToSasUrlAsync(blobRelativePath, true)), sourceLocalFilePath);
 
     /// <inheritdoc />
-    public abstract Task<bool> IsPublicHttpUrl(string uriString);
+    public abstract Task<bool> IsPublicHttpUrlAsync(string uriString);
 
     /// <inheritdoc />
     public abstract Task<string> MapLocalPathToSasUrlAsync(string path, bool getContainerSas = false);

--- a/src/TesApi.Web/Storage/StorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/StorageAccessProvider.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace TesApi.Web.Storage;
+
+/// <summary>
+/// 
+/// </summary>
+public abstract class StorageAccessProvider : IStorageAccessProvider
+{
+    /// <summary>
+    /// Logger instance. 
+    /// </summary>
+    protected readonly ILogger logger;
+    /// <summary>
+    /// Azure proxy instance.
+    /// </summary>
+    protected readonly IAzureProxy azureProxy;
+
+    /// <summary>
+    /// Provides base methods for blob storage access and local input mapping.
+    /// </summary>
+    /// <param name="logger">Logger <see cref="ILogger"/></param>
+    /// <param name="azureProxy">Azure proxy <see cref="IAzureProxy"/></param>
+    public StorageAccessProvider(ILogger<DefaultStorageAccessProvider> logger, IAzureProxy azureProxy)
+    {
+        this.logger = logger;
+        this.azureProxy = azureProxy;
+
+    }
+
+    /// <inheritdoc />
+    public async Task<string> DownloadBlobAsync(string blobRelativePath)
+    {
+        try
+        {
+            return await this.azureProxy.DownloadBlobAsync(new Uri(await MapLocalPathToSasUrlAsync(blobRelativePath)));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryDownloadBlobAsync(string blobRelativePath, Action<string> action)
+    {
+        try
+        {
+            var content = await this.azureProxy.DownloadBlobAsync(new Uri(await MapLocalPathToSasUrlAsync(blobRelativePath)));
+            action?.Invoke(content);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task UploadBlobAsync(string blobRelativePath, string content)
+        => await this.azureProxy.UploadBlobAsync(new Uri(await MapLocalPathToSasUrlAsync(blobRelativePath, true)), content);
+
+    /// <inheritdoc />
+    public async Task UploadBlobFromFileAsync(string blobRelativePath, string sourceLocalFilePath)
+        => await this.azureProxy.UploadBlobFromFileAsync(new Uri(await MapLocalPathToSasUrlAsync(blobRelativePath, true)), sourceLocalFilePath);
+
+    /// <inheritdoc />
+    public abstract Task<bool> IsPublicHttpUrl(string uriString);
+
+    /// <inheritdoc />
+    public abstract Task<string> MapLocalPathToSasUrlAsync(string path, bool getContainerSas = false);
+
+    /// <summary>
+    /// Tries to parse the input into a Http Url. 
+    /// </summary>
+    /// <param name="input">string to parse</param>
+    /// <param name="uri">resulting Url if successful</param>
+    /// <returns>true if the input is a Url, false otherwise</returns>
+    protected static bool TryParseHttpUrlFromInput(string input, out Uri uri)
+    {
+        return Uri.TryCreate(input, UriKind.Absolute, out uri) && (uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) || uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/TesApi.Web/Storage/StorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/StorageAccessProvider.cs
@@ -97,7 +97,7 @@ public abstract class StorageAccessProvider : IStorageAccessProvider
     /// </summary>
     /// <param name="path"></param>
     /// <returns></returns>
-    protected bool IsItKnownFilePath(string path)
+    protected bool IsItKnownExecutionFilePath(string path)
     {
         return path.StartsWith(CromwellPathPrefix, StringComparison.OrdinalIgnoreCase)
                || path.StartsWith(BatchPathPrefix, StringComparison.OrdinalIgnoreCase);

--- a/src/TesApi.Web/Storage/StorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/StorageAccessProvider.cs
@@ -23,7 +23,7 @@ public abstract class StorageAccessProvider : IStorageAccessProvider
     /// </summary>
     /// <param name="logger">Logger <see cref="ILogger"/></param>
     /// <param name="azureProxy">Azure proxy <see cref="IAzureProxy"/></param>
-    public StorageAccessProvider(ILogger<DefaultStorageAccessProvider> logger, IAzureProxy azureProxy)
+    public StorageAccessProvider(ILogger logger, IAzureProxy azureProxy)
     {
         this.logger = logger;
         this.azureProxy = azureProxy;

--- a/src/TesApi.Web/Storage/StorageAccountInfo.cs
+++ b/src/TesApi.Web/Storage/StorageAccountInfo.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace TesApi.Web
+namespace TesApi.Web.Storage
 {
     /// <summary>
     /// A representation associating an Azure Storage account with an Azure SubscriptionId

--- a/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
@@ -58,9 +58,14 @@ namespace TesApi.Web.Storage
 
             var normalizedPath = path.TrimStart('/');
 
+            if (IsItKnownFilePath(normalizedPath))
+            {
+                return await GetMappedSasUrlFromWsmAsync(normalizedPath);
+            }
+
             CheckIfPathMatchesExpectedTerraLocation(normalizedPath);
 
-            return await GetMappedSasUrlFromWsmAsync(ToBlobNameWithSegments(normalizedPath));
+            return await GetMappedSasUrlFromWsmAsync(RemoveStorageAndContainerSegments(normalizedPath));
 
         }
 
@@ -84,7 +89,7 @@ namespace TesApi.Web.Storage
             return tokenInfo.Url;
         }
 
-        private string ToBlobNameWithSegments(string path)
+        private string RemoveStorageAndContainerSegments(string path)
         {
             var segments = path.Split('/');
 

--- a/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using TesApi.Web.Management.Clients;
+using TesApi.Web.Management.Configuration;
+using TesApi.Web.Management.Models.Terra;
+
+namespace TesApi.Web.Storage
+{
+    /// <summary>
+    /// Provides methods for blob storage access by using local path references in form of /storageaccount/container/blobpath
+    /// </summary>
+    public class TerraStorageAccessProvider : StorageAccessProvider
+    {
+        private readonly TerraOptions terraOptions;
+        private readonly TerraWsmApiClient terraWsmApiClient;
+        private const int FirstSegment = 0;
+        private const int SecondSegment = 1;
+        private const string SasTokenPermissions = "racw";
+
+        /// <summary>
+        /// Provides methods for blob storage access by using local path references in form of /storageaccount/container/blobpath
+        /// for Terra
+        /// </summary>
+        /// <param name="logger">Logger <see cref="ILogger"/></param>
+        /// <param name="terraOptions"><see cref="TerraOptions"/></param>
+        /// <param name="azureProxy">Azure proxy <see cref="IAzureProxy"/></param>
+        /// <param name="terraWsmApiClient"><see cref="terraWsmApiClient"/></param>
+        public TerraStorageAccessProvider(ILogger<DefaultStorageAccessProvider> logger,
+            IOptions<TerraOptions> terraOptions, IAzureProxy azureProxy, TerraWsmApiClient terraWsmApiClient) : base(
+            logger, azureProxy)
+        {
+            this.terraWsmApiClient = terraWsmApiClient;
+            ArgumentNullException.ThrowIfNull(terraOptions);
+
+            this.terraOptions = terraOptions.Value;
+
+        }
+
+        /// <inheritdoc />
+        public override Task<bool> IsPublicHttpUrl(string uriString)
+        {
+            //TODO: check if this assumption is correct
+            //For Terra, if it is a Http/Https Url then it is public.
+            return Task.FromResult(TryParseHttpUrlFromInput(uriString, out _));
+
+        }
+
+        /// <inheritdoc />
+        public override async Task<string> MapLocalPathToSasUrlAsync(string path, bool getContainerSas = false)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(path);
+
+            var normalizedPath = path.TrimStart('/');
+
+            CheckIfPathMatchesExpectedTerraLocation(normalizedPath);
+
+            return await GetMappedSasUrlFromWsmAsync(ToBlobNameWithSegments(normalizedPath));
+
+        }
+
+        private async Task<string> GetMappedSasUrlFromWsmAsync(string blobName)
+        {
+            var tokenParams = new SasTokenApiParameters(
+                terraOptions.SasAllowedIpRange,
+                terraOptions.SasTokenExpirationInSeconds,
+                SasTokenPermissions, blobName);
+
+            logger.LogInformation($"Getting Sas Url from Terra. Requested blobName:{blobName}. Wsm resource id:{terraOptions.WorkspaceStorageContainerResourceId}");
+
+            var tokenInfo = await terraWsmApiClient.GetSasTokenAsync(
+                 Guid.Parse(terraOptions.WorkspaceId),
+                 Guid.Parse(terraOptions.WorkspaceStorageContainerResourceId),
+                 tokenParams);
+
+
+            logger.LogInformation($"Successfully obtained the Sas Url from Terra. Requested blobName:{blobName}. Wsm resource id:{terraOptions.WorkspaceStorageContainerResourceId}");
+
+            return tokenInfo.Url.ToString();
+        }
+
+        private string ToBlobNameWithSegments(string path)
+        {
+            var segments = path.Split('/');
+
+            //removes the storage and container segments form the path, but keeps the additional segments
+            return string.Join("/", segments.Skip(2).ToArray());
+        }
+
+        private void CheckIfPathMatchesExpectedTerraLocation(string path)
+        {
+            var segments = path.Split('/');
+
+            var errorMsg =
+                $"The path must contain the expected Terra storage location:{terraOptions.WorkspaceStorageAccountName}/{terraOptions.WorkspaceStorageContainerName}. " +
+                $"Path provided:{path}.";
+
+            if (segments.Length < 2)
+            {
+                throw new Exception("Invalid path provided. " + errorMsg);
+            }
+
+            if (!segments[FirstSegment].Equals(terraOptions.WorkspaceStorageAccountName, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new Exception("The account name does not match. " + errorMsg);
+            }
+
+            if (!segments[SecondSegment].Equals(terraOptions.WorkspaceStorageContainerName, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new Exception("The container name does not match. " + errorMsg);
+            }
+        }
+    }
+}

--- a/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
@@ -81,7 +81,7 @@ namespace TesApi.Web.Storage
 
             logger.LogInformation($"Successfully obtained the Sas Url from Terra. Requested blobName:{blobName}. Wsm resource id:{terraOptions.WorkspaceStorageContainerResourceId}");
 
-            return tokenInfo.Url.ToString();
+            return tokenInfo.Url;
         }
 
         private string ToBlobNameWithSegments(string path)

--- a/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
@@ -31,7 +31,7 @@ namespace TesApi.Web.Storage
         /// <param name="terraOptions"><see cref="TerraOptions"/></param>
         /// <param name="azureProxy">Azure proxy <see cref="IAzureProxy"/></param>
         /// <param name="terraWsmApiClient"><see cref="terraWsmApiClient"/></param>
-        public TerraStorageAccessProvider(ILogger<DefaultStorageAccessProvider> logger,
+        public TerraStorageAccessProvider(ILogger<TerraStorageAccessProvider> logger,
             IOptions<TerraOptions> terraOptions, IAzureProxy azureProxy, TerraWsmApiClient terraWsmApiClient) : base(
             logger, azureProxy)
         {

--- a/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
@@ -43,7 +43,7 @@ namespace TesApi.Web.Storage
         }
 
         /// <inheritdoc />
-        public override Task<bool> IsPublicHttpUrl(string uriString)
+        public override Task<bool> IsPublicHttpUrlAsync(string uriString)
         {
             //TODO: check if this assumption is correct
             //For Terra, if it is a Http/Https Url then it is public.


### PR DESCRIPTION
 - This PR introduces the Terra storage provider `TerraStorageProvider`
 - New options in `TerraOptions` to set the workspace, storage account, container name and resource id from Terra.
 -  Additional refactoring:
     -  Added a base class for the storage providers to encapsulate common functionality amongst them: `StorageProvider` is now abstract. 
     - The existing storage provider was renamed to `DefaultStorageProvider`
     - Moved storage related classes to the `Storage` namespace/folder.
     - Noticed that `configurationUtils` was called at start up while setting up the DI. This is a duplicate operation that was impacting start up time - this called is via the `DoOnceAtStartUp` hosted service.
  