### PR TITLE
WSM create batch pool operations uses the client id.

### DIFF
--- a/src/TesApi.Web/Management/Batch/MappingProfilePoolToWsmRequest.cs
+++ b/src/TesApi.Web/Management/Batch/MappingProfilePoolToWsmRequest.cs
@@ -37,10 +37,11 @@ namespace TesApi.Web.Management.Batch
             CreateMap<PublicIPAddressConfiguration, ApiPublicIpAddressConfiguration>();
             //TODO: This mapping to be updated once the WSM API changes to support the correct values 
             CreateMap<UserAssignedIdentities, ApiUserAssignedIdentity>()
-                .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.PrincipalId))
-                .ForMember(dest => dest.ResourceGroupName, opt => opt.Ignore());
+                .ForMember(dest => dest.ClientId, opt => opt.MapFrom(src => src.ClientId))
+                .ForMember(dest => dest.ResourceGroupName, opt => opt.Ignore())
+                .ForMember(dest => dest.Name, opt => opt.Ignore());
             CreateMap<Pool, ApiAzureBatchPool>()
-               .ForMember(dest => dest.UserAssignedIdentities, opt => opt.Ignore());
+               .ForMember(dest => dest.UserAssignedIdentities, opt => opt.MapFrom(src => src.Identity.UserAssignedIdentities.Values));
         }
     }
 }

--- a/src/TesApi.Web/Management/Models/Terra/ApiCreateBatchPoolRequest.cs
+++ b/src/TesApi.Web/Management/Models/Terra/ApiCreateBatchPoolRequest.cs
@@ -328,6 +328,9 @@ namespace TesApi.Web.Management.Models.Terra
 
         [JsonPropertyName("resourceGroupName")]
         public string ResourceGroupName { get; set; }
+
+        [JsonPropertyName("clientId")]
+        public string ClientId { get; set; }
     }
 
     public class ApiCommon


### PR DESCRIPTION
Closes #65 

- Updated API request to include the client id.
- Update mapping to map client identity from the pool to the WSM API request. 