### PR TITLE
Add streamable to TES input

### DIFF
--- a/src/Tes/Models/TesInput.cs
+++ b/src/Tes/Models/TesInput.cs
@@ -68,6 +68,13 @@ namespace Tes.Models
         public string Content { get; set; }
 
         /// <summary>
+        /// Indicates that the file should not be downloaded 
+        /// https://github.com/ga4gh/task-execution-schemas/blob/1df37d34242f74d3f03475c6b9de3324b8094054/openapi/task_execution_service.openapi.yaml#L481
+        /// </summary>
+        [DataMember(Name = "streamable")]
+        public bool Streamable { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -80,6 +87,7 @@ namespace Tes.Models
             .Append("  Path: ").Append(Path).Append('\n')
             .Append("  Type: ").Append(Type).Append('\n')
             .Append("  Content: ").Append(Content).Append('\n')
+            .Append("  Streamable: ").Append(Streamable).Append('\n')
             .Append("}\n")
             .ToString();
 
@@ -142,6 +150,9 @@ namespace Tes.Models
                     Content == other.Content ||
                     Content is not null &&
                     Content.Equals(other.Content)
+                ) &&
+                (
+                    Streamable.Equals(other.Streamable)
                 ),
             };
 
@@ -176,11 +187,14 @@ namespace Tes.Models
                 }
 
                 hashCode = hashCode * 59 + Type.GetHashCode();
+
                 if (Content is not null)
                 {
                     hashCode = hashCode * 59 + Content.GetHashCode();
                 }
 
+                hashCode = hashCode * 59 + Streamable.GetHashCode();
+                
                 return hashCode;
             }
         }

--- a/src/TesApi.Tests/expectedBasicJsonResult.json
+++ b/src/TesApi.Tests/expectedBasicJsonResult.json
@@ -9,7 +9,8 @@
       "description": "string",
       "url": "string",
       "path": "string",
-      "type": "FILE"
+      "type": "FILE",
+      "streamable": false
     }
   ],
   "outputs": [

--- a/src/TesApi.Tests/expectedFullJsonResult.json
+++ b/src/TesApi.Tests/expectedFullJsonResult.json
@@ -10,7 +10,8 @@
       "url": "string",
       "path": "string",
       "type": "FILE",
-      "content": "string"
+      "content": "string",
+      "streamable": false
     }
   ],
   "outputs": [

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -983,7 +983,9 @@ namespace TesApi.Web
 
             var filesToDownload = await Task.WhenAll(
                 inputFiles
-                .Where(f => f?.Url?.StartsWith("drs://", StringComparison.OrdinalIgnoreCase) != true) // do not attempt to download DRS input files since the cromwell-drs-localizer will
+                .Where(f => 
+                    f?.Url?.StartsWith("drs://", StringComparison.OrdinalIgnoreCase) != true // do not attempt to download DRS input files since the cromwell-drs-localizer will
+                    && f?.Streamable == false)  // Don't download files where localization_optional is set to true in WDL (corresponds to "Streamable" property being true on TesInput)
                 .Union(additionalInputFiles)
                 .Select(async f => await GetTesInputFileUrlAsync(f, task, queryStringsToRemoveFromLocalFilePaths, cancellationToken)));
 


### PR DESCRIPTION
Adds a new "streamable" property to TES inputs.  If set to "true", then the file will not be downloaded locally on the Batch node.

Spec: https://github.com/ga4gh/task-execution-schemas/blob/1df37d34242f74d3f03475c6b9de3324b8094054/openapi/task_execution_service.openapi.yaml#L481

Resolves: https://github.com/microsoft/ga4gh-tes/issues/12