### PR TITLE
Handle null inputs or outputs in a TES task

### DIFF
--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -890,9 +890,14 @@ namespace TesApi.Web
             var downloadFilesScriptUrl = await this.storageAccessProvider.MapLocalPathToSasUrlAsync($"/{downloadFilesScriptPath}");
             await this.storageAccessProvider.UploadBlobAsync($"/{downloadFilesScriptPath}", downloadFilesScriptContent);
 
-            var filesToUpload = await Task.WhenAll(
-                task.Outputs?.Select(async f =>
-                    new TesOutput { Path = f.Path, Url = await this.storageAccessProvider.MapLocalPathToSasUrlAsync(f.Path, getContainerSas: true), Name = f.Name, Type = f.Type }));
+            var filesToUpload = new TesOutput[0];
+
+            if (task.Outputs?.Count > 0)
+            {
+                filesToUpload = await Task.WhenAll(
+                    task.Outputs?.Select(async f =>
+                        new TesOutput { Path = f.Path, Url = await this.storageAccessProvider.MapLocalPathToSasUrlAsync(f.Path, getContainerSas: true), Name = f.Name, Type = f.Type }));
+            }
 
             // Ignore missing stdout/stderr files. CWL workflows have an issue where if the stdout/stderr are redirected, they are still listed in the TES outputs
             // Ignore any other missing files and directories. WDL tasks can have optional output files.

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -823,15 +823,15 @@ namespace TesApi.Web
             var cromwellExecutionDirectoryPath = GetCromwellExecutionDirectoryPath(task);
             var batchExecutionPathPrefix = cromwellExecutionDirectoryPath is null ? ExecutionsPathPrefix : CromwellPathPrefix;
 
-            var queryStringsToRemoveFromLocalFilePaths = task.Inputs
+            var queryStringsToRemoveFromLocalFilePaths = task.Inputs?
                 .Select(i => i.Path)
                 .Concat(task.Outputs.Select(o => o.Path))
                 .Where(p => p is not null)
                 .Select(p => queryStringRegex.Match(p).Groups[1].Value)
                 .Where(qs => !string.IsNullOrEmpty(qs))
-                .ToList();
+                .ToList() ?? new List<string>();
 
-            var inputFiles = task.Inputs.Distinct();
+            var inputFiles = task.Inputs?.Distinct().ToList() ?? new List<TesInput>();
 
             var drsInputFiles = inputFiles
                 .Where(f => f?.Url?.StartsWith("drs://", StringComparison.OrdinalIgnoreCase) == true)

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -823,7 +823,7 @@ namespace TesApi.Web
             var cromwellExecutionDirectoryPath = GetCromwellExecutionDirectoryPath(task);
             var batchExecutionPathPrefix = cromwellExecutionDirectoryPath is null ? ExecutionsPathPrefix : CromwellPathPrefix;
 
-            var queryStringsToRemoveFromLocalFilePaths = task.Inputs?
+            var queryStringsToRemoveFromLocalFilePaths = task?.Inputs
                 .Select(i => i.Path)
                 .Concat(task.Outputs.Select(o => o.Path))
                 .Where(p => p is not null)
@@ -831,7 +831,7 @@ namespace TesApi.Web
                 .Where(qs => !string.IsNullOrEmpty(qs))
                 .ToList() ?? new List<string>();
 
-            var inputFiles = task.Inputs?.Distinct().ToList() ?? new List<TesInput>();
+            var inputFiles = task?.Inputs.Distinct().ToList() ?? new List<TesInput>();
 
             var drsInputFiles = inputFiles
                 .Where(f => f?.Url?.StartsWith("drs://", StringComparison.OrdinalIgnoreCase) == true)

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -837,14 +837,11 @@ namespace TesApi.Web
                 .Where(f => f?.Url?.StartsWith("drs://", StringComparison.OrdinalIgnoreCase) == true)
                 .ToList();
 
