### PR TITLE
tes compliance tests now require to supply a version

### DIFF
--- a/src/TesApi.Web/tes-compliance-test/entrypoint.sh
+++ b/src/TesApi.Web/tes-compliance-test/entrypoint.sh
@@ -6,4 +6,4 @@ tespassword=$(jq -r '.TesPassword' TesCredentials.json)
 # This file will be used to run tes-compliance-tests as part of the ADO release
 # TES-compliance-suite repo provides a default entry point script, but since TES uses basic auth it needs to be replaced to add approprite credentials
 # https://github.com/elixir-cloud-aai/tes-compliance-suite
-tes-compliance-suite report --server http://$tesuser:$tespassword@$teshostname/ --tag all --output_path results
+tes-compliance-suite report --server http://$tesuser:$tespassword@$teshostname/ --tag all --version 1.0.0 --output_path results


### PR DESCRIPTION
adding version param for the entrypoint script for tes compliance tests 
more details here: https://github.com/elixir-cloud-aai/tes-compliance-suite/blob/dev/docs/utility.md#usage

relates to this [issue](https://github.com/microsoft/ga4gh-tes/issues/26). 