### PR TITLE
Editor config  adds and enforces license information

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -71,6 +71,7 @@ dotnet_style_prefer_conditional_expression_over_return = true:silent
 dotnet_diagnostic.IDE0073.severity = warning 
 file_header_template = Copyright (c) Microsoft Corporation.\nLicensed under the MIT License. 
 
+
 ###############################
 # Naming Conventions          #
 ###############################
@@ -81,19 +82,10 @@ dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
 # Use PascalCase for constant fields
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
 dotnet_naming_symbols.constant_fields.applicable_kinds            = field
 dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
 dotnet_naming_symbols.constant_fields.required_modifiers          = const
-dotnet_style_operator_placement_when_wrapping = beginning_of_line
-tab_width = 4
-dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
-dotnet_style_prefer_compound_assignment = true:suggestion
-dotnet_style_prefer_simplified_interpolation = true:suggestion
-dotnet_style_namespace_match_folder = true:suggestion
-dotnet_style_allow_multiple_blank_lines_experimental = true:silent
-dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
-dotnet_code_quality_unused_parameters = all:suggestion
 
 ###############################
 # C# Code Style Rules         #
@@ -167,33 +159,6 @@ csharp_space_after_dot = false
 # Wrapping preferences
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
-csharp_style_prefer_null_check_over_type_check = true:suggestion
-
-csharp_using_directive_placement = outside_namespace:silent
-csharp_prefer_simple_using_statement = true:suggestion
-csharp_style_namespace_declarations = block_scoped:silent
-csharp_style_prefer_method_group_conversion = true:silent
-csharp_style_prefer_top_level_statements = true:silent
-csharp_style_expression_bodied_lambdas = true:silent
-csharp_style_prefer_local_over_anonymous_function = true:suggestion
-csharp_style_prefer_index_operator = true:suggestion
-csharp_style_prefer_range_operator = true:suggestion
-csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
-csharp_style_prefer_tuple_swap = true:suggestion
-csharp_style_prefer_utf8_string_literals = true:suggestion
-csharp_style_unused_value_assignment_preference = discard_variable:suggestion
-csharp_style_unused_value_expression_statement_preference = discard_variable:silent
-csharp_prefer_static_local_function = true:suggestion
-csharp_style_prefer_readonly_struct = true:suggestion
-csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
-csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
-csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
-csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true:silent
-csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
-csharp_style_prefer_switch_expression = true:suggestion
-csharp_style_prefer_pattern_matching = true:silent
-csharp_style_prefer_not_pattern = true:suggestion
-csharp_style_prefer_extended_property_pattern = true:suggestion
 
 ##################################
 # Visual Basic Code Style Rules  #

--- a/.editorconfig
+++ b/.editorconfig
@@ -67,6 +67,10 @@ dotnet_style_prefer_auto_properties = true:silent
 dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 dotnet_style_prefer_conditional_expression_over_return = true:silent
 
+# Enforce license header
+dotnet_diagnostic.IDE0073.severity = warning 
+file_header_template = Copyright (c) Microsoft Corporation.\nLicensed under the MIT License. 
+
 ###############################
 # Naming Conventions          #
 ###############################
@@ -77,10 +81,19 @@ dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
 # Use PascalCase for constant fields
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
 dotnet_naming_symbols.constant_fields.applicable_kinds            = field
 dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
 dotnet_naming_symbols.constant_fields.required_modifiers          = const
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_allow_multiple_blank_lines_experimental = true:silent
+dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
+dotnet_code_quality_unused_parameters = all:suggestion
 
 ###############################
 # C# Code Style Rules         #
@@ -154,6 +167,33 @@ csharp_space_after_dot = false
 # Wrapping preferences
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+csharp_prefer_static_local_function = true:suggestion
+csharp_style_prefer_readonly_struct = true:suggestion
+csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true:silent
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_pattern_matching = true:silent
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
 
 ##################################
 # Visual Basic Code Style Rules  #

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Reflection;
 
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("TES on Azure")]

