### PR TITLE
Remove task ID from executions path

### DIFF
--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -346,7 +346,7 @@ namespace TesApi.Web
             }
             else
             {
-                return $"{ExecutionsPathPrefix.TrimStart('/')}/{task.Id}";
+                return $"{ExecutionsPathPrefix.TrimStart('/')}";
             }
         }
 

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -889,7 +889,9 @@ namespace TesApi.Web
 
             var filesToUpload = await Task.WhenAll(
                 task.Outputs.Select(async f =>
-                    new TesOutput { Path = f.Path, Url = await this.storageAccessProvider.MapLocalPathToSasUrlAsync(f.Path, getContainerSas: true), Name = f.Name, Type = f.Type }));
+                    new TesOutput { Path = f.Path, Url = await this.storageAccessProvider.MapLocalPathToSasUrlAsync(
+                        f.Path.StartsWith(ExecutionsPathPrefix) ? $"{ExecutionsPathPrefix}/{task.Id}{f.Path.Substring(ExecutionsPathPrefix.Length)}" : f.Path,
+                        getContainerSas: true), Name = f.Name, Type = f.Type }));
 
             // Ignore missing stdout/stderr files. CWL workflows have an issue where if the stdout/stderr are redirected, they are still listed in the TES outputs
             // Ignore any other missing files and directories. WDL tasks can have optional output files.

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -892,9 +892,7 @@ namespace TesApi.Web
                 task.Outputs.Select(async f =>
                     new TesOutput { 
                         Path = f.Path, 
-                        Url = isCromwell ? 
-                            await this.storageAccessProvider.MapLocalPathToSasUrlAsync(f.Path, getContainerSas: true) : 
-                            await this.storageAccessProvider.MapLocalPathToSasUrlAsync(f.Url, getContainerSas: true),
+                        Url = await this.storageAccessProvider.MapLocalPathToSasUrlAsync(f.Url, getContainerSas: true),
                         Name = f.Name, 
                         Type = f.Type }));
 

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -892,7 +892,9 @@ namespace TesApi.Web
                 task.Outputs.Select(async f =>
                     new TesOutput { 
                         Path = f.Path, 
-                        Url = isCromwell ? await this.storageAccessProvider.MapLocalPathToSasUrlAsync(f.Path, getContainerSas: true) : f.Url,
+                        Url = isCromwell ? 
+                            await this.storageAccessProvider.MapLocalPathToSasUrlAsync(f.Path, getContainerSas: true) : 
+                            await this.storageAccessProvider.MapLocalPathToSasUrlAsync(f.Url, getContainerSas: true),
                         Name = f.Name, 
                         Type = f.Type }));
 

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -993,7 +993,7 @@ namespace TesApi.Web
             await this.storageAccessProvider.UploadBlobAsync($"/{batchScriptPath}", sb.ToString());
 
             var batchScriptSasUrl = await this.storageAccessProvider.MapLocalPathToSasUrlAsync($"/{batchScriptPath}");
-            var batchExecutionDirectorySasUrl = await this.storageAccessProvider.MapLocalPathToSasUrlAsync($"/{batchExecutionDirectoryPath}", getContainerSas: true);
+            var batchExecutionDirectorySasUrl = await this.storageAccessProvider.MapLocalPathToSasUrlAsync($"/{batchExecutionDirectoryPath}/", getContainerSas: true);
 
             var batchRunCommand = enableBatchAutopool
                 ? $"/bin/bash {batchScriptPath}"


### PR DESCRIPTION
The task ID is created by TES and is not known _a priori_, so there is no way for the user to specify it.  Also it's unnecessary, since the task is already running in a unique path specified in the environment variable `$AZ_BATCH_TASK_WORKING_DIR`

This PR simply removes it from the path.  TES inputs and outputs shall now be specified like this:

`/executions/my_output_file.txt`

For a later discussion:

- There is no way the user would know that `/executions` is hard-coded in this implementation without reading the code or docs: https://github.com/microsoft/ga4gh-tes/blob/92208718b1d36d2eb2854f2ecd9892b3d9056a96/src/TesApi.Web/BatchScheduler.cs#L52
- Just using root seems better `/my_output_file.txt`, however there might be a permissions issue writing there
- Furthermore, it seems best to also support simply `my_output_file.txt` - however, [the TES spec says the path should be absolute](https://github.com/ga4gh/task-execution-schemas/blob/1df37d34242f74d3f03475c6b9de3324b8094054/openapi/task_execution_service.openapi.yaml#L537), when there is no slash, is it considered absolute still?
- There might be an unrelated bug here I noticed, since the first slash `/` is specified here:
https://github.com/microsoft/ga4gh-tes/blob/92208718b1d36d2eb2854f2ecd9892b3d9056a96/src/TesApi.Web/BatchScheduler.cs#L990
But not here:
https://github.com/microsoft/ga4gh-tes/blob/92208718b1d36d2eb2854f2ecd9892b3d9056a96/src/TesApi.Web/BatchScheduler.cs#L994
Or here:
https://github.com/microsoft/ga4gh-tes/blob/92208718b1d36d2eb2854f2ecd9892b3d9056a96/src/TesApi.Web/BatchScheduler.cs#L995