### PR TITLE
Add support for pool metadata properties and fixes

### DIFF
--- a/src/TesApi.Tests/TerraApiStubData.cs
+++ b/src/TesApi.Tests/TerraApiStubData.cs
@@ -15,6 +15,8 @@ public class TerraApiStubData
     public const string ResourceGroup = "mrg-terra-dev-previ-20191228";
     public const string WorkspaceAccountName = "fooaccount";
     public const string WorkspaceContainerName = "foocontainer";
+    public const string SasToken = "SASTOKENSTUB=";
+    public const string WsmGetSasResponseStorageUrl = "https://bloburl.foo/container";
 
     public Guid LandingZoneId { get; } = Guid.NewGuid();
     public Guid SubscriptionId { get; } = Guid.NewGuid();
@@ -68,10 +70,10 @@ public class TerraApiStubData
 
     public string GetWsmSasTokenApiResponseInJson()
     {
-        return @"{
-  ""token"": ""SASTOKENSTUB="",
-  ""url"": ""https://bloburl.foo/container?sas=SASTOKENSTUB=""
-    }";
+        return $@"{{
+  ""token"": ""{SasToken}"",
+  ""url"": ""{WsmGetSasResponseStorageUrl}?sv={SasToken}""
+    }}";
     }
 
     public string GetResourceApiResponseInJson()

--- a/src/TesApi.Tests/TerraApiStubData.cs
+++ b/src/TesApi.Tests/TerraApiStubData.cs
@@ -70,10 +70,12 @@ public class TerraApiStubData
 
     public string GetWsmSasTokenApiResponseInJson()
     {
-        return $@"{{
-  ""token"": ""{SasToken}"",
-  ""url"": ""{WsmGetSasResponseStorageUrl}?sv={SasToken}""
-    }}";
+        return $$"""
+        {
+            "token": "{{SasToken}}",
+            "url": "{{WsmGetSasResponseStorageUrl}}?sv={{SasToken}}"
+        }
+        """;
     }
 
     public string GetResourceApiResponseInJson()

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -890,7 +890,7 @@ namespace TesApi.Web
                         ? $"blobxfer download --storage-url \"$url\" --local-path \"$path\" --chunk-size-bytes 104857600 --rename --include '{StorageAccountUrlSegments.Create(f.Url).BlobName}'"
                         : "mkdir -p $(dirname \"$path\") && wget -O \"$path\" \"$url\"";
 
-                    return $" && {setVariables} && {downloadSingleFile} && {exitIfDownloadedFileIsNotFound} && {incrementTotalBytesTransferred}";
+                    return $"&& echo $(date +%T) && {setVariables} && {downloadSingleFile} && {exitIfDownloadedFileIsNotFound} && {incrementTotalBytesTransferred}";
                 }))
                 + $" && echo FileDownloadSizeInBytes=$total_bytes >> {metricsPath}";
 

--- a/src/TesApi.Web/Management/Batch/MappingProfilePoolToWsmRequest.cs
+++ b/src/TesApi.Web/Management/Batch/MappingProfilePoolToWsmRequest.cs
@@ -40,6 +40,7 @@ namespace TesApi.Web.Management.Batch
             CreateMap<ImageReference, ApiImageReference>();
             CreateMap<FixedScaleSettings, ApiFixedScale>();
             CreateMap<PublicIPAddressConfiguration, ApiPublicIpAddressConfiguration>();
+            CreateMap<MetadataItem, ApiBatchPoolMetadataItem>();
             //TODO: This mapping to be updated once the WSM API changes to support the correct values 
             CreateMap<UserAssignedIdentities, ApiUserAssignedIdentity>()
                 .ForMember(dest => dest.ClientId, opt => opt.MapFrom(src => src.ClientId))

--- a/src/TesApi.Web/Management/Clients/TerraWsmApiClient.cs
+++ b/src/TesApi.Web/Management/Clients/TerraWsmApiClient.cs
@@ -81,9 +81,11 @@ namespace TesApi.Web.Management.Clients
                     await HttpSendRequestWithRetryPolicyAsync(() => new HttpRequestMessage(HttpMethod.Post, uri) { Content = GetBatchPoolRequestContent(apiCreateBatchPool) },
                         setAuthorizationHeader: true);
 
