### PR TITLE
Reduce blobxfer memory usage

### DIFF
--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -973,6 +973,8 @@ namespace TesApi.Web
                 blobxferChunkSizeBytes = 33_554_432; // max file size = 32 MiB * 50k blocks = 1,677,721,600,000 bytes
             }
 
+            logger.LogInformation($"Configuring blobxfer with {vmVCpusAvailable} vCPUS to use blobxferChunkSizeBytes={blobxferChunkSizeBytes:D} blobxferOneShotBytes={blobxferOneShotBytes:D}");
+
             // Using --include and not using --no-recursive as a workaround for https://github.com/Azure/blobxfer/issues/123
             var downloadFilesScriptContent = "total_bytes=0"
                 + string.Join("", filesToDownload.Select(f =>


### PR DESCRIPTION
Blobxfer is running out of memory in some scenarios on a `D1_v2`, for both download and upload.

[Blobxfer sets the transfer threads to 2 x core count](https://github.com/Azure/blobxfer/blob/0ac1212326a43dfd6cb2b8525ff95f1c4ae540af/blobxfer/models/options.py#LL232C17-L232C73), which seems sufficient to prevent OOM, however for some reason in practice this is not the case.

The long term solution is to move to our own node agent for finer-grained control of all of these parameters with our own storage library (OR move to azcopy).

In the short term, there doesn't appear to be a way in the Blobxfer docs to reduce memory usage explicitly.  Instead, it seems likely that reducing chunk size and one shot size are most likely to impact memory usage.  A D1_v2 has a resource disk size (temp disk) of 50 GiB, so it doesn't actually need to be able to upload/download very large files.

This PR makes some minor modifications to that end.
