### PR TITLE
[Issue-64] Delete Batch Pool operation via WSM

### DIFF
--- a/src/TesApi.Tests/TerraWsmApiClientTests.cs
+++ b/src/TesApi.Tests/TerraWsmApiClientTests.cs
@@ -108,5 +108,30 @@ namespace TesApi.Tests
             Assert.IsTrue(!string.IsNullOrEmpty(apiResponse.Token));
             Assert.IsTrue(!string.IsNullOrEmpty(apiResponse.Url));
         }
+
+        [TestMethod]
+        public async Task DeleteBatchPoolAsync_204Response_Succeeds()
+        {
+            var wsmResourceId = Guid.NewGuid();
+            var response = new HttpResponseMessage(HttpStatusCode.NoContent);
+
+            cacheAndRetryHandler.Setup(c => c.ExecuteWithRetryAsync(It.IsAny<Func<Task<HttpResponseMessage>>>()))
+                .ReturnsAsync(response);
+
+            await terraWsmApiClient.DeleteBatchPoolAsync(terraApiStubData.WorkspaceId, wsmResourceId);
+        }
+
+        [TestMethod]
+        public void GetDeleteBatchPoolUrl_ValidWorkspaceAndResourceId_ValidWSMUrl()
+        {
+            var wsmResourceId = Guid.NewGuid();
+
+            var url = terraWsmApiClient.GetDeleteBatchPoolUrl(terraApiStubData.WorkspaceId, wsmResourceId);
+
+            Assert.IsNotNull(url);
+            var expectedUrl = $"{TerraApiStubData.WsmApiHost}/api/workspaces/v1/{terraApiStubData.WorkspaceId}/resources/controlled/azure/batchpool/{wsmResourceId}";
+            Assert.AreEqual(expectedUrl,url);
+        }
+
     }
 }

--- a/src/TesApi.Web/Management/Batch/TerraBatchPoolManager.cs
+++ b/src/TesApi.Web/Management/Batch/TerraBatchPoolManager.cs
@@ -124,19 +124,17 @@ namespace TesApi.Web.Management.Batch
         {
             ArgumentException.ThrowIfNullOrEmpty(poolId);
 
-            //TODO: This is a temporary implementation. It must be changed once WSM supports deleting batch pools
             try
             {
-                var batchClient = CreateBatchClientFromOptions();
-
                 logger.LogInformation(
                     $"Deleting pool with the id/name:{poolId}");
 
-                await batchClient.PoolOperations.DeletePoolAsync(poolId, cancellationToken: cancellationToken);
+                var wsmResourceId = await GetWsmResourceIdFromBatchPoolMetadataAsync(poolId, cancellationToken);
+
+                await terraWsmApiClient.DeleteBatchPoolAsync(Guid.Parse(terraOptions.WorkspaceId), wsmResourceId);
 
                 logger.LogInformation(
-                    $"Successfully deleted pool with the id/name:{poolId}");
-
+                    $"Successfully deleted pool with the id/name via WSM:{poolId}");
             }
             catch (Exception e)
             {
@@ -144,6 +142,28 @@ namespace TesApi.Web.Management.Batch
 
                 throw;
             }
+        }
+
+        private async Task<Guid> GetWsmResourceIdFromBatchPoolMetadataAsync(string poolId, CancellationToken cancellationToken)
+        {
+            var batchClient = CreateBatchClientFromOptions();
+
+            var pool = await batchClient.PoolOperations.GetPoolAsync(poolId, cancellationToken: cancellationToken);
+
+            if (pool is null)
+            {
+                throw new InvalidOperationException($"The batch pool was not found. Pool id:{poolId}");
+            }
+
+            var metadataItem = pool.Metadata.SingleOrDefault(m => m.Name.Equals(TerraResourceIdMetadataKey));
+
+            if (metadataItem is null || string.IsNullOrEmpty(metadataItem.Value))
+            {
+                throw new InvalidOperationException("The WSM resource id was not found in the pool's metadata.");
+            }
+
+            var wsmResourceId = Guid.Parse(metadataItem.Value);
+            return wsmResourceId;
         }
 
         private BatchClient CreateBatchClientFromOptions()

--- a/src/TesApi.Web/Management/Batch/TerraBatchPoolManager.cs
+++ b/src/TesApi.Web/Management/Batch/TerraBatchPoolManager.cs
@@ -157,7 +157,7 @@ namespace TesApi.Web.Management.Batch
 
             var metadataItem = pool.Metadata.SingleOrDefault(m => m.Name.Equals(TerraResourceIdMetadataKey));
 
-            if (metadataItem is null || string.IsNullOrEmpty(metadataItem.Value))
+            if (string.IsNullOrEmpty(metadataItem?.Value))
             {
                 throw new InvalidOperationException("The WSM resource ID was not found in the pool's metadata.");
             }

--- a/src/TesApi.Web/Management/Batch/TerraBatchPoolManager.cs
+++ b/src/TesApi.Web/Management/Batch/TerraBatchPoolManager.cs
@@ -127,14 +127,14 @@ namespace TesApi.Web.Management.Batch
             try
             {
                 logger.LogInformation(
-                    $"Deleting pool with the id/name:{poolId}");
+                    $"Deleting pool with the ID/name: {poolId}");
 
                 var wsmResourceId = await GetWsmResourceIdFromBatchPoolMetadataAsync(poolId, cancellationToken);
 
                 await terraWsmApiClient.DeleteBatchPoolAsync(Guid.Parse(terraOptions.WorkspaceId), wsmResourceId);
 
                 logger.LogInformation(
-                    $"Successfully deleted pool with the id/name via WSM:{poolId}");
+                    $"Successfully deleted pool with the ID/name via WSM: {poolId}");
             }
             catch (Exception e)
             {
@@ -152,14 +152,14 @@ namespace TesApi.Web.Management.Batch
 
             if (pool is null)
             {
-                throw new InvalidOperationException($"The batch pool was not found. Pool id:{poolId}");
+                throw new InvalidOperationException($"The Batch pool was not found. Pool ID: {poolId}");
             }
 
             var metadataItem = pool.Metadata.SingleOrDefault(m => m.Name.Equals(TerraResourceIdMetadataKey));
 
             if (metadataItem is null || string.IsNullOrEmpty(metadataItem.Value))
             {
-                throw new InvalidOperationException("The WSM resource id was not found in the pool's metadata.");
+                throw new InvalidOperationException("The WSM resource ID was not found in the pool's metadata.");
             }
 
             var wsmResourceId = Guid.Parse(metadataItem.Value);

--- a/src/TesApi.Web/Management/Clients/TerraWsmApiClient.cs
+++ b/src/TesApi.Web/Management/Clients/TerraWsmApiClient.cs
@@ -76,7 +76,7 @@ namespace TesApi.Web.Management.Clients
             {
                 var uri = GetCreateBatchPoolUrl(workspaceId);
 
-                Logger.LogInformation($"Creating a batch pool using WSM for workspace:{workspaceId}");
+                Logger.LogInformation($"Creating a batch pool using WSM for workspace: {workspaceId}");
 
                 response =
                     await HttpSendRequestWithRetryPolicyAsync(() => new HttpRequestMessage(HttpMethod.Post, uri) { Content = GetBatchPoolRequestContent(apiCreateBatchPool) },
@@ -84,7 +84,7 @@ namespace TesApi.Web.Management.Clients
 
                 var apiResponse = await GetApiResponseContentAsync<ApiCreateBatchPoolResponse>(response);
 
-                Logger.LogInformation($"Successfully created a batch pool using WSM for workspace:{workspaceId}");
+                Logger.LogInformation($"Successfully created a batch pool using WSM for workspace: {workspaceId}");
 
                 return apiResponse;
             }
@@ -111,7 +111,7 @@ namespace TesApi.Web.Management.Clients
             {
                 var uri = GetDeleteBatchPoolUrl(workspaceId, wsmBatchPoolResourceId);
 
-                Logger.LogInformation($"Deleting the batch pool using WSM for workspace:{workspaceId} WSM resource id:{wsmBatchPoolResourceId}");
+                Logger.LogInformation($"Deleting the Batch pool using WSM for workspace: {workspaceId} WSM resource ID: {wsmBatchPoolResourceId}");
 
                 response =
                     await HttpSendRequestWithRetryPolicyAsync(() => new HttpRequestMessage(HttpMethod.Delete, uri),
@@ -119,11 +119,11 @@ namespace TesApi.Web.Management.Clients
 
                 response.EnsureSuccessStatusCode();
 
-                Logger.LogInformation($"Successfully deleted  batch pool, WSM resource id: {wsmBatchPoolResourceId} using WSM for workspace:{workspaceId}");
+                Logger.LogInformation($"Successfully deleted Batch pool, WSM resource ID: {wsmBatchPoolResourceId} using WSM for workspace: {workspaceId}");
             }
             catch (Exception ex)
             {
-                await LogResponseContentAsync(response, "Failed to delete a Batch Pool via WSM", ex);
+                await LogResponseContentAsync(response, "Failed to delete the Batch pool via WSM", ex);
                 throw;
             }
         }


### PR DESCRIPTION
Closes #64 

This PR includes:
- Batch Pool deletion is via WSM when TES is running in Terra
- New WSM API in the client to delete the batch pool via the WSM resource id. 