+                var apiResponse = await GetApiResponseContentAsync<ApiCreateBatchPoolResponse>(response);
+
                 Logger.LogInformation($"Successfully created a batch pool using WSM for workspace:{workspaceId}");
 
-                return await GetApiResponseContentAsync<ApiCreateBatchPoolResponse>(response);
+                return apiResponse;
             }
             catch (Exception ex)
             {

--- a/src/TesApi.Web/Management/Models/Terra/ApiCreateBatchPoolRequest.cs
+++ b/src/TesApi.Web/Management/Models/Terra/ApiCreateBatchPoolRequest.cs
@@ -49,6 +49,17 @@ namespace TesApi.Web.Management.Models.Terra
 
         [JsonPropertyName("networkConfiguration")]
         public ApiNetworkConfiguration NetworkConfiguration { get; set; }
+
+        [JsonPropertyName("metadata")]
+        public ApiBatchPoolMetadataItem[] Metadata { get; set; }
+    }
+
+    public class ApiBatchPoolMetadataItem
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+        [JsonPropertyName("value")]
+        public string Value { get; set; }
     }
 
     public class ApiApplicationPackage

--- a/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
@@ -19,7 +19,7 @@ namespace TesApi.Web.Storage
     {
         private readonly TerraOptions terraOptions;
         private readonly TerraWsmApiClient terraWsmApiClient;
-        private const string SasBlobPermissions = "racwl";
+        private const string SasBlobPermissions = "racw";
         private const string SasContainerPermissions = "racwl";
 
         /// <summary>
@@ -80,18 +80,7 @@ namespace TesApi.Web.Storage
 
             if (getContainerSas)
             {
-                if (IsKnownExecutionFilePath(normalizedPath))
-                {
-                    return await GetMappedSasContainerUrlFromWsmAsync(normalizedPath);
-                }
-
-                if (!StorageAccountUrlSegments.TryCreate(normalizedPath, out var withContainerSegments))
-                {
-                    throw new Exception(
-                        "Invalid path provided. The path must be a valid blob storage url or a path with the following format: /accountName/container");
-                }
-
-                return await GetMappedSasContainerUrlFromWsmAsync(withContainerSegments.BlobName);
+                return await MapAndGetSasContainerUrlFromWsmAsync(normalizedPath);
             }
 
             if (IsKnownExecutionFilePath(normalizedPath))
@@ -108,6 +97,22 @@ namespace TesApi.Web.Storage
             CheckIfAccountAndContainerAreWorkspaceStorage(segments.AccountName, segments.ContainerName);
 
             return await GetMappedSasUrlFromWsmAsync(segments.BlobName);
+        }
+
+        private async Task<string> MapAndGetSasContainerUrlFromWsmAsync(string inputPath)
+        {
+            if (IsKnownExecutionFilePath(inputPath))
+            {
+                return await GetMappedSasContainerUrlFromWsmAsync(inputPath);
+            }
+
+            if (!StorageAccountUrlSegments.TryCreate(inputPath, out var withContainerSegments))
+            {
+                throw new Exception(
+                    "Invalid path provided. The path must be a valid blob storage url or a path with the following format: /accountName/container");
+            }
+
+            return await GetMappedSasContainerUrlFromWsmAsync(withContainerSegments.BlobName);
         }
 
         private async Task<string> GetMappedSasContainerUrlFromWsmAsync(string pathToAppend)

--- a/src/TesApi.Web/appsettings.json
+++ b/src/TesApi.Web/appsettings.json
@@ -21,7 +21,7 @@
   "Gen2BatchImageVersion": "latest",
   "Gen1BatchImageOffer": "ubuntu-server-container",
   "Gen1BatchImagePublisher": "microsoft-azure-batch",
-  "Gen1BatchImageSku": "microsoft-azure-batch",
+  "Gen1BatchImageSku": "20-04-lts",
   "Gen1BatchImageVersion": "latest",
   "BatchPoolRotationForcedDays": "7",
   "BatchAccount": {


### PR DESCRIPTION
Closes #81, #89 
This PR includes the following changes:
- Adds support to create batch pools with metadata properties via WSM
- Adds the WSM resource id as a batch pool metadata - this facilitates the deletion of batch pools via WSM as the resource id is required.
- Additional fixes:
  - Resource id and name for WSM is unique for each create operation (fixes #89)
  - Success log entry for WSM create operation is created after response validation. 
  - Added correct value for `Gen1BatchImageSku` in appsetttings.