### PR TITLE
[220] Upload and download operations are now a subprocess

### DIFF
--- a/src/Tes.Runner.Test/Commands/BlobPipelineOptionsConverterTests.cs
+++ b/src/Tes.Runner.Test/Commands/BlobPipelineOptionsConverterTests.cs
@@ -1,0 +1,38 @@
+﻿using Tes.Runner.Transfer;
+
+namespace Tes.RunnerCLI.Commands.Tests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class BlobPipelineOptionsConverterTests
+    {
+        [TestMethod]
+        public void ToCommandArgs_SetsAllOptionsAsCliOptions()
+        {
+            var args = BlobPipelineOptionsConverter.ToCommandArgs("upload", "file", new BlobPipelineOptions());
+
+            Assert.IsNotNull(args);
+            Assert.AreEqual("upload", args[0]);
+            Assert.AreEqual($"--blockSize {BlobSizeUtils.DefaultBlockSizeBytes}", args[1]);
+            Assert.AreEqual($"--writers {BlobPipelineOptions.DefaultNumberOfWriters}", args[2]);
+            Assert.AreEqual($"--readers {BlobPipelineOptions.DefaultNumberOfReaders}", args[3]);
+            Assert.AreEqual($"--bufferCapacity {BlobPipelineOptions.DefaultReadWriteBuffersCapacity}", args[4]);
+            Assert.AreEqual($"--apiVersion {BlobPipelineOptions.DefaultApiVersion}", args[5]);
+            Assert.AreEqual("--file file", args[6]);
+        }
+
+        [TestMethod]
+        public void ToBlobPipelineOptions_CreatesBlobPipelinesOptions()
+        {
+
+            var options = BlobPipelineOptionsConverter.ToBlobPipelineOptions(1, 2, 3, 4, "2010-01-01");
+            Assert.IsNotNull(options);
+            Assert.AreEqual(1, options.BlockSizeBytes);
+            Assert.AreEqual(2, options.NumberOfWriters);
+            Assert.AreEqual(3, options.NumberOfReaders);
+            Assert.AreEqual(4, options.ReadWriteBuffersCapacity);
+            Assert.AreEqual(4, options.MemoryBufferCapacity);
+            Assert.AreEqual("2010-01-01", options.ApiVersion);
+        }
+    }
+}

--- a/src/Tes.Runner.Test/Tes.Runner.Test.csproj
+++ b/src/Tes.Runner.Test/Tes.Runner.Test.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Tes.RunnerCLI\Tes.RunnerCLI.csproj" />
     <ProjectReference Include="..\Tes.Runner\Tes.Runner.csproj" />
   </ItemGroup>
 

--- a/src/Tes.Runner/Docker/DockerExecutor.cs
+++ b/src/Tes.Runner/Docker/DockerExecutor.cs
@@ -3,12 +3,15 @@
 
 using Docker.DotNet;
 using Docker.DotNet.Models;
+using Microsoft.Extensions.Logging;
+using Tes.Runner.Transfer;
 
 namespace Tes.Runner.Docker
 {
     public class DockerExecutor
     {
         private readonly IDockerClient dockerClient;
+        private readonly ILogger logger = PipelineLoggerFactory.Create<DockerExecutor>();
 
         public DockerExecutor(Uri dockerHost)
         {
@@ -78,7 +81,7 @@ namespace Tes.Runner.Docker
                     Tag = tag
                 },
                 authConfig,
-                new Progress<JSONMessage>(message => Console.WriteLine(message)));
+                new Progress<JSONMessage>(message => logger.LogInformation(message.Status)));
         }
     }
 }

--- a/src/Tes.Runner/Executor.cs
+++ b/src/Tes.Runner/Executor.cs
@@ -33,19 +33,13 @@ namespace Tes.Runner
             resolutionPolicyHandler = new ResolutionPolicyHandler();
         }
 
-        public async Task<NodeTaskResult> ExecuteNodeTaskAsync(DockerExecutor dockerExecutor)
+        public async Task<NodeTaskResult> ExecuteNodeContainerTaskAsync(DockerExecutor dockerExecutor)
         {
             ArgumentNullException.ThrowIfNull(blobPipelineOptions);
 
-            var memoryBufferChannel = await MemoryBufferPoolFactory.CreateMemoryBufferPoolAsync(blobPipelineOptions.MemoryBufferCapacity, blobPipelineOptions.BlockSizeBytes);
-
-            var inputLength = await DownloadInputsAsync(memoryBufferChannel);
-
             var result = await dockerExecutor.RunOnContainerAsync(tesNodeTask.ImageName, tesNodeTask.ImageTag, tesNodeTask.CommandsToExecute);
 
-            var outputLength = await UploadOutputsAsync(memoryBufferChannel);
-
-            return new NodeTaskResult(result, inputLength, outputLength);
+            return new NodeTaskResult(result);
         }
 
 

