### PR TITLE
[Fix-154] Blob name is added only if not returned by WSM

### DIFF
--- a/src/TesApi.Tests/TerraApiStubData.cs
+++ b/src/TesApi.Tests/TerraApiStubData.cs
@@ -16,8 +16,8 @@ public class TerraApiStubData
     public const string WorkspaceAccountName = "fooaccount";
     public const string WorkspaceContainerName = "foocontainer";
     public const string SasToken = "SASTOKENSTUB=";
-    public const string WsmGetSasResponseStorageUrl = "https://bloburl.foo/container";
-
+    public const string WsmGetSasResponseStorageUrl = $"https://bloburl.foo/{WorkspaceContainerName}";
+    
     public Guid LandingZoneId { get; } = Guid.NewGuid();
     public Guid SubscriptionId { get; } = Guid.NewGuid();
     public Guid WorkspaceId { get; } = Guid.NewGuid();
@@ -37,9 +37,9 @@ public class TerraApiStubData
         return JsonSerializer.Deserialize<QuotaApiResponse>(GetResourceQuotaApiResponseInJson());
     }
 
-    public WsmSasTokenApiResponse GetWsmSasTokenApiResponse()
+    public WsmSasTokenApiResponse GetWsmSasTokenApiResponse(string blobName = null)  
     {
-        return JsonSerializer.Deserialize<WsmSasTokenApiResponse>(GetWsmSasTokenApiResponseInJson());
+        return JsonSerializer.Deserialize<WsmSasTokenApiResponse>(GetWsmSasTokenApiResponseInJson(blobName));
     }
 
     public TerraOptions GetTerraOptions()
@@ -68,16 +68,22 @@ public class TerraApiStubData
         };
     }
 
-    public string GetWsmSasTokenApiResponseInJson()
+    public string GetWsmSasTokenApiResponseInJson(string blobName = null)
     {
+        var blobToAppend = blobName;
+        if (!string.IsNullOrEmpty(blobName))
+        {
+            blobToAppend = $"/{blobName.TrimStart('/')}";
+        }
+
         return $$"""
         {
             "token": "{{SasToken}}",
-            "url": "{{WsmGetSasResponseStorageUrl}}?sv={{SasToken}}"
+            "url": "{{WsmGetSasResponseStorageUrl}}{{blobToAppend}}?sv={{SasToken}}"
         }
         """;
     }
-
+    
     public string GetResourceApiResponseInJson()
     {
         return $@"{{

--- a/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
+++ b/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
@@ -108,5 +108,22 @@ namespace TesApi.Tests
         {
             await terraStorageAccessProvider.MapLocalPathToSasUrlAsync(input);
         }
+
+        [TestMethod]
+        [DataRow("")]
+        [DataRow("blobName")]
+        public async Task GetMappedSasUrlFromWsmAsync_WithOrWithOutBlobName_ReturnsValidURLWithBlobName(string responseBlobName)
+        {
+            wsmApiClientMock.Setup(a => a.GetSasTokenAsync(terraApiStubData.WorkspaceId,
+                    terraApiStubData.ContainerResourceId, It.IsAny<SasTokenApiParameters>()))
+                .ReturnsAsync(terraApiStubData.GetWsmSasTokenApiResponse(responseBlobName));
+
+           var url =  await terraStorageAccessProvider.GetMappedSasUrlFromWsmAsync("blobName");
+           
+           Assert.IsNotNull(url);
+           var uri = new Uri(url);
+
+           Assert.AreEqual(uri.AbsolutePath,$"/{TerraApiStubData.WorkspaceContainerName}/blobName");
+        }
     }
 }

--- a/src/TesApi.Tests/TerraWsmApiClientTests.cs
+++ b/src/TesApi.Tests/TerraWsmApiClientTests.cs
@@ -42,7 +42,7 @@ namespace TesApi.Tests
         [TestMethod]
         public void GetContainerSasTokenApiUri_NoSasParameters_ReturnsExpectedUriWithoutQueryString()
         {
-            var uri = terraWsmApiClient.GetContainerSasTokenApiUrl(terraApiStubData.WorkspaceId,
+            var uri = terraWsmApiClient.GetSasTokenApiUrl(terraApiStubData.WorkspaceId,
                 terraApiStubData.ContainerResourceId, null);
 
             var expectedUri =
@@ -56,7 +56,7 @@ namespace TesApi.Tests
         {
             var sasParams = new SasTokenApiParameters("ipRange", 10, "rwdl", "blobName");
 
-            var uri = terraWsmApiClient.GetContainerSasTokenApiUrl(terraApiStubData.WorkspaceId,
+            var uri = terraWsmApiClient.GetSasTokenApiUrl(terraApiStubData.WorkspaceId,
                 terraApiStubData.ContainerResourceId, sasParams);
 
             var expectedUri =
@@ -77,7 +77,7 @@ namespace TesApi.Tests
         {
             var sasParams = new SasTokenApiParameters("ipRange", 10, null, null);
 
-            var uri = terraWsmApiClient.GetContainerSasTokenApiUrl(terraApiStubData.WorkspaceId,
+            var uri = terraWsmApiClient.GetSasTokenApiUrl(terraApiStubData.WorkspaceId,
                 terraApiStubData.ContainerResourceId, sasParams);
 
             var expectedUri =

--- a/src/TesApi.Web/Management/Clients/TerraWsmApiClient.cs
+++ b/src/TesApi.Web/Management/Clients/TerraWsmApiClient.cs
@@ -52,7 +52,7 @@ namespace TesApi.Web.Management.Clients
         /// <returns></returns>
         public virtual async Task<WsmSasTokenApiResponse> GetSasTokenAsync(Guid workspaceId, Guid resourceId, SasTokenApiParameters sasTokenApiParameters)
         {
-            var url = GetContainerSasTokenApiUrl(workspaceId, resourceId, sasTokenApiParameters);
+            var url = GetSasTokenApiUrl(workspaceId, resourceId, sasTokenApiParameters);
 
             var response = await HttpSendRequestWithRetryPolicyAsync(() => new HttpRequestMessage(HttpMethod.Post, url),
                 setAuthorizationHeader: true);
@@ -121,13 +121,13 @@ namespace TesApi.Web.Management.Clients
                 ParseQueryStringParameter("sasBlobName", sasTokenApiParameters.SasBlobName));
 
         /// <summary>
-        /// Gets the Api Url to get a container sas token
+        /// Gets the Api Url to get a container or blob sas token
         /// </summary>
         /// <param name="workspaceId">Workspace Id</param>
         /// <param name="resourceId">WSM resource Id of the container</param>
         /// <param name="sasTokenApiParameters"><see cref="SasTokenApiParameters"/></param>
         /// <returns></returns>
-        public virtual Uri GetContainerSasTokenApiUrl(Guid workspaceId, Guid resourceId, SasTokenApiParameters sasTokenApiParameters)
+        public virtual Uri GetSasTokenApiUrl(Guid workspaceId, Guid resourceId, SasTokenApiParameters sasTokenApiParameters)
         {
             var segments = $"/resources/controlled/azure/storageContainer/{resourceId}/getSasToken";
 

--- a/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
@@ -130,7 +130,12 @@ namespace TesApi.Web.Storage
             return urlBuilder.Uri.ToString();
         }
 
-        private async Task<string> GetMappedSasUrlFromWsmAsync(string blobName)
+        /// <summary>
+        /// Returns a Url with a SAS token for the given input. 
+        /// </summary>
+        /// <param name="blobName"></param>
+        /// <returns>SAS Token URL</returns>
+        public async Task<string> GetMappedSasUrlFromWsmAsync(string blobName)
         {
             var normalizedBlobName = blobName.TrimStart('/');
 
@@ -144,7 +149,10 @@ namespace TesApi.Web.Storage
 
             if (normalizedBlobName != string.Empty)
             {
-                uriBuilder.Path += $"/{normalizedBlobName.TrimStart('/')}";
+                if (!uriBuilder.Path.Contains(normalizedBlobName,StringComparison.OrdinalIgnoreCase))
+                {
+                    uriBuilder.Path += $"/{normalizedBlobName}";
+                }
             }
 
             return uriBuilder.Uri.ToString();


### PR DESCRIPTION
 - This PR prepares TES for the upcoming change in WSM where the blobname is returned when requesting the SAS token
 - The Terra Storage Provider adds the blobname only when is not returned by WSM. 