### PR TITLE
Fixes broken dockerfile

### DIFF
--- a/src/Dockerfile-Tes
+++ b/src/Dockerfile-Tes
@@ -5,13 +5,13 @@ FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
 WORKDIR /app
 
 # Restore packages in separate layer
-COPY TesApi.Web/TesApi.Web.csproj TesApi.Web/
+COPY CommonUtilities/CommonUtilities.csproj CommonUtilities/
 COPY Tes/Tes.csproj Tes/
-RUN dotnet restore TesApi.Web/TesApi.Web.csproj
+COPY TesApi.Web/TesApi.Web.csproj TesApi.Web/
 
 # Copy the rest of the files and publish
 COPY . ./
-RUN dotnet publish -c Release -o out --no-restore TesApi.Web/TesApi.Web.csproj
+RUN dotnet publish -c Release /p:PublishDir=/app/out TesApi.Web/TesApi.Web.csproj
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:7.0


### PR DESCRIPTION
Previously, the dockerfile would throw errors like "The "ResolvePackageAssets" task failed unexpectedly.".   Tested with:

`docker build -f "C:\Users\mattmcl\source\repos\microsoft\CromwellOnAzure\src\ga4gh-tes\src\Dockerfile-Tes" .`

Fixes https://github.com/microsoft/ga4gh-tes/issues/72