### PR TITLE
App insights key lookup occurs only when configuration option is set

### DIFF
--- a/src/TesApi.Web/Management/ArmResourceInformationFinder.cs
+++ b/src/TesApi.Web/Management/ArmResourceInformationFinder.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Management.ApplicationInsights.Management;
+using Microsoft.Azure.Management.Batch;
+using Microsoft.Azure.Services.AppAuthentication;
+using Microsoft.Rest;
+
+namespace TesApi.Web.Management
+{
+    /// <summary>
+    /// Provides utility methods to find resource information using the TES service identity
+    /// </summary>
+    public class ArmResourceInformationFinder
+    {
+        /// <summary>
+        /// Looks up the AppInsights instrumentation key in subscriptions the TES services has access to 
+        /// </summary>
+        /// <param name="accountName"></param>
+        /// <returns></returns>
+        public static async Task<string> GetAppInsightsInstrumentationKeyAsync(string accountName)
+        {
+            var azureClient = await AzureManagementClientsFactory.GetAzureManagementClientAsync();
+            var subscriptionIds = (await azureClient.Subscriptions.ListAsync()).Select(s => s.SubscriptionId);
+
+            var credentials = new TokenCredentials(await GetAzureAccessTokenAsync());
+
+            foreach (var subscriptionId in subscriptionIds)
+            {
+                var app = (await new ApplicationInsightsManagementClient(credentials) { SubscriptionId = subscriptionId }.Components.ListAsync())
+                    .FirstOrDefault(a => a.ApplicationId.Equals(accountName, StringComparison.OrdinalIgnoreCase));
+
+                if (app is not null)
+                {
+                    return app.InstrumentationKey;
+                }
+            }
+
+            return null;
+        }
+        //TODO: refactor this to use Azure Identity token provider. 
+        private static Task<string> GetAzureAccessTokenAsync(string resource = "https://management.azure.com/")
+        {
+            return new AzureServiceTokenProvider().GetAccessTokenAsync(resource);
+        }
+
+        /// <summary>
+        /// Attempts to get the batch resource information using the ARM api.
+        /// Returns null if the resource was not found or the account does not have access.
+        /// </summary>
+        /// <param name="batchAccountName">batch account name</param>
+        /// <returns></returns>
+        public static async Task<BatchAccountResourceInformation> TryGetResourceInformationFromAccountNameAsync(string batchAccountName)
+        {
+            //TODO: look if a newer version of the management SDK provides a simpler way to look for this information .
+            var tokenCredentials = new TokenCredentials(await GetAzureAccessTokenAsync());
+            var azureClient = await AzureManagementClientsFactory.GetAzureManagementClientAsync();
+
+            var subscriptionIds = (await azureClient.Subscriptions.ListAsync()).Select(s => s.SubscriptionId);
+
+            foreach (var subId in subscriptionIds)
+            {
+                using var batchClient = new BatchManagementClient(tokenCredentials) { SubscriptionId = subId };
+
+                var batchAccount = (await batchClient.BatchAccount.ListAsync())
+                    .FirstOrDefault(a => a.Name.Equals(batchAccountName, StringComparison.OrdinalIgnoreCase));
+
+                if (batchAccount is not null)
+                {
+                    return BatchAccountResourceInformation.FromBatchResourceId(batchAccount.Id, batchAccount.Location);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/TesApi.Web/Management/AzureManagementClientsFactory.cs
+++ b/src/TesApi.Web/Management/AzureManagementClientsFactory.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.Management.Batch;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
@@ -70,36 +69,6 @@ namespace TesApi.Web.Management
         /// <returns></returns>
         public async Task<FluentAzure.IAuthenticated> CreateAzureManagementClientAsync()
             => await AzureManagementClientsFactory.GetAzureManagementClientAsync();
-
-        /// <summary>
-        /// Attempts to get the batch resource information using the ARM api.
-        /// Returns null if the resource was not found or the account does not have access.
-        /// </summary>
-        /// <param name="batchAccountName">batch account name</param>
-        /// <returns></returns>
-        public static async Task<BatchAccountResourceInformation> TryGetResourceInformationFromAccountNameAsync(string batchAccountName)
-        {
-            //TODO: look if a newer version of the management SDK provides a simpler way to look for this information .
-            var tokenCredentials = new TokenCredentials(await GetAzureAccessTokenAsync());
-            var azureClient = await GetAzureManagementClientAsync();
-
-            var subscriptionIds = (await azureClient.Subscriptions.ListAsync()).Select(s => s.SubscriptionId);
-
-            foreach (var subId in subscriptionIds)
-            {
-                using var batchClient = new BatchManagementClient(tokenCredentials) { SubscriptionId = subId };
-
-                var batchAccount = (await batchClient.BatchAccount.ListAsync())
-                    .FirstOrDefault(a => a.Name.Equals(batchAccountName, StringComparison.OrdinalIgnoreCase));
-
-                if (batchAccount is not null)
-                {
-                    return BatchAccountResourceInformation.FromBatchResourceId(batchAccount.Id, batchAccount.Location);
-                }
-            }
-
-            return null;
-        }
 
         /// <summary>
         /// Creates a new instance of Azure Management client

--- a/src/TesApi.Web/Management/Configuration/BatchAccountOptions.cs
+++ b/src/TesApi.Web/Management/Configuration/BatchAccountOptions.cs
@@ -11,7 +11,7 @@ namespace TesApi.Web.Management.Configuration
         /// <summary>
         /// Configuration section.
         /// </summary>
-        public const string BatchAccount = "BatchAccount";
+        public const string SectionName = "BatchAccount";
         /// <summary>
         /// Default Azure offer durable id. 
         /// </summary>

--- a/src/TesApi.Web/Management/Configuration/ContainerRegistryOptions.cs
+++ b/src/TesApi.Web/Management/Configuration/ContainerRegistryOptions.cs
@@ -11,7 +11,7 @@ public class ContainerRegistryOptions
     /// <summary>
     /// Configuration section.
     /// </summary>
-    public const string ContainerRegistrySection = "ContainerRegistry";
+    public const string SectionName = "ContainerRegistry";
     /// <summary>
     /// Enables/disables auto-discovery features
     /// </summary>

--- a/src/TesApi.Web/Management/Configuration/RetryPolicyOptions.cs
+++ b/src/TesApi.Web/Management/Configuration/RetryPolicyOptions.cs
@@ -11,7 +11,7 @@ namespace TesApi.Web.Management.Configuration
         /// <summary>
         /// Retry policy configuration section
         /// </summary>
-        public const string RetryPolicy = "RetryPolicy";
+        public const string SectionName = "RetryPolicy";
 
         private const int DefaultRetryCount = 3;
         private const int DefaultExponentialBackOffExponent = 2;

--- a/src/TesApi.Web/Management/Configuration/TerraOptions.cs
+++ b/src/TesApi.Web/Management/Configuration/TerraOptions.cs
@@ -11,7 +11,7 @@ public class TerraOptions
     /// <summary>
     /// Terra configuration section
     /// </summary>
-    public const string Terra = "Terra";
+    public const string SectionName = "Terra";
     private const int DefaultSasTokenExpirationInSeconds = 60 * 24 * 3; // 3 days
 
     /// <summary>

--- a/src/TesApi.Web/Startup.cs
+++ b/src/TesApi.Web/Startup.cs
@@ -70,9 +70,6 @@ namespace TesApi.Web
                 .Configure<ContainerRegistryOptions>(Configuration.GetSection(ContainerRegistryOptions.SectionName))
                 .AddSingleton<IAppCache, CachingService>()
                 .AddSingleton<AzureProxy>()
-                .AddSingleton<IAzureProxy>(sp =>
-                    ActivatorUtilities.CreateInstance<CachingWithRetriesAzureProxy>(sp,
-                        (IAzureProxy)sp.GetRequiredService(typeof(AzureProxy))))
                 .AddSingleton(CreateCosmosDbRepositoryFromConfiguration)
                 .AddSingleton<IBatchPoolFactory, BatchPoolFactory>()
                 .AddTransient<BatchPool>()

--- a/src/TesApi.Web/Startup.cs
+++ b/src/TesApi.Web/Startup.cs
@@ -4,6 +4,28 @@
 using System;
 using System.IO;
 using System.Reflection;
+using AutoMapper;
+using Azure.Core;
+using Azure.Identity;
+using LazyCache;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using Tes.Models;
+using Tes.Repository;
+using TesApi.Filters;
+using TesApi.Web.Management;
+using TesApi.Web.Management.Batch;
+using TesApi.Web.Management.Clients;
+using TesApi.Web.Management.Configuration;
+using TesApi.Web.Storage;
 
 namespace TesApi.Web
 {
@@ -43,14 +65,10 @@ namespace TesApi.Web
             services
                 .Configure<BatchAccountOptions>(Configuration.GetSection(BatchAccountOptions.SectionName))
                 .Configure<CosmosDbOptions>(Configuration.GetSection(CosmosDbOptions.CosmosDbAccount))
-                .Configure<RetryPolicyOptions>(Configuration.GetSection(RetryPolicyOptions.RetryPolicy))
-                .Configure<TerraOptions>(Configuration.GetSection(TerraOptions.Terra))
-                .Configure<ContainerRegistryOptions>(Configuration.GetSection(ContainerRegistryOptions.ContainerRegistrySection))
+                .Configure<RetryPolicyOptions>(Configuration.GetSection(RetryPolicyOptions.SectionName))
+                .Configure<TerraOptions>(Configuration.GetSection(TerraOptions.SectionName))
+                .Configure<ContainerRegistryOptions>(Configuration.GetSection(ContainerRegistryOptions.SectionName))
                 .AddSingleton<IAppCache, CachingService>()
-                .AddSingleton(CreateBatchPoolManagerFromConfiguration)
-
-                .AddSingleton<AzureProxy, AzureProxy>()
-
                 .AddSingleton<AzureProxy>()
                 .AddSingleton<IAzureProxy>(sp =>
                     ActivatorUtilities.CreateInstance<CachingWithRetriesAzureProxy>(sp,
@@ -58,6 +76,7 @@ namespace TesApi.Web
                 .AddSingleton(CreateCosmosDbRepositoryFromConfiguration)
                 .AddSingleton<IBatchPoolFactory, BatchPoolFactory>()
                 .AddTransient<BatchPool>()
+                .AddSingleton(CreateBatchPoolManagerFromConfiguration)
 
                 .AddControllers()
                 .AddNewtonsoftJson(opts =>


### PR DESCRIPTION
Closes #68 

- This PR modifies the start-up logic so it only performs the look up of the app insights key/connection string if the app insights configuration is provided.
- If not provided the default configuration is used - [documentation here](https://learn.microsoft.com/en-us/azure/azure-monitor/app/sdk-connection-string?tabs=net).