--- a/src/Tes.Runner/Executor.cs
+++ b/src/Tes.Runner/Executor.cs
@@ -73,7 +73,7 @@ namespace Tes.Runner
 
             LogStartConfig();
 
-            logger.LogInformation($"{tesNodeTask.Outputs.Count} inputs to upload.");
+            logger.LogInformation($"{tesNodeTask.Outputs.Count} outputs to upload.");
 
             var uploader = new BlobUploader(blobPipelineOptions, memoryBufferChannel);
 

--- a/src/Tes.Runner/NodeTaskResult.cs
+++ b/src/Tes.Runner/NodeTaskResult.cs
@@ -5,4 +5,4 @@ using Tes.Runner.Docker;
 
 namespace Tes.Runner;
 
-public record NodeTaskResult(ContainerExecutionResult ContainerResult, long InputsLength, long OutputsLength);
+public record NodeTaskResult(ContainerExecutionResult ContainerResult);

--- a/src/Tes.Runner/Storage/CloudProviderSchemeConverter.cs
+++ b/src/Tes.Runner/Storage/CloudProviderSchemeConverter.cs
@@ -11,7 +11,6 @@ namespace Tes.Runner.Storage
         private const string GcpHost = "storage.googleapis.com";
         private const string AwsSuffix = ".s3.amazonaws.com";
 
-        //https://broad-references.s3.amazonaws.com/hg38/v0/Homo_sapiens_assembly38.dict
         public Task<Uri> CreateSasTokenWithStrategyAsync(string sourceUrl)
         {
             var sourceUri = new Uri(sourceUrl);

--- a/src/Tes.RunnerCLI/Commands/BlobPipelineOptionsConverter.cs
+++ b/src/Tes.RunnerCLI/Commands/BlobPipelineOptionsConverter.cs
@@ -1,0 +1,53 @@
+﻿using Tes.Runner.Transfer;
+
+namespace Tes.RunnerCLI.Commands
+{
+    internal class BlobPipelineOptionsConverter
+    {
+        internal const string FileOption = "file";
+        internal const string BlockSizeOption = "blockSize";
+        internal const string WritersOption = "writers";
+        internal const string ReadersOption = "readers";
+        internal const string BufferCapacityOption = "bufferCapacity";
+        internal const string ApiVersionOption = "apiVersion";
+
+        internal static string[] ToCommandArgs(string command, string fileOption, BlobPipelineOptions blobPipelineOptions)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(command, nameof(command));
+            ArgumentNullException.ThrowIfNull(blobPipelineOptions, nameof(blobPipelineOptions));
+
+            var args = new List<string>()
+            {
+                command,
+                $"--{BlockSizeOption} {blobPipelineOptions.BlockSizeBytes}",
+                $"--{WritersOption} {blobPipelineOptions.NumberOfWriters}",
+                $"--{ReadersOption} {blobPipelineOptions.NumberOfReaders}",
+                $"--{BufferCapacityOption} {blobPipelineOptions.ReadWriteBuffersCapacity}",
+                $"--{ApiVersionOption} {blobPipelineOptions.ApiVersion}"
+            };
+
+            if (!string.IsNullOrEmpty(fileOption))
+            {
+                args.Add($"--{fileOption} {fileOption}");
+            }
+
+            return args.ToArray();
+        }
+
+        internal static BlobPipelineOptions ToBlobPipelineOptions(int blockSize, int writers, int readers,
+            int bufferCapacity, string apiVersion)
+        {
+            var options = new BlobPipelineOptions(
+                BlockSizeBytes: blockSize,
+                NumberOfWriters: writers,
+                NumberOfReaders: readers,
+                ReadWriteBuffersCapacity: bufferCapacity,
+                MemoryBufferCapacity: bufferCapacity,
+                ApiVersion: apiVersion);
+
+            options = PipelineOptionsOptimizer.OptimizeOptionsIfApplicable(options);
+
+            return options;
+        }
+    }
+}