--- a/src/CommonUtilities.Tests/Usings.cs
+++ b/src/CommonUtilities.Tests/Usings.cs
@@ -1,1 +1,4 @@
-﻿global using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/Tes.Runner.Test/Commands/BlobPipelineOptionsConverterTests.cs
+++ b/src/Tes.Runner.Test/Commands/BlobPipelineOptionsConverterTests.cs
@@ -1,4 +1,7 @@
-﻿using Tes.Runner.Transfer;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Tes.Runner.Transfer;
 
 namespace Tes.RunnerCLI.Commands.Tests
 {

--- a/src/Tes.Runner.Test/Storage/CloudProviderSchemeConverterTests.cs
+++ b/src/Tes.Runner.Test/Storage/CloudProviderSchemeConverterTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Tes.Runner.Test/Transfer/PipelineOptionsOptimizerTests.cs
+++ b/src/Tes.Runner.Test/Transfer/PipelineOptionsOptimizerTests.cs
@@ -1,4 +1,7 @@
-﻿using Moq;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Moq;
 
 namespace Tes.Runner.Transfer.Tests
 {

--- a/src/Tes.Runner/Storage/CloudProviderSchemeConverter.cs
+++ b/src/Tes.Runner/Storage/CloudProviderSchemeConverter.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Tes.Runner/Transfer/RetriableException.cs
+++ b/src/Tes.Runner/Transfer/RetriableException.cs
@@ -1,4 +1,7 @@
-﻿namespace Tes.Runner.Transfer;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Tes.Runner.Transfer;
 
 public class RetriableException : Exception
 {

--- a/src/Tes.RunnerCLI/Commands/BlobPipelineOptionsConverter.cs
+++ b/src/Tes.RunnerCLI/Commands/BlobPipelineOptionsConverter.cs
@@ -1,4 +1,7 @@
-﻿using Tes.Runner.Transfer;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Tes.Runner.Transfer;
 
 namespace Tes.RunnerCLI.Commands
 {

--- a/src/Tes.RunnerCLI/Commands/CommandFactory.cs
+++ b/src/Tes.RunnerCLI/Commands/CommandFactory.cs
@@ -1,4 +1,7 @@
-﻿using System.CommandLine;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
 using Tes.Runner.Transfer;
 
 namespace Tes.RunnerCLI.Commands

--- a/src/Tes.RunnerCLI/Commands/CommandHandlers.cs
+++ b/src/Tes.RunnerCLI/Commands/CommandHandlers.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging;
 using Tes.Runner;
 using Tes.Runner.Docker;
 using Tes.Runner.Transfer;

--- a/src/Tes.RunnerCLI/Commands/ProcessExecutionResult.cs
+++ b/src/Tes.RunnerCLI/Commands/ProcessExecutionResult.cs
@@ -1,3 +1,6 @@
-﻿namespace Tes.RunnerCLI.Commands;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Tes.RunnerCLI.Commands;
 
 public record ProcessExecutionResult(string StandardOutput, string StandardError, int ExitCode);

--- a/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
+++ b/src/Tes.RunnerCLI/Commands/ProcessLauncher.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
 using System.Reflection;
 
 namespace Tes.RunnerCLI.Commands

--- a/src/Tes/Migrations/20230106185229_InitialCreate.cs
+++ b/src/Tes/Migrations/20230106185229_InitialCreate.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tes.Models;
 

--- a/src/Tes/Migrations/20230320202549_AddIndicesToJson.cs
+++ b/src/Tes/Migrations/20230320202549_AddIndicesToJson.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/Tes/Models/PostgreSqlOptions.cs
+++ b/src/Tes/Models/PostgreSqlOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace Tes.Models
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Tes.Models
 {
     /// <summary>
     /// PostgresSql configuration options

--- a/src/Tes/Models/TesTaskPostgres.cs
+++ b/src/Tes/Models/TesTaskPostgres.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Tes.Models

--- a/src/Tes/Repository/TesDbContext.cs
+++ b/src/Tes/Repository/TesDbContext.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
 using Microsoft.EntityFrameworkCore;
 using Tes.Models;
 

--- a/src/Tes/Utilities/PostgresConnectionStringUtility.cs
+++ b/src/Tes/Utilities/PostgresConnectionStringUtility.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
 using System.Text;
 using Microsoft.Extensions.Options;
 using Tes.Models;

--- a/src/TesApi.Tests/TesDockerClientTests.cs
+++ b/src/TesApi.Tests/TesDockerClientTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/TesApi.Web/BatchScheduler.BatchPools.cs
+++ b/src/TesApi.Web/BatchScheduler.BatchPools.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;

--- a/src/TesApi.Web/Management/Batch/PoolMetadataReader.cs
+++ b/src/TesApi.Web/Management/Batch/PoolMetadataReader.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
 using System.Linq;
 using Microsoft.Azure.Batch;
 using Microsoft.Azure.Batch.Auth;

--- a/src/TesApi.Web/RefreshVMSizesAndPricesHostedService.cs
+++ b/src/TesApi.Web/RefreshVMSizesAndPricesHostedService.cs
@@ -1,5 +1,5 @@
-﻿//// Copyright (c) Microsoft Corporation.
-//// Licensed under the MIT License.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 //using System;
 //using System.Threading;

--- a/src/deploy-tes-on-azure.Tests/KubernetesManagerTests.cs
+++ b/src/deploy-tes-on-azure.Tests/KubernetesManagerTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace TesDeployer.Tests


### PR DESCRIPTION
fixes #233

This PR adds two config values to the `.editorconfig`, that result on the following behavior:
 - A IDE warning is raised if a file is missing the license header.
 - `dotnet format` sets license header information if missing.

I also ran `dotnet format` for the entire solution. If this is too disruptive, please let me know and I can revert the format changes and just add the new editor config file. 