### PR TITLE
Fix node cleanup script

### DIFF
--- a/src/TesApi.Web/scripts/task-run.sh
+++ b/src/TesApi.Web/scripts/task-run.sh
@@ -1,5 +1,5 @@
-sudo echo -n 'if [ "$1" != "{TaskExecutor}" ]; then docker rmi {TaskExecutor} -f; fi;' > ../clean-executor.sh
-sudo echo -n ' rm -fdr wd/{ExecutionPathPrefix} || :' >> ../clean-executor.sh
+sudo echo -n 'if [ "$1" != "{TaskExecutor}" ]; then docker rmi {TaskExecutor} -f; fi && ' > ../clean-executor.sh
+sudo echo -n 'rm -fdr wd/{ExecutionPathPrefix} || rm -fdr wd/{ExecutionPathPrefix} || :' >> ../clean-executor.sh
 sudo chmod a+x ../clean-executor.sh
 sudo find $AZ_BATCH_NODE_ROOT_DIR/workitems -maxdepth 5 -path $(dirname $(dirname $(dirname $PWD))) -prune -o -type f -name clean-executor.sh -execdir '{}' {TaskExecutor} \; || :
 sudo docker container prune -f || :


### PR DESCRIPTION
The previous version of the compute node cleaning script would skip the directory cleaning step under certain scenarios. This version will always run the directory cleaning step no matter the results of the docker cleaning step. Note that it runs the risk of running the directory cleaning step twice if the first time results in a failed exit code. That is not considered to be a problem in this circumstance.