--- a/src/Tes.RunnerCLI/Commands/BlobPipelineOptionsConverter.cs
+++ b/src/Tes.RunnerCLI/Commands/BlobPipelineOptionsConverter.cs
@@ -2,16 +2,16 @@
 
 namespace Tes.RunnerCLI.Commands
 {
-    internal class BlobPipelineOptionsConverter
+    public class BlobPipelineOptionsConverter
     {
-        internal const string FileOption = "file";
-        internal const string BlockSizeOption = "blockSize";
-        internal const string WritersOption = "writers";
-        internal const string ReadersOption = "readers";
-        internal const string BufferCapacityOption = "bufferCapacity";
-        internal const string ApiVersionOption = "apiVersion";
+        public const string FileOption = "file";
+        public const string BlockSizeOption = "blockSize";
+        public const string WritersOption = "writers";
+        public const string ReadersOption = "readers";
+        public const string BufferCapacityOption = "bufferCapacity";
+        public const string ApiVersionOption = "apiVersion";
 
-        internal static string[] ToCommandArgs(string command, string fileOption, BlobPipelineOptions blobPipelineOptions)
+        public static string[] ToCommandArgs(string command, string fileOption, BlobPipelineOptions blobPipelineOptions)
         {
             ArgumentException.ThrowIfNullOrEmpty(command, nameof(command));
             ArgumentNullException.ThrowIfNull(blobPipelineOptions, nameof(blobPipelineOptions));
@@ -28,13 +28,13 @@ namespace Tes.RunnerCLI.Commands
 
             if (!string.IsNullOrEmpty(fileOption))
             {
-                args.Add($"--{fileOption} {fileOption}");
+                args.Add($"--{FileOption} {fileOption}");
             }
 
             return args.ToArray();
         }
 
-        internal static BlobPipelineOptions ToBlobPipelineOptions(int blockSize, int writers, int readers,
+        public static BlobPipelineOptions ToBlobPipelineOptions(int blockSize, int writers, int readers,
             int bufferCapacity, string apiVersion)
         {
             var options = new BlobPipelineOptions(

--- a/src/Tes.RunnerCLI/Commands/CommandFactory.cs
+++ b/src/Tes.RunnerCLI/Commands/CommandFactory.cs
@@ -9,7 +9,6 @@ namespace Tes.RunnerCLI.Commands
 
         private static readonly Uri DefaultDockerUri = new Uri("unix:///var/run/docker.sock");
 
-        const string ExecCommandName = "exec";
         internal const string UploadCommandName = "upload";
         internal const string DownloadCommandName = "download";
         internal const string DockerUriOption = "docker-url";
@@ -122,7 +121,7 @@ namespace Tes.RunnerCLI.Commands
             };
         }
 
-        private static object? GetDefaultTaskDefinitionFile()
+        private static FileInfo GetDefaultTaskDefinitionFile()
         {
             return new FileInfo(DefaultTaskDefinitionFile);
         }

--- a/src/Tes.RunnerCLI/Commands/CommandFactory.cs
+++ b/src/Tes.RunnerCLI/Commands/CommandFactory.cs
@@ -26,10 +26,7 @@ namespace Tes.RunnerCLI.Commands
 
             rootCommand.AddOption(dockerUriOption);
 
-            rootCommand.SetHandler(async (file, blockSize, writers, readers, bufferCapacity, apiVersion, dockerUri) =>
-                {
-                    await CommandHandlers.ExecuteNodeTaskAsync(file, blockSize, writers, readers, bufferCapacity, apiVersion, dockerUri);
-                },
+            rootCommand.SetHandler(CommandHandlers.ExecuteNodeTaskAsync,
                 GetOptionByName<FileInfo>(rootCommand.Options, BlobPipelineOptionsConverter.FileOption),
                 GetOptionByName<int>(rootCommand.Options, BlobPipelineOptionsConverter.BlockSizeOption),
                 GetOptionByName<int>(rootCommand.Options, BlobPipelineOptionsConverter.WritersOption),
@@ -47,15 +44,7 @@ namespace Tes.RunnerCLI.Commands
 
             rootCommand.Add(cmd);
 
-            cmd.SetHandler(async (file, blockSize, writers, readers, bufferCapacity, apiVersion) =>
-                {
-                    await CommandHandlers.ExecuteUploadTaskAsync(file,
-                            blockSize,
-                            writers,
-                            readers,
-                            bufferCapacity,
-                            apiVersion);
-                },
+            cmd.SetHandler(CommandHandlers.ExecuteUploadTaskAsync,
                 GetOptionByName<FileInfo>(cmd.Options, BlobPipelineOptionsConverter.FileOption),
                 GetOptionByName<int>(cmd.Options, BlobPipelineOptionsConverter.BlockSizeOption),
                 GetOptionByName<int>(cmd.Options, BlobPipelineOptionsConverter.WritersOption),
@@ -72,16 +61,7 @@ namespace Tes.RunnerCLI.Commands
 
             rootCommand.Add(cmd);
 
-            cmd.SetHandler(async (file, blockSize, writers, readers, bufferCapacity, apiVersion) =>
-                {
-                    await CommandHandlers.ExecuteDownloadTaskAsync(file,
-                        blockSize,
-                        writers,
-                        readers,
-                        bufferCapacity,
-                        apiVersion);
-
-                },
+            cmd.SetHandler(CommandHandlers.ExecuteDownloadTaskAsync,
                 GetOptionByName<FileInfo>(cmd.Options, BlobPipelineOptionsConverter.FileOption),
                 GetOptionByName<int>(cmd.Options, BlobPipelineOptionsConverter.BlockSizeOption),
                 GetOptionByName<int>(cmd.Options, BlobPipelineOptionsConverter.WritersOption),

--- a/src/Tes.RunnerCLI/Commands/CommandFactory.cs
+++ b/src/Tes.RunnerCLI/Commands/CommandFactory.cs
@@ -5,24 +5,18 @@ namespace Tes.RunnerCLI.Commands
 {
     internal class CommandFactory
     {
-        const string FileOption = "file";
-        const string BlockSizeOption = "blockSize";
-        const string WritersOption = "writers";
-        const string ReadersOption = "readers";
-        const string BufferCapacityOption = "bufferCapacity";
-        const string ApiVersionOption = "apiVersion";
-        const string DockerUriOption = "docker-url";
         const string DefaultTaskDefinitionFile = "TesTask.json";
 
         private static readonly Uri DefaultDockerUri = new Uri("unix:///var/run/docker.sock");
 
         const string ExecCommandName = "exec";
-        private const string UploadCommandName = "upload";
-        private const string DownloadCommandName = "download";
+        internal const string UploadCommandName = "upload";
+        internal const string DownloadCommandName = "download";
+        internal const string DockerUriOption = "docker-url";
 
         internal static RootCommand CreateExecutorCommand()
         {
-            var dockerUriOption = CreateOption<Uri>(DockerUriOption, "local docker engine endpoint", "-u", defaultValue: DefaultDockerUri);
+            var dockerUriOption = CreateOption<Uri>(CommandFactory.DockerUriOption, "local docker engine endpoint", "-u", defaultValue: DefaultDockerUri);
 
             var rootCommand = new RootCommand("Executes the specified TES Task");
 
@@ -37,12 +31,12 @@ namespace Tes.RunnerCLI.Commands
                 {
                     await CommandHandlers.ExecuteNodeTaskAsync(file, blockSize, writers, readers, bufferCapacity, apiVersion, dockerUri);
                 },
-                GetOptionByName<FileInfo>(rootCommand.Options, FileOption),
-                GetOptionByName<int>(rootCommand.Options, BlockSizeOption),
-                GetOptionByName<int>(rootCommand.Options, WritersOption),
-                GetOptionByName<int>(rootCommand.Options, ReadersOption),
-                GetOptionByName<int>(rootCommand.Options, BufferCapacityOption),
-                GetOptionByName<string>(rootCommand.Options, ApiVersionOption),
+                GetOptionByName<FileInfo>(rootCommand.Options, BlobPipelineOptionsConverter.FileOption),
+                GetOptionByName<int>(rootCommand.Options, BlobPipelineOptionsConverter.BlockSizeOption),
+                GetOptionByName<int>(rootCommand.Options, BlobPipelineOptionsConverter.WritersOption),
+                GetOptionByName<int>(rootCommand.Options, BlobPipelineOptionsConverter.ReadersOption),
+                GetOptionByName<int>(rootCommand.Options, BlobPipelineOptionsConverter.BufferCapacityOption),
+                GetOptionByName<string>(rootCommand.Options, BlobPipelineOptionsConverter.ApiVersionOption),
                 dockerUriOption);
 
             return rootCommand;
@@ -63,12 +57,12 @@ namespace Tes.RunnerCLI.Commands
                             bufferCapacity,
                             apiVersion);
                 },
-                GetOptionByName<FileInfo>(cmd.Options, FileOption),
-                GetOptionByName<int>(cmd.Options, BlockSizeOption),
-                GetOptionByName<int>(cmd.Options, WritersOption),
-                GetOptionByName<int>(cmd.Options, ReadersOption),
-                GetOptionByName<int>(cmd.Options, BufferCapacityOption),
-                GetOptionByName<string>(cmd.Options, ApiVersionOption));
+                GetOptionByName<FileInfo>(cmd.Options, BlobPipelineOptionsConverter.FileOption),
+                GetOptionByName<int>(cmd.Options, BlobPipelineOptionsConverter.BlockSizeOption),
+                GetOptionByName<int>(cmd.Options, BlobPipelineOptionsConverter.WritersOption),
+                GetOptionByName<int>(cmd.Options, BlobPipelineOptionsConverter.ReadersOption),
+                GetOptionByName<int>(cmd.Options, BlobPipelineOptionsConverter.BufferCapacityOption),
+                GetOptionByName<string>(cmd.Options, BlobPipelineOptionsConverter.ApiVersionOption));
 
             return cmd;
         }
@@ -89,12 +83,12 @@ namespace Tes.RunnerCLI.Commands
                         apiVersion);
 
                 },
-                GetOptionByName<FileInfo>(cmd.Options, FileOption),
-                GetOptionByName<int>(cmd.Options, BlockSizeOption),
-                GetOptionByName<int>(cmd.Options, WritersOption),
-                GetOptionByName<int>(cmd.Options, ReadersOption),
-                GetOptionByName<int>(cmd.Options, BufferCapacityOption),
-                GetOptionByName<string>(cmd.Options, ApiVersionOption));
+                GetOptionByName<FileInfo>(cmd.Options, BlobPipelineOptionsConverter.FileOption),
+                GetOptionByName<int>(cmd.Options, BlobPipelineOptionsConverter.BlockSizeOption),
+                GetOptionByName<int>(cmd.Options, BlobPipelineOptionsConverter.WritersOption),
+                GetOptionByName<int>(cmd.Options, BlobPipelineOptionsConverter.ReadersOption),
+                GetOptionByName<int>(cmd.Options, BlobPipelineOptionsConverter.BufferCapacityOption),
+                GetOptionByName<string>(cmd.Options, BlobPipelineOptionsConverter.ApiVersionOption));
 
             return cmd;
         }
@@ -119,12 +113,12 @@ namespace Tes.RunnerCLI.Commands
         {
             return new List<Option>()
             {
-                CreateOption<FileInfo>(FileOption, "The file with the task definition",  "-f", required: true, defaultValue: GetDefaultTaskDefinitionFile()),
-                CreateOption<int>(BlockSizeOption, "Blob block size in bytes", "-b", defaultValue: BlobSizeUtils.DefaultBlockSizeBytes),
-                CreateOption<int>(WritersOption, "Number of concurrent writers", "-w", defaultValue: BlobPipelineOptions.DefaultNumberOfWriters),
-                CreateOption<int>(ReadersOption, "Number of concurrent readers", "-r", defaultValue: BlobPipelineOptions.DefaultNumberOfReaders),
-                CreateOption<int>(BufferCapacityOption, "Pipeline buffer capacity", "-c", defaultValue: BlobPipelineOptions.DefaultReadWriteBuffersCapacity),
-                CreateOption<string>(ApiVersionOption, "Azure Storage API version", "-v", defaultValue: BlobPipelineOptions.DefaultApiVersion),
+                CreateOption<FileInfo>(BlobPipelineOptionsConverter.FileOption, "The file with the task definition",  "-f", required: true, defaultValue: GetDefaultTaskDefinitionFile()),
+                CreateOption<int>(BlobPipelineOptionsConverter.BlockSizeOption, "Blob block size in bytes", "-b", defaultValue: BlobSizeUtils.DefaultBlockSizeBytes),
+                CreateOption<int>(BlobPipelineOptionsConverter.WritersOption, "Number of concurrent writers", "-w", defaultValue: BlobPipelineOptions.DefaultNumberOfWriters),
+                CreateOption<int>(BlobPipelineOptionsConverter.ReadersOption, "Number of concurrent readers", "-r", defaultValue: BlobPipelineOptions.DefaultNumberOfReaders),
+                CreateOption<int>(BlobPipelineOptionsConverter.BufferCapacityOption, "Pipeline buffer capacity", "-c", defaultValue: BlobPipelineOptions.DefaultReadWriteBuffersCapacity),
+                CreateOption<string>(BlobPipelineOptionsConverter.ApiVersionOption, "Azure Storage API version", "-v", defaultValue: BlobPipelineOptions.DefaultApiVersion),
             };
         }
 

--- a/src/Tes.RunnerCLI/Commands/CommandHandlers.cs
+++ b/src/Tes.RunnerCLI/Commands/CommandHandlers.cs
@@ -23,11 +23,11 @@ namespace Tes.RunnerCLI.Commands
             {
                 var options = BlobPipelineOptionsConverter.ToBlobPipelineOptions(blockSize, writers, readers, bufferCapacity, apiVersion);
 
-                ExecuteTransferAsSubProcess(CommandFactory.DownloadCommandName, file, options);
+                await ExecuteTransferAsSubProcessAsync(CommandFactory.DownloadCommandName, file, options);
 
                 await ExecuteNodeContainerTaskAsync(file, dockerUri, options);
 
-                ExecuteTransferAsSubProcess(CommandFactory.UploadCommandName, file, options);
+                await ExecuteTransferAsSubProcessAsync(CommandFactory.UploadCommandName, file, options);
 
                 return SuccessExitCode;
 
@@ -107,11 +107,11 @@ namespace Tes.RunnerCLI.Commands
             Console.WriteLine($"Result: {results.StandardOutput}");
         }
 
-        private static void ExecuteTransferAsSubProcess(string command, FileInfo file, BlobPipelineOptions options)
+        private static async Task ExecuteTransferAsSubProcessAsync(string command, FileInfo file, BlobPipelineOptions options)
         {
             var processLauncher = new ProcessLauncher();
 
-            var results = processLauncher.LaunchProcessAndWait(BlobPipelineOptionsConverter.ToCommandArgs(command, file.FullName, options));
+            var results = await processLauncher.LaunchProcessAndWaitAsync(BlobPipelineOptionsConverter.ToCommandArgs(command, file.FullName, options));
 
             HandleResult(results, command);
         }

--- a/src/Tes.RunnerCLI/Commands/ProcessExecutionResult.cs
+++ b/src/Tes.RunnerCLI/Commands/ProcessExecutionResult.cs
@@ -1,0 +1,3 @@
+﻿namespace Tes.RunnerCLI.Commands;
+
+public record ProcessExecutionResult(string StandardOutput, string StandardError, int ExitCode);

--- a/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
+++ b/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
@@ -17,7 +17,7 @@ namespace Tes.RunnerCLI.Commands
             process.Start();
             await process.WaitForExitAsync();
 
-            return ToProcessExecutionResult(process);
+            return await ToProcessExecutionResultAsync(process);
         }
 
         private static string? GetExecutableFullPath()
