### PR TITLE
Identity value from pool maps to the correct value in the request to WSM

### DIFF
--- a/src/TesApi.Tests/TerraBatchPoolManagerTests.cs
+++ b/src/TesApi.Tests/TerraBatchPoolManagerTests.cs
@@ -127,5 +127,34 @@ namespace TesApi.Tests
             Assert.AreNotEqual(name, capturedApiCreateBatchPoolRequest.Common.Name);
             Assert.AreNotEqual(resourceId, capturedApiCreateBatchPoolRequest.Common.ResourceId);
         }
+
+        [TestMethod]
+        public async Task CreateBatchPoolAsync_UserIdentityMapsCorrectly()
+        {
+            var identities = new Dictionary<string, UserAssignedIdentities>();
+
+            var identityName = "MyTestIdentity";
+
+            identities.Add(identityName, new UserAssignedIdentities());
+
+            var poolInfo = new Pool()
+            {
+                DeploymentConfiguration = new DeploymentConfiguration()
+                {
+                    CloudServiceConfiguration = new CloudServiceConfiguration("osfamily", "osversion"),
+                    VirtualMachineConfiguration = new VirtualMachineConfiguration()
+                },
+                Identity = new BatchPoolIdentity(PoolIdentityType.UserAssigned, identities)
+            };
+
+            var pool = await terraBatchPoolManager.CreateBatchPoolAsync(poolInfo, false);
+
+            var name = capturedApiCreateBatchPoolRequest.Common.Name;
+            var resourceId = capturedApiCreateBatchPoolRequest.Common.ResourceId;
+
+            pool = await terraBatchPoolManager.CreateBatchPoolAsync(poolInfo, false);
+
+            Assert.AreEqual(identityName, capturedApiCreateBatchPoolRequest.AzureBatchPool.UserAssignedIdentities.SingleOrDefault().Name);
+        }
     }
 }

--- a/src/TesApi.Web/Management/Batch/MappingProfilePoolToWsmRequest.cs
+++ b/src/TesApi.Web/Management/Batch/MappingProfilePoolToWsmRequest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using AutoMapper;
 using Microsoft.Azure.Management.Batch.Models;
 using TesApi.Web.Management.Models.Terra;
@@ -47,7 +48,7 @@ namespace TesApi.Web.Management.Batch
                 .ForMember(dest => dest.ResourceGroupName, opt => opt.Ignore())
                 .ForMember(dest => dest.Name, opt => opt.Ignore());
             CreateMap<Pool, ApiAzureBatchPool>()
-               .ForMember(dest => dest.UserAssignedIdentities, opt => opt.MapFrom(src => src.Identity.UserAssignedIdentities.Values));
+               .ForMember(dest => dest.UserAssignedIdentities, opt => opt.MapFrom(src => src.Identity.UserAssignedIdentities.Select(kvp => new ApiUserAssignedIdentity() { Name = kvp.Key, ClientId = kvp.Value.ClientId })));
         }
     }
 }

--- a/src/TesApi.Web/appsettings.json
+++ b/src/TesApi.Web/appsettings.json
@@ -4,6 +4,7 @@
       "Default": "Warning"
     }
   },
+  "Name": "TES1",
   "AllowedHosts": "*",
   "BatchImagePublisher": "microsoft-dsvm",
   "BatchImageOffer": "ubuntu-hpc",


### PR DESCRIPTION
Closes #87 

PR includes:
 - The identity value in the TES Task, in  `"workflow_execution_identity"` maps to the user identity name in the WSM request. 

Additional fixes:
- Added `Name` config option in appsettings. 