-            if (task.Outputs != null)
+            foreach (var output in task.Outputs ?? Enumerable.Empty<TesOutput>())
             {
-                foreach (var output in task.Outputs)
+                if (!output.Path.StartsWith($"{CromwellPathPrefix}/", StringComparison.OrdinalIgnoreCase) && !output.Path.StartsWith($"{ExecutionsPathPrefix}/", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (!output.Path.StartsWith($"{CromwellPathPrefix}/", StringComparison.OrdinalIgnoreCase) && !output.Path.StartsWith($"{ExecutionsPathPrefix}/", StringComparison.OrdinalIgnoreCase))
-                    {
-                        throw new TesException("InvalidOutputPath", $"Unsupported output path '{output.Path}' for task Id {task.Id}. Must start with {CromwellPathPrefix} or {ExecutionsPathPrefix}");
-                    }
+                    throw new TesException("InvalidOutputPath", $"Unsupported output path '{output.Path}' for task Id {task.Id}. Must start with {CromwellPathPrefix} or {ExecutionsPathPrefix}");
                 }
             }
 

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -823,7 +823,7 @@ namespace TesApi.Web
             var cromwellExecutionDirectoryPath = GetCromwellExecutionDirectoryPath(task);
             var batchExecutionPathPrefix = cromwellExecutionDirectoryPath is null ? ExecutionsPathPrefix : CromwellPathPrefix;
 
-            var queryStringsToRemoveFromLocalFilePaths = task?.Inputs
+            var queryStringsToRemoveFromLocalFilePaths = task.Inputs?
                 .Select(i => i.Path)
                 .Concat(task.Outputs.Select(o => o.Path))
                 .Where(p => p is not null)
@@ -831,7 +831,7 @@ namespace TesApi.Web
                 .Where(qs => !string.IsNullOrEmpty(qs))
                 .ToList() ?? new List<string>();
 
-            var inputFiles = task?.Inputs.Distinct().ToList() ?? new List<TesInput>();
+            var inputFiles = task.Inputs?.Distinct().ToList() ?? new List<TesInput>();
 
             var drsInputFiles = inputFiles
                 .Where(f => f?.Url?.StartsWith("drs://", StringComparison.OrdinalIgnoreCase) == true)

--- a/src/TesApi.Web/Controllers/TaskServiceApi.cs
+++ b/src/TesApi.Web/Controllers/TaskServiceApi.cs
@@ -139,7 +139,7 @@ namespace TesApi.Controllers
             // For CWL workflows, if disk size is not specified in TES object (always), try to retrieve it from the corresponding workflow stored by Cromwell in /cromwell-tmp directory
             // Also allow for TES-style "memory" and "cpu" hints in CWL.
             if (tesTask.Name is not null
-                && tesTask?.Inputs.Any(i => i.Path.Contains(".cwl/")) == true
+                && tesTask.Inputs?.Any(i => i.Path.Contains(".cwl/")) == true
                 && tesTask.WorkflowId is not null
                 && azureProxy.TryReadCwlFile(tesTask.WorkflowId, out var cwlContent)
                 && CwlDocument.TryCreate(cwlContent, out var cwlDocument))

--- a/src/TesApi.Web/Controllers/TaskServiceApi.cs
+++ b/src/TesApi.Web/Controllers/TaskServiceApi.cs
@@ -139,7 +139,7 @@ namespace TesApi.Controllers
             // For CWL workflows, if disk size is not specified in TES object (always), try to retrieve it from the corresponding workflow stored by Cromwell in /cromwell-tmp directory
             // Also allow for TES-style "memory" and "cpu" hints in CWL.
             if (tesTask.Name is not null
-                && tesTask.Inputs.Any(i => i.Path.Contains(".cwl/"))
+                && tesTask?.Inputs.Any(i => i.Path.Contains(".cwl/")) == true
                 && tesTask.WorkflowId is not null
                 && azureProxy.TryReadCwlFile(tesTask.WorkflowId, out var cwlContent)
                 && CwlDocument.TryCreate(cwlContent, out var cwlDocument))


### PR DESCRIPTION
Fixes the case when no inputs or outputs are specified like in the below JSON, which is accepted by TES but throws an exception while processing.

```
{
  "resources": {
    "preemptible": true,
    "backend_parameters": {
      "vm_size": "Standard_D2a_v4"
    }
  },
  "executors": [
    {
      "image": "ubuntu:22.04",
      "command": [ "echo hello > test.txt" ],
    }
  ]
}
```