@@ -39,11 +39,11 @@ namespace Tes.RunnerCLI.Commands
             return string.Join(" ", argList.ToArray());
         }
 
-        private ProcessExecutionResult ToProcessExecutionResult(Process process)
+        private async Task<ProcessExecutionResult> ToProcessExecutionResultAsync(Process process)
         {
             return new ProcessExecutionResult(
-                process.StandardOutput.ReadToEnd(),
-                process.StandardError.ReadToEnd(),
+                await process.StandardOutput.ReadToEndAsync(),
+                await process.StandardError.ReadToEndAsync(),
                 process.ExitCode);
         }
     }

--- a/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
+++ b/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tes.RunnerCLI.Commands
+{
+    public class ProcessLauncher
+    {
+       private readonly string executableName = Process.GetCurrentProcess().ProcessName;
+
+       public ProcessExecutionResult LaunchProcess(string[] args)
+       {
+           var process = new Process();
+            process.StartInfo.FileName = executableName;
+            process.StartInfo.Arguments = string.Join(" ", args);
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.Start();
+            process.WaitForExit();
+
+            return ToProcessExecutionResult(process);
+       }
+
+       private ProcessExecutionResult ToProcessExecutionResult(Process process)
+       {
+           return new ProcessExecutionResult(
+               process.StandardOutput.ReadToEnd(),
+               process.StandardError.ReadToEnd(),
+               process.ExitCode);
+       }
+    }
+
+    public record ProcessExecutionResult(string StandardOutput, string StandardError, int ExitCode)
+    {
+    }
+}

--- a/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
+++ b/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
@@ -9,7 +9,7 @@ namespace Tes.RunnerCLI.Commands
         public ProcessExecutionResult LaunchProcessAndWait(string[] options)
         {
             var process = new Process();
-            process.StartInfo.FileName = Process.GetCurrentProcess().MainModule?.FileName;
+            process.StartInfo.FileName = GetExecutableFullPath();
             process.StartInfo.Arguments = ParseArguments(options);
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.RedirectStandardOutput = true;
@@ -20,17 +20,22 @@ namespace Tes.RunnerCLI.Commands
             return ToProcessExecutionResult(process);
         }
 
+        private static string? GetExecutableFullPath()
+        {
+            return Process.GetCurrentProcess().MainModule?.FileName;
+        }
+
         private string ParseArguments(string[] options)
         {
             var argList = new List<string>(options);
             var assemblyName = Assembly.GetExecutingAssembly().Location;
 
-            if (assemblyName is null)
+            if (!string.IsNullOrEmpty(assemblyName))
             {
-                throw new InvalidOperationException("Invalid execution context. The assembly name was not found.");
+                //the application is not running as a single file executable
+                argList.Insert(0, assemblyName);
             }
 
-            argList.Insert(0, assemblyName);
             return string.Join(" ", argList.ToArray());
         }
 

--- a/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
+++ b/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
@@ -6,7 +6,7 @@ namespace Tes.RunnerCLI.Commands
     public class ProcessLauncher
     {
 
-        public ProcessExecutionResult LaunchProcessAndWait(string[] options)
+        public async Task<ProcessExecutionResult> LaunchProcessAndWaitAsync(string[] options)
         {
             var process = new Process();
             process.StartInfo.FileName = GetExecutableFullPath();
@@ -15,7 +15,7 @@ namespace Tes.RunnerCLI.Commands
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.RedirectStandardError = true;
             process.Start();
-            process.WaitForExit();
+            await process.WaitForExitAsync();
 
             return ToProcessExecutionResult(process);
         }

--- a/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
+++ b/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
@@ -5,19 +5,33 @@ namespace Tes.RunnerCLI.Commands
 {
     public class ProcessLauncher
     {
-        private readonly string executableName = Process.GetCurrentProcess().ProcessName;
 
-        public ProcessExecutionResult LaunchProcess(string[] args)
+        public ProcessExecutionResult LaunchProcessAndWait(string[] options)
         {
             var process = new Process();
-            process.StartInfo.FileName = executableName;
-            process.StartInfo.Arguments = string.Join(" ", args);
+            process.StartInfo.FileName = Process.GetCurrentProcess().MainModule?.FileName;
+            process.StartInfo.Arguments = ParseArguments(options);
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
             process.Start();
             process.WaitForExit();
 
             return ToProcessExecutionResult(process);
+        }
+
+        private string ParseArguments(string[] options)
+        {
+            var argList = new List<string>(options);
+            var assemblyName = Assembly.GetExecutingAssembly().Location;
+
+            if (assemblyName is null)
+            {
+                throw new InvalidOperationException("Invalid execution context. The assembly name was not found.");
+            }
+
+            argList.Insert(0, assemblyName);
+            return string.Join(" ", argList.ToArray());
         }
 
         private ProcessExecutionResult ToProcessExecutionResult(Process process)
@@ -26,38 +40,6 @@ namespace Tes.RunnerCLI.Commands
                 process.StandardOutput.ReadToEnd(),
                 process.StandardError.ReadToEnd(),
                 process.ExitCode);
-        }
-
-        private static void ConfigureProcessStartInfoForMethodInvocation(MethodInfo method, string[] args, ProcessStartInfo psi)
-        {
-            if (method.ReturnType != typeof(void) &&
-                method.ReturnType != typeof(int) &&
-                method.ReturnType != typeof(Task<int>))
-            {
-                throw new ArgumentException("method has an invalid return type", nameof(method));
-            }
-            if (method.GetParameters().Length > 1)
-            {
-                throw new ArgumentException("method has more than one argument argument", nameof(method));
-            }
-            if (method.GetParameters().Length == 1 && method.GetParameters()[0].ParameterType != typeof(string[]))
-            {
-                throw new ArgumentException("method has non string[] argument", nameof(method));
-            }
-
-            // If we need the host (if it exists), use it, otherwise target the console app directly.
-            Type t = method.DeclaringType;
-            Assembly a = t.GetTypeInfo().Assembly;
-
-            bool enableDebuggerAttach = Debugger.IsAttached && Environment.OSVersion.Platform == PlatformID.Win32NT;
-            int pid = Process.GetCurrentProcess().Id;
-
-            //string programArgs = PasteArguments.Paste(new string[] { a.FullName, t.FullName, method.Name, enableDebuggerAttach.ToString(System.Globalization.CultureInfo.InvariantCulture), pid.ToString(System.Globalization.CultureInfo.InvariantCulture) });
-            //string functionArgs = PasteArguments.Paste(args);
-            //string fullArgs = HostArguments + " " + " " + programArgs + " " + functionArgs;
-
-            //psi.FileName = HostFilename;
-            //psi.Arguments = fullArgs;
         }
     }
 

--- a/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
+++ b/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
@@ -1,19 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Diagnostics;
+using System.Reflection;
 
 namespace Tes.RunnerCLI.Commands
 {
     public class ProcessLauncher
     {
-       private readonly string executableName = Process.GetCurrentProcess().ProcessName;
+        private readonly string executableName = Process.GetCurrentProcess().ProcessName;
 
-       public ProcessExecutionResult LaunchProcess(string[] args)
-       {
-           var process = new Process();
+        public ProcessExecutionResult LaunchProcess(string[] args)
+        {
+            var process = new Process();
             process.StartInfo.FileName = executableName;
             process.StartInfo.Arguments = string.Join(" ", args);
             process.StartInfo.UseShellExecute = false;
@@ -22,15 +18,47 @@ namespace Tes.RunnerCLI.Commands
             process.WaitForExit();
 
             return ToProcessExecutionResult(process);
-       }
+        }
 
-       private ProcessExecutionResult ToProcessExecutionResult(Process process)
-       {
-           return new ProcessExecutionResult(
-               process.StandardOutput.ReadToEnd(),
-               process.StandardError.ReadToEnd(),
-               process.ExitCode);
-       }
+        private ProcessExecutionResult ToProcessExecutionResult(Process process)
+        {
+            return new ProcessExecutionResult(
+                process.StandardOutput.ReadToEnd(),
+                process.StandardError.ReadToEnd(),
+                process.ExitCode);
+        }
+
+        private static void ConfigureProcessStartInfoForMethodInvocation(MethodInfo method, string[] args, ProcessStartInfo psi)
+        {
+            if (method.ReturnType != typeof(void) &&
+                method.ReturnType != typeof(int) &&
+                method.ReturnType != typeof(Task<int>))
+            {
+                throw new ArgumentException("method has an invalid return type", nameof(method));
+            }
+            if (method.GetParameters().Length > 1)
+            {
+                throw new ArgumentException("method has more than one argument argument", nameof(method));
+            }
+            if (method.GetParameters().Length == 1 && method.GetParameters()[0].ParameterType != typeof(string[]))
+            {
+                throw new ArgumentException("method has non string[] argument", nameof(method));
+            }
+
+            // If we need the host (if it exists), use it, otherwise target the console app directly.
+            Type t = method.DeclaringType;
+            Assembly a = t.GetTypeInfo().Assembly;
+
+            bool enableDebuggerAttach = Debugger.IsAttached && Environment.OSVersion.Platform == PlatformID.Win32NT;
+            int pid = Process.GetCurrentProcess().Id;
+
+            //string programArgs = PasteArguments.Paste(new string[] { a.FullName, t.FullName, method.Name, enableDebuggerAttach.ToString(System.Globalization.CultureInfo.InvariantCulture), pid.ToString(System.Globalization.CultureInfo.InvariantCulture) });
+            //string functionArgs = PasteArguments.Paste(args);
+            //string fullArgs = HostArguments + " " + " " + programArgs + " " + functionArgs;
+
+            //psi.FileName = HostFilename;
+            //psi.Arguments = fullArgs;
+        }
     }
 
     public record ProcessExecutionResult(string StandardOutput, string StandardError, int ExitCode)

--- a/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
+++ b/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
@@ -47,8 +47,4 @@ namespace Tes.RunnerCLI.Commands
                 process.ExitCode);
         }
     }
-
-    public record ProcessExecutionResult(string StandardOutput, string StandardError, int ExitCode)
-    {
-    }
 }

--- a/src/Tes.RunnerCLI/Program.cs
+++ b/src/Tes.RunnerCLI/Program.cs
@@ -4,14 +4,14 @@
 using System.CommandLine;
 using Tes.RunnerCLI.Commands;
 
-await StartUpAsync(args);
+return await StartUpAsync(args);
 
-static async Task StartUpAsync(string[] args)
+static async Task<int> StartUpAsync(string[] args)
 {
     var rootCommand = CommandFactory.CreateExecutorCommand();
     CommandFactory.CreateUploadCommand(rootCommand);
     CommandFactory.CreateDownloadCommand(rootCommand);
 
 
-    await rootCommand.InvokeAsync(args);
+    return await rootCommand.InvokeAsync(args);
 }


### PR DESCRIPTION
Closes: #220 

This PR includes:
 -  The download and upload operations are launched as subprocesses when the runner executes a full task.
 - The runner returns 1 as the exit code when an operation fails, 0 if it succeeds.
 - Refactoring and improved logging and console output. 