### PR TITLE
Get Application Insights connection string instead of instrumentation key

### DIFF
--- a/src/TesApi.Web/AzureProxy.cs
+++ b/src/TesApi.Web/AzureProxy.cs
@@ -135,7 +135,7 @@ namespace TesApi.Web
         /// </summary>
         /// <param name="appInsightsApplicationId">Application Insights application id</param>
         /// <returns>Application Insights instrumentation key</returns>
-        public static async Task<string> GetAppInsightsInstrumentationKeyAsync(string appInsightsApplicationId)
+        public static async Task<string> GetAppInsightsConnectionStringAsync(string appInsightsApplicationId)
         {
             var azureClient = await GetAzureManagementClientAsync();
             var subscriptionIds = (await azureClient.Subscriptions.ListAsync()).Select(s => s.SubscriptionId);
@@ -151,7 +151,7 @@ namespace TesApi.Web
 
                     if (app is not null)
                     {
-                        return app.InstrumentationKey;
+                        return app.ConnectionString;
                     }
                 }
                 catch

--- a/src/TesApi.Web/Program.cs
+++ b/src/TesApi.Web/Program.cs
@@ -64,10 +64,10 @@ namespace TesApi.Web
                         return applicationInsightsOptions;
                     }
 
-                    var instrumentationKey = AzureProxy.GetAppInsightsInstrumentationKeyAsync(applicationInsightsAccountName).Result;
-                    if (!string.IsNullOrWhiteSpace(instrumentationKey))
+                    var connectionString = AzureProxy.GetAppInsightsConnectionStringAsync(applicationInsightsAccountName).Result;
+                    if (!string.IsNullOrWhiteSpace(connectionString))
                     {
-                        applicationInsightsOptions.ConnectionString = $"InstrumentationKey={instrumentationKey}";
+                        applicationInsightsOptions.ConnectionString = connectionString;
                     }
 
                     return applicationInsightsOptions;


### PR DESCRIPTION
It's now recommended to use connection strings: https://learn.microsoft.com/en-us/azure/azure-monitor/app/migrate-from-instrumentation-keys-to-connection-strings#new-capabilities