### PR TITLE
Add tes-compliance-suite entry point script

### DIFF
--- a/src/TesApi.Web/TesApi.Web.csproj
+++ b/src/TesApi.Web/TesApi.Web.csproj
@@ -58,4 +58,9 @@
     <ProjectReference Include="..\CommonUtilities\CommonUtilities.csproj" />
     <ProjectReference Include="..\Tes\Tes.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="tes-compliance-test\entrypoint.sh">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/TesApi.Web/tes-compliance-test/entrypoint.sh
+++ b/src/TesApi.Web/tes-compliance-test/entrypoint.sh
@@ -1,0 +1,9 @@
+﻿#!/bin/sh
+teshostname=$(jq -r '.TesHostname' TesCredentials.json)
+tesuser=$(jq -r '.TesUsername' TesCredentials.json)
+tespassword=$(jq -r '.TesPassword' TesCredentials.json)
+
+# This file will be used to run tes-compliance-tests as part of the ADO release
+# TES-compliance-suite repo provides a default entry point script, but since TES uses basic auth it needs to be replaced to add approprite credentials
+# https://github.com/elixir-cloud-aai/tes-compliance-suite
+tes-compliance-suite report --server http://$tesuser:$tespassword@$teshostname/ --tag all --output_path results


### PR DESCRIPTION
https://github.com/elixir-cloud-aai/tes-compliance-suite now provides a Dockerfile that will enable running of tes compliance tests. That repo also provides a default entrypoint for the Docker file, however ga4gh-tes requires basic auth to connect to the tes endpoint to run the tests. 

This PR adds the entrypoint script specific to this repo, will make it easy to make changes if the way the tests are run (all at once vs individually or updating versions/etc) would be simple. It will be used during [the release in ADO](https://malibu00.visualstudio.com/Emmons/_release?_a=releases&view=mine&definitionId=29) to run the tes-compalince-suite tests. 

relates to this [issue](https://github.com/microsoft/ga4gh-tes/issues/26). 