### PR TITLE
Fix integration test on linux

### DIFF
--- a/src/deploy-tes-on-azure/Deployer.cs
+++ b/src/deploy-tes-on-azure/Deployer.cs
@@ -515,11 +515,6 @@ namespace TesDeployer
                                     _ = await kubernetesManager.EnableIngress(configuration.TesUsername, configuration.TesPassword, kubernetesClient);
                                 }
                             });
-
-                        if (configuration.EnableIngress.GetValueOrDefault() && !configuration.SkipTestWorkflow)
-                        {
-                            await Task.Delay(System.TimeSpan.FromMinutes(3)); // Give Ingress a moment longer to complete its standup.
-                        }
                     }
                 }
                 finally


### PR DESCRIPTION
Its still unclear to me why this issue only presents when running on linux, maybe the helm process returns faster. Waiting for cert-manager to start + 10 secs fixes it though, waiting for cert-manager alone still results in failures. The bottom issue is some form of deadlock on the tls-secret object, where cert-manager is unable to update because the object was modified while cert-manager was running. 

Other cleanup:
Create namespace was unnecessary. 
process.StandardError.ReadLineAsync() was occasionally throwing exceptions, process.OutputDataReceived += new DataReceivedEventHandler(OutputHandler) seems to be better. 
