### PR TITLE
Fix manual/auto-scale switching back-off implementation

### DIFF
--- a/src/TesApi.Web/BatchPool.cs
+++ b/src/TesApi.Web/BatchPool.cs
@@ -269,18 +269,18 @@ namespace TesApi.Web
                             }
                             else
                             {
-                                _scalingMode = ScalingMode.RemovingFailedNodes;
                                 goto case ScalingMode.RemovingFailedNodes;
                             }
                         }
                         break;
 
                     case ScalingMode.RemovingFailedNodes:
+                        _scalingMode = ScalingMode.RemovingFailedNodes;
                         ResizeErrors.Clear();
                         _resizeErrorsRetrieved = true;
                         _logger.LogInformation(@"Switching pool {PoolId} back to autoscale.", Pool.PoolId);
                         await _azureProxy.EnableBatchPoolAutoScaleAsync(Pool.PoolId, !IsDedicated, AutoScaleEvaluationInterval, AutoPoolFormula, cancellationToken);
-                        _autoScaleWaitTime = DateTime.UtcNow + AutoScaleEvaluationInterval + BatchPoolService.RunInterval;
+                        _autoScaleWaitTime = DateTime.UtcNow + (3 * AutoScaleEvaluationInterval) + BatchPoolService.RunInterval;
                         _scalingMode = _resetAutoScalingRequired ? ScalingMode.WaitingForAutoScale : ScalingMode.SettingAutoScale;
                         break;
 


### PR DESCRIPTION
While the batch account evaluates the auto scale formula and switches the pool's evaluation state to resizing fairly soon after setting that resize mode, it isn't always as prompt in switching the state to resizing (if needed) after the next automatic reevaluation of the formula, and the previous implementation of this code would often switch the pool back to manual scale mode in order to remove more (and/or newly) useless nodes from the pool.

This change gives the auto-scale mode sufficient time to act on the changing scale demands before interrupting to remove the next batch of useless nodes.