### PR TITLE
Add detail for failures in the test task that refer to the inner exception

### DIFF
--- a/src/deploy-tes-on-azure/Deployer.cs
+++ b/src/deploy-tes-on-azure/Deployer.cs
@@ -628,7 +628,7 @@ namespace TesDeployer
                             ConsoleEx.WriteLine($"HTTP Request StatusCode: {rExc.StatusCode.ToString()}");
                             if (rExc.InnerException is not null)
                             {
-                                ConsoleEx.WriteLine($"InnerException: {.Message.GetType().FullName}: {rExc.InnerException.Message}");
+                                ConsoleEx.WriteLine($"InnerException: {rExc.InnerException.GetType().FullName}: {rExc.InnerException.Message}");
                             }
                         }
                     }

--- a/src/deploy-tes-on-azure/Deployer.cs
+++ b/src/deploy-tes-on-azure/Deployer.cs
@@ -622,6 +622,15 @@ namespace TesDeployer
                         {
                             ConsoleEx.WriteLine($"HTTP Response: {hExc.Response.Content}");
                         }
+                        
+                        if (exc is HttpRequestException rExc)
+                        {
+                            ConsoleEx.WriteLine($"HTTP Request StatusCode: {rExc.StatusCode.ToString()}");
+                            if (rExc.InnerException is not null)
+                            {
+                                ConsoleEx.WriteLine($"InnerException: {.Message.GetType().FullName}: {rExc.InnerException.Message}");
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
This is the detail provided with this change:

> 2023-04-05T22:28:08.3122463Z Running a test task...
> 2023-04-05T22:43:13.2145849Z 
> 2023-04-05T22:43:13.2277889Z HttpRequestException: The SSL connection could not be established, see inner exception.
> 2023-04-05T22:43:13.2279075Z    at System.Net.Http.ConnectHelper.EstablishSslConnectionAsync(SslClientAuthenticationOptions sslOptions, HttpRequestMessage request, Boolean async, Stream stream, CancellationToken cancellationToken)
> 2023-04-05T22:43:13.2280087Z    at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
> 2023-04-05T22:43:13.2280628Z    at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
> 2023-04-05T22:43:13.2281303Z    at System.Net.Http.HttpConnectionPool.AddHttp11ConnectionAsync(QueueItem queueItem)
> 2023-04-05T22:43:13.2281778Z    at System.Threading.Tasks.TaskCompletionSourceWithCancellation\`1.WaitWithCancellationAsync(CancellationToken cancellationToken)
> 2023-04-05T22:43:13.2282508Z    at System.Net.Http.HttpConnectionPool.HttpConnectionWaiter\`1.WaitForConnectionAsync(Boolean async, CancellationToken requestCancellationToken)
> 2023-04-05T22:43:13.2283059Z    at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
> 2023-04-05T22:43:13.2283799Z    at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
> 2023-04-05T22:43:13.2284395Z    at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
> 2023-04-05T22:43:13.2285139Z    at TesDeployer.Deployer.<>c__DisplayClass62_0.<<TestTaskAsync>b__0>d.MoveNext()
> 2023-04-05T22:43:13.2285790Z --- End of stack trace from previous location ---
> 2023-04-05T22:43:13.2286395Z    at Polly.AsyncPolicy.<>c__DisplayClass40_0.<<ImplementationAsync>b__0>d.MoveNext()
> 2023-04-05T22:43:13.2286855Z --- End of stack trace from previous location ---
> 2023-04-05T22:43:13.2287938Z    at Polly.Retry.AsyncRetryEngine.ImplementationAsync[TResult](Func\`3 action, Context context, CancellationToken cancellationToken, ExceptionPredicates shouldRetryExceptionPredicates, ResultPredicates\`1 shouldRetryResultPredicates, Func\`5 onRetryAsync, Int32 permittedRetryCount, IEnumerable\`1 sleepDurationsEnumerable, Func\`4 sleepDurationProvider, Boolean continueOnCapturedContext)
> 2023-04-05T22:43:13.2288647Z    at Polly.AsyncPolicy.ExecuteAsync(Func\`3 action, Context context, CancellationToken cancellationToken, Boolean continueOnCapturedContext)
> 2023-04-05T22:43:13.2302972Z    at TesDeployer.Deployer.TestTaskAsync(String tesEndpoint, Boolean preemptible, String tesUsername, String tesPassword)
> 2023-04-05T22:43:13.2304165Z    at TesDeployer.Deployer.RunTestTask(String tesEndpoint, Boolean preemptible, String tesUsername, String tesPassword)
> 2023-04-05T22:43:13.2305610Z    at TesDeployer.Deployer.DeployAsync()
> 2023-04-05T22:43:13.2305787Z HTTP Request StatusCode: 
> 2023-04-05T22:43:13.2306106Z InnerException: System.Security.Authentication.AuthenticationException: The remote certificate is invalid according to the validation procedure: RemoteCertificateNameMismatch, RemoteCertificateChainErrors
> 