### PR TITLE
[245] Wildcard support and refactoring of runner task outputs and inputs expansion logic 

### DIFF
--- a/src/CommonUtilities/Models/NodeTask.cs
+++ b/src/CommonUtilities/Models/NodeTask.cs
@@ -19,7 +19,7 @@ namespace Tes.Runner.Models
 
     public class FileOutput
     {
-        public string? FullFileName { get; set; }
+        public string? Path { get; set; }
         public string? TargetUrl { get; set; }
         public SasResolutionStrategy? SasStrategy { get; set; }
         public FileType? FileType { get; set; }
@@ -28,7 +28,7 @@ namespace Tes.Runner.Models
 
     public class FileInput
     {
-        public string? FullFileName { get; set; }
+        public string? Path { get; set; }
         public string? SourceUrl { get; set; }
         public SasResolutionStrategy? SasStrategy { get; set; }
     }

--- a/src/CommonUtilities/Models/NodeTask.cs
+++ b/src/CommonUtilities/Models/NodeTask.cs
@@ -23,7 +23,7 @@ namespace Tes.Runner.Models
         public string? TargetUrl { get; set; }
         public SasResolutionStrategy? SasStrategy { get; set; }
         public FileType? FileType { get; set; }
-        public string? PathPrefix { get; set;}
+        public string? PathPrefix { get; set; }
     }
 
     public class FileInput

--- a/src/CommonUtilities/Models/NodeTask.cs
+++ b/src/CommonUtilities/Models/NodeTask.cs
@@ -23,7 +23,7 @@ namespace Tes.Runner.Models
         public string? TargetUrl { get; set; }
         public SasResolutionStrategy? SasStrategy { get; set; }
         public FileType? FileType { get; set; }
-        public bool? Required { get; set; }
+        public string? PathPrefix { get; set;}
     }
 
     public class FileInput

--- a/src/Tes.Runner.Test/ResolutionPolicyHandlerTests.cs
+++ b/src/Tes.Runner.Test/ResolutionPolicyHandlerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Moq;
 using Tes.Runner.Models;
 using Tes.Runner.Storage;
 
@@ -19,7 +18,6 @@ namespace Tes.Runner.Test
         public void SetUp()
         {
             resolutionPolicyHandler = new ResolutionPolicyHandler();
-            new Mock<ISasResolutionStrategy>();
         }
 
         [TestMethod]
@@ -44,9 +42,9 @@ namespace Tes.Runner.Test
         {
             var testTaskOutputs = new List<FileOutput>
             {
-                new FileOutput(){FullFileName = "file", TargetUrl = "http://foo.bar", SasStrategy = SasResolutionStrategy.None, Required = true},
-                new FileOutput(){FullFileName = "file1", TargetUrl = "http://foo1.bar", SasStrategy = SasResolutionStrategy.None, Required = true},
-                new FileOutput(){FullFileName = "file2", TargetUrl = "http://foo2.bar", SasStrategy = SasResolutionStrategy.None, Required = true}
+                new FileOutput(){FullFileName = "file", TargetUrl = "http://foo.bar", SasStrategy = SasResolutionStrategy.None},
+                new FileOutput(){FullFileName = "file1", TargetUrl = "http://foo1.bar", SasStrategy = SasResolutionStrategy.None},
+                new FileOutput(){FullFileName = "file2", TargetUrl = "http://foo2.bar", SasStrategy = SasResolutionStrategy.None}
             };
             var result = await resolutionPolicyHandler.ApplyResolutionPolicyAsync(testTaskOutputs);
             Assert.IsNotNull(result);

--- a/src/Tes.Runner.Test/ResolutionPolicyHandlerTests.cs
+++ b/src/Tes.Runner.Test/ResolutionPolicyHandlerTests.cs
@@ -42,9 +42,9 @@ namespace Tes.Runner.Test
         {
             var testTaskOutputs = new List<FileOutput>
             {
-                new FileOutput(){FullFileName = "file", TargetUrl = "http://foo.bar", SasStrategy = SasResolutionStrategy.None},
-                new FileOutput(){FullFileName = "file1", TargetUrl = "http://foo1.bar", SasStrategy = SasResolutionStrategy.None},
-                new FileOutput(){FullFileName = "file2", TargetUrl = "http://foo2.bar", SasStrategy = SasResolutionStrategy.None}
+                new FileOutput(){Path = "file", TargetUrl = "http://foo.bar", SasStrategy = SasResolutionStrategy.None},
+                new FileOutput(){Path = "file1", TargetUrl = "http://foo1.bar", SasStrategy = SasResolutionStrategy.None},
+                new FileOutput(){Path = "file2", TargetUrl = "http://foo2.bar", SasStrategy = SasResolutionStrategy.None}
             };
             var result = await resolutionPolicyHandler.ApplyResolutionPolicyAsync(testTaskOutputs);
             Assert.IsNotNull(result);
@@ -72,9 +72,9 @@ namespace Tes.Runner.Test
         {
             var testTaskInputs = new List<FileInput>
             {
-                new FileInput(){FullFileName = "file", SourceUrl = "http://foo.bar", SasStrategy = SasResolutionStrategy.None},
-                new FileInput(){FullFileName = "file1", SourceUrl = "http://foo1.bar", SasStrategy = SasResolutionStrategy.None},
-                new FileInput(){FullFileName = "file2", SourceUrl = "http://foo2.bar", SasStrategy = SasResolutionStrategy.None}
+                new FileInput(){Path = "file", SourceUrl = "http://foo.bar", SasStrategy = SasResolutionStrategy.None},
+                new FileInput(){Path = "file1", SourceUrl = "http://foo1.bar", SasStrategy = SasResolutionStrategy.None},
+                new FileInput(){Path = "file2", SourceUrl = "http://foo2.bar", SasStrategy = SasResolutionStrategy.None}
             };
             var result = await resolutionPolicyHandler.ApplyResolutionPolicyAsync(testTaskInputs);
             Assert.IsNotNull(result);

--- a/src/Tes.Runner.Test/RunnerTestUtils.cs
+++ b/src/Tes.Runner.Test/RunnerTestUtils.cs
@@ -20,6 +20,30 @@ public class RunnerTestUtils
         return file;
     }
 
+    public static DirectoryInfo CreateTempFilesInDirectory(string dirStructure, string filePrefix)
+    {
+        var parentDirName = Guid.NewGuid().ToString();
+        var root = Directory.CreateDirectory($"{parentDirName}/{dirStructure}");
+
+        while (root.Parent != null)
+        {
+            var fileName = $"{root.FullName}/{filePrefix}{Guid.NewGuid()}.tmp";
+
+            using var fs = File.Create(fileName);
+
+            fs.Close();
+
+            if (root.Name.Equals(parentDirName, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return root;
+            }
+
+            root = root.Parent;
+        }
+
+        throw new Exception("Could not find root directory");
+    }
+
     public static string CalculateMd5(string file)
     {
         using var md5 = MD5.Create();

--- a/src/Tes.Runner.Test/RunnerTestUtils.cs
+++ b/src/Tes.Runner.Test/RunnerTestUtils.cs
@@ -52,11 +52,6 @@ public class RunnerTestUtils
         }
         return pipelineBuffers;
     }
-    public static string AddRandomDataAndReturnMd5(byte[] data)
-    {
-        Random.NextBytes(data);
-        return CalculateMd5Hash(data);
-    }
 
     public static string CalculateMd5Hash(byte[] data)
     {

--- a/src/Tes.Runner.Test/Storage/CloudProviderSchemeConverterTests.cs
+++ b/src/Tes.Runner.Test/Storage/CloudProviderSchemeConverterTests.cs
@@ -1,23 +1,26 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Tes.Runner.Storage.Tests
+using Tes.Runner.Storage;
+
+namespace Tes.Runner.Test.Storage
 {
-    [TestClass()]
+    [TestClass]
+    [TestCategory("Unit")]
     public class CloudProviderSchemeConverterTests
     {
         [DataTestMethod]
         [DataRow(@"https://blob.name", @"https://blob.name")]
         [DataRow(@"s3://broad-references/hg38/v0/Homo_sapiens_assembly38.dict", @"https://broad-references.s3.amazonaws.com/hg38/v0/Homo_sapiens_assembly38.dict")]
         [DataRow(@"gs://encode-pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF641SFZ.subsampled.400.fastq.gz", @"https://storage.googleapis.com/encode-pipeline-test-samples/encode-atac-seq-pipeline/ENCSR356KRQ/fastq_subsampled/rep2/pair1/ENCFF641SFZ.subsampled.400.fastq.gz")]
-        public async Task CreateSasTokenWithStrategyAsyncTest_URIProvided_MatchesExpected(string sourceURI, string expectedURI)
+        public async Task CreateSasTokenWithStrategyAsyncTest_URIProvided_MatchesExpected(string sourceUri, string expectedUri)
         {
             var provider = new CloudProviderSchemeConverter();
 
-            var result = await provider.CreateSasTokenWithStrategyAsync(sourceURI);
+            var result = await provider.CreateSasTokenWithStrategyAsync(sourceUri);
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(result.AbsoluteUri, new Uri(expectedURI).AbsoluteUri);
+            Assert.AreEqual(result.AbsoluteUri, new Uri(expectedUri).AbsoluteUri);
         }
     }
 }

--- a/src/Tes.Runner.Test/Storage/FileOperationResolverTests.cs
+++ b/src/Tes.Runner.Test/Storage/FileOperationResolverTests.cs
@@ -1,0 +1,180 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Moq;
+using Tes.Runner.Models;
+using Tes.Runner.Storage;
+using Tes.Runner.Transfer;
+
+namespace Tes.Runner.Test.Storage
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class FileOperationResolverTests
+    {
+        private ResolutionPolicyHandler resolutionPolicyHandler = null!;
+        private Mock<IFileInfoProvider> fileInfoProvider = null!;
+        private FileOutput singleFileOutput = null!;
+        private FileOutput directoryFileOutput = null!;
+        private FileOutput patternFileOutput = null!;
+
+        private FileInput singleFileInput = null!;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            resolutionPolicyHandler = new ResolutionPolicyHandler();
+            fileInfoProvider = new Mock<IFileInfoProvider>();
+
+            fileInfoProvider.Setup(x => x.GetFileName(It.IsAny<string>())).Returns<string>(x => x);
+            fileInfoProvider.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+            
+            singleFileInput = new FileInput
+            {
+                FullFileName = "/foo/bar",
+                SourceUrl = "https://foo.bar/cont/foo/bar?sig=sasToken",
+                SasStrategy = SasResolutionStrategy.None,
+            };
+
+            singleFileOutput = new FileOutput
+            {
+                FullFileName = "/foo/bar",
+                TargetUrl = "https://foo.bar/cont/foo/bar?sig=sasToken",
+                SasStrategy = SasResolutionStrategy.None,
+                FileType = FileType.File
+            };
+
+            directoryFileOutput = new FileOutput
+            {
+                FullFileName = "/foo",
+                TargetUrl = "https://foo.bar/cont?sig=sasToken",
+                SasStrategy = SasResolutionStrategy.None,
+                FileType = FileType.Directory
+            };
+
+            patternFileOutput = new FileOutput
+            {
+                FullFileName = "/data/*.foo",
+                TargetUrl = "https://foo.bar/cont?sig=sasToken",
+                SasStrategy = SasResolutionStrategy.None,
+                PathPrefix = "/prefix",
+                FileType = FileType.File
+            };
+        }
+
+        [TestMethod]
+        public async Task ResolveOutputsAsync_FileOutputProvided_FileOperationIsResolved()
+        {
+            var nodeTask = new NodeTask()
+            {
+                Outputs = new List<FileOutput>
+                {
+                    singleFileOutput
+                }
+            };
+
+            var fileOperationInfoResolver = new FileOperationResolver(nodeTask, resolutionPolicyHandler, fileInfoProvider.Object);
+            var resolvedOutputs = await fileOperationInfoResolver.ResolveOutputsAsync();
+
+            Assert.AreEqual(1, resolvedOutputs?.Count);
+            Assert.IsTrue(resolvedOutputs?.Any(r => r.FullFilePath.Equals(singleFileOutput.FullFileName, StringComparison.InvariantCultureIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs?.Any(r => r.TargetUri.ToString().Equals(singleFileOutput.TargetUrl, StringComparison.InvariantCultureIgnoreCase)));
+        }
+
+        [TestMethod]
+        public async Task ResolveOutputsAsync_PatternOutputProvided_FileOperationsAreResolved()
+        {
+            var nodeTask = new NodeTask()
+            {
+                Outputs = new List<FileOutput>
+                {
+                    patternFileOutput
+                }
+            };
+
+            fileInfoProvider.Setup(x => x.GetFilesInAllDirectories(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(new List<string> { "/prefix/data/foo.foo", "/prefix/data/bar.foo" }.ToArray);
+
+            var fileOperationInfoResolver = new FileOperationResolver(nodeTask, resolutionPolicyHandler, fileInfoProvider.Object);
+            var resolvedOutputs = await fileOperationInfoResolver.ResolveOutputsAsync();
+
+            Assert.AreEqual(2, resolvedOutputs?.Count);
+            Assert.IsTrue(resolvedOutputs!.Any(r=>r.FullFilePath.Equals("/prefix/data/foo.foo", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/prefix/data/bar.foo", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/data/foo.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/data/bar.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
+        }
+
+        [TestMethod]
+        public async Task ResolveOutputsAsync_DirectoryOutputProvided_FileOperationsAreResolved()
+        {
+            var nodeTask = new NodeTask()
+            {
+                Outputs = new List<FileOutput>
+                {
+                    directoryFileOutput
+                }
+            };
+
+            fileInfoProvider.Setup(x => x.GetFilesInDirectory(It.IsAny<string>()))
+                .Returns(new List<string> { "/foo/foo.foo", "/foo/bar.foo" }.ToArray);
+
+            var fileOperationInfoResolver = new FileOperationResolver(nodeTask, resolutionPolicyHandler, fileInfoProvider.Object);
+            var resolvedOutputs = await fileOperationInfoResolver.ResolveOutputsAsync();
+
+            Assert.AreEqual(2, resolvedOutputs?.Count);
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/foo/foo.foo", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/foo/bar.foo", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/foo/foo.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/foo/bar.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
+        }
+
+        [TestMethod]
+        public async Task ResolveOutputsAsync_PatternAndFileOutputProvided_FileOperationsAreResolved()
+        {
+            var nodeTask = new NodeTask()
+            {
+                Outputs = new List<FileOutput>
+                {
+                    patternFileOutput,
+                    singleFileOutput
+                }
+            };
+
+            fileInfoProvider.Setup(x => x.GetFilesInAllDirectories(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(new List<string> { "/prefix/data/foo.foo", "/prefix/data/bar.foo" }.ToArray);
+
+            var fileOperationInfoResolver = new FileOperationResolver(nodeTask, resolutionPolicyHandler, fileInfoProvider.Object);
+            var resolvedOutputs = await fileOperationInfoResolver.ResolveOutputsAsync();
+
+            Assert.AreEqual(3, resolvedOutputs?.Count);
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/prefix/data/foo.foo", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/prefix/data/bar.foo", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/prefix/data/bar.foo", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/data/foo.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/data/bar.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs?.Any(r => r.FullFilePath.Equals(singleFileOutput.FullFileName, StringComparison.InvariantCultureIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs?.Any(r => r.TargetUri.ToString().Equals(singleFileOutput.TargetUrl, StringComparison.InvariantCultureIgnoreCase)));
+        }
+
+        [TestMethod]
+        public async Task ResolveInputsAsync_FileInputProvided_FileOperationsAreResolved()
+        {
+            var nodeTask = new NodeTask()
+            {
+                Inputs = new List<FileInput>
+                {
+                    singleFileInput
+                }
+            };
+
+            var fileOperationInfoResolver = new FileOperationResolver(nodeTask, resolutionPolicyHandler, fileInfoProvider.Object);
+
+            var resolvedInputs = await fileOperationInfoResolver.ResolveInputsAsync();
+
+            Assert.AreEqual(1, resolvedInputs?.Count);
+            Assert.IsTrue(resolvedInputs?.Any(r => r.FullFilePath.Equals(singleFileInput.FullFileName, StringComparison.InvariantCultureIgnoreCase)));
+            Assert.IsTrue(resolvedInputs?.Any(r => r.SourceUrl.ToString().Equals(singleFileInput.SourceUrl, StringComparison.InvariantCultureIgnoreCase)));
+        }
+    }
+}

--- a/src/Tes.Runner.Test/Storage/FileOperationResolverTests.cs
+++ b/src/Tes.Runner.Test/Storage/FileOperationResolverTests.cs
@@ -181,10 +181,5 @@ namespace Tes.Runner.Test.Storage
             Assert.IsTrue(resolvedInputs?.Any(r => r.SourceUrl.ToString().Equals(singleFileInput.SourceUrl, StringComparison.InvariantCultureIgnoreCase)));
         }
 
-        // [TestMethod]
-        // public async Task ResolveOutputsAsync_DirectoryOutputIsProvided_AllFilesInDirectoryAreResolved()
-        // {
-        //
-        // }
     }
 }

--- a/src/Tes.Runner.Test/Storage/FileOperationResolverTests.cs
+++ b/src/Tes.Runner.Test/Storage/FileOperationResolverTests.cs
@@ -28,7 +28,7 @@ namespace Tes.Runner.Test.Storage
 
             fileInfoProvider.Setup(x => x.GetFileName(It.IsAny<string>())).Returns<string>(x => x);
             fileInfoProvider.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
-            
+
             singleFileInput = new FileInput
             {
                 Path = "/foo/bar",
@@ -99,7 +99,7 @@ namespace Tes.Runner.Test.Storage
             var resolvedOutputs = await fileOperationInfoResolver.ResolveOutputsAsync();
 
             Assert.AreEqual(2, resolvedOutputs?.Count);
-            Assert.IsTrue(resolvedOutputs!.Any(r=>r.FullFilePath.Equals("/prefix/data/foo.foo", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/prefix/data/foo.foo", StringComparison.OrdinalIgnoreCase)));
             Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/prefix/data/bar.foo", StringComparison.OrdinalIgnoreCase)));
             Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/data/foo.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
             Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/data/bar.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));

--- a/src/Tes.Runner.Test/Storage/FileOperationResolverTests.cs
+++ b/src/Tes.Runner.Test/Storage/FileOperationResolverTests.cs
@@ -31,14 +31,14 @@ namespace Tes.Runner.Test.Storage
             
             singleFileInput = new FileInput
             {
-                FullFileName = "/foo/bar",
+                Path = "/foo/bar",
                 SourceUrl = "https://foo.bar/cont/foo/bar?sig=sasToken",
                 SasStrategy = SasResolutionStrategy.None,
             };
 
             singleFileOutput = new FileOutput
             {
-                FullFileName = "/foo/bar",
+                Path = "/foo/bar",
                 TargetUrl = "https://foo.bar/cont/foo/bar?sig=sasToken",
                 SasStrategy = SasResolutionStrategy.None,
                 FileType = FileType.File
@@ -46,7 +46,7 @@ namespace Tes.Runner.Test.Storage
 
             directoryFileOutput = new FileOutput
             {
-                FullFileName = "/foo",
+                Path = "/foo",
                 TargetUrl = "https://foo.bar/cont?sig=sasToken",
                 SasStrategy = SasResolutionStrategy.None,
                 FileType = FileType.Directory
@@ -54,7 +54,7 @@ namespace Tes.Runner.Test.Storage
 
             patternFileOutput = new FileOutput
             {
-                FullFileName = "/data/*.foo",
+                Path = "/data/*.foo",
                 TargetUrl = "https://foo.bar/cont?sig=sasToken",
                 SasStrategy = SasResolutionStrategy.None,
                 PathPrefix = "/prefix",
@@ -77,7 +77,7 @@ namespace Tes.Runner.Test.Storage
             var resolvedOutputs = await fileOperationInfoResolver.ResolveOutputsAsync();
 
             Assert.AreEqual(1, resolvedOutputs?.Count);
-            Assert.IsTrue(resolvedOutputs?.Any(r => r.FullFilePath.Equals(singleFileOutput.FullFileName, StringComparison.InvariantCultureIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs?.Any(r => r.FullFilePath.Equals(singleFileOutput.Path, StringComparison.InvariantCultureIgnoreCase)));
             Assert.IsTrue(resolvedOutputs?.Any(r => r.TargetUri.ToString().Equals(singleFileOutput.TargetUrl, StringComparison.InvariantCultureIgnoreCase)));
         }
 
@@ -153,7 +153,7 @@ namespace Tes.Runner.Test.Storage
             Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/prefix/data/bar.foo", StringComparison.OrdinalIgnoreCase)));
             Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/data/foo.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
             Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/data/bar.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
-            Assert.IsTrue(resolvedOutputs?.Any(r => r.FullFilePath.Equals(singleFileOutput.FullFileName, StringComparison.InvariantCultureIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs?.Any(r => r.FullFilePath.Equals(singleFileOutput.Path, StringComparison.InvariantCultureIgnoreCase)));
             Assert.IsTrue(resolvedOutputs?.Any(r => r.TargetUri.ToString().Equals(singleFileOutput.TargetUrl, StringComparison.InvariantCultureIgnoreCase)));
         }
 
@@ -173,7 +173,7 @@ namespace Tes.Runner.Test.Storage
             var resolvedInputs = await fileOperationInfoResolver.ResolveInputsAsync();
 
             Assert.AreEqual(1, resolvedInputs?.Count);
-            Assert.IsTrue(resolvedInputs?.Any(r => r.FullFilePath.Equals(singleFileInput.FullFileName, StringComparison.InvariantCultureIgnoreCase)));
+            Assert.IsTrue(resolvedInputs?.Any(r => r.FullFilePath.Equals(singleFileInput.Path, StringComparison.InvariantCultureIgnoreCase)));
             Assert.IsTrue(resolvedInputs?.Any(r => r.SourceUrl.ToString().Equals(singleFileInput.SourceUrl, StringComparison.InvariantCultureIgnoreCase)));
         }
     }

--- a/src/Tes.Runner.Test/Transfer/DefaultFileInfoProviderTests.cs
+++ b/src/Tes.Runner.Test/Transfer/DefaultFileInfoProviderTests.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Tes.Runner.Transfer;
+
+namespace Tes.Runner.Test.Transfer
+{
+    [TestClass, TestCategory("Unit")]
+    public class DefaultFileInfoProviderTests
+    {
+        private DirectoryInfo directoryInfo = null!;
+        private string testFile = null!;
+        private const string TestFilePrefix = "foo";
+        private DefaultFileInfoProvider fileInfoProvider = null!;
+
+        [TestInitialize]
+        public async Task Setup()
+        {
+            //this creates a directory structure like this: guid/dir1/dir2/dir3, with a file in each directory with the same prefix
+            directoryInfo = RunnerTestUtils.CreateTempFilesInDirectory("dir1/dir2/dir3", TestFilePrefix);
+            testFile = await RunnerTestUtils.CreateTempFileWithContentAsync(numberOfMiB: 1, extraBytes: 0);
+            fileInfoProvider = new DefaultFileInfoProvider();
+        }
+
+        [TestMethod]
+        public void GetFileSizeTest_FileExists_ReturnsValidSize()
+        {
+            var size = fileInfoProvider.GetFileSize(testFile);
+
+            Assert.AreEqual(BlobSizeUtils.MiB, size);
+        }
+
+        [TestMethod]
+        public void GetFileSizeTest_FileDoesNotExist_ThrowsFileNotFoundException()
+        {
+            Assert.ThrowsException<FileNotFoundException>(() => fileInfoProvider.GetFileSize("foo"));
+        }
+
+        [TestMethod]
+        public void GetExpandedFileName_EnvVariableIsInPath_FileNameIsExpanded()
+        {
+            Environment.SetEnvironmentVariable("AZ_PATH", "foo");
+
+            var expandedFileName = fileInfoProvider.GetExpandedFileName("%AZ_PATH%/bar");
+
+            Assert.AreEqual("foo/bar", expandedFileName);
+        }
+
+        [TestMethod]
+        public void FileExistsTest_FileExists_ReturnsTrue()
+        {
+            Assert.IsTrue(fileInfoProvider.FileExists(testFile));
+        }
+
+        [TestMethod]
+        public void FileExistsTest_FileDoesNotExist_ReturnsFalse()
+        {
+            Assert.IsFalse(fileInfoProvider.FileExists("foo"));
+        }
+
+        [TestMethod]
+        [DataRow($"{TestFilePrefix}*")]
+        [DataRow($"*")]
+        [DataRow($"*.tmp")]
+        public void GetFilesBySearchPattern_PatternThatMatchesAllFiles_ReturnsAllFilesInAllLevels(string pattern)
+        {
+            var files = fileInfoProvider.GetFilesBySearchPattern(directoryInfo.FullName, pattern);
+
+            AssertAllTempFilesAreReturned(files);
+        }
+
+        private static void AssertAllTempFilesAreReturned(string[] files)
+        {
+            //the setup creates 4 files with the same prefix
+            Assert.AreEqual(4, files.Length);
+        }
+
+        [TestMethod]
+        public void GetAllFilesInDirectoryTest_RootDirectoryIsProvided_AllFilesAreReturned()
+        {
+            var files = fileInfoProvider.GetAllFilesInDirectory(directoryInfo.FullName);
+
+            AssertAllTempFilesAreReturned(files);
+        }
+    }
+}

--- a/src/Tes.Runner.Test/Transfer/PipelineOptionsOptimizerTests.cs
+++ b/src/Tes.Runner.Test/Transfer/PipelineOptionsOptimizerTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Moq;
-using Tes.Runner.Models;
 using Tes.Runner.Transfer;
 
 namespace Tes.Runner.Test.Transfer
@@ -119,7 +118,7 @@ namespace Tes.Runner.Test.Transfer
             systemInfoProviderMock.Setup(x => x.TotalMemory).Returns(10 * BlobSizeUtils.GiB);
             fileInfoProviderMock.Setup(x => x.GetFileSize(It.IsAny<string>())).Returns(fileSizeInGiB * BlobSizeUtils.GiB);
 
-            var outputs = new List<FileOutput>() { new FileOutput() { Path = "fileName", SasStrategy = SasResolutionStrategy.None, TargetUrl = "https://blob.foo/cont/blob" } };
+            var outputs = new List<UploadInfo>() { new UploadInfo("fileName", new Uri("https://blob.foo/cont/blob")) };
             var options = new BlobPipelineOptions();
 
             var newOptions = optimizer.Optimize(options, outputs);

--- a/src/Tes.Runner.Test/Transfer/PipelineOptionsOptimizerTests.cs
+++ b/src/Tes.Runner.Test/Transfer/PipelineOptionsOptimizerTests.cs
@@ -119,7 +119,7 @@ namespace Tes.Runner.Test.Transfer
             systemInfoProviderMock.Setup(x => x.TotalMemory).Returns(10 * BlobSizeUtils.GiB);
             fileInfoProviderMock.Setup(x => x.GetFileSize(It.IsAny<string>())).Returns(fileSizeInGiB * BlobSizeUtils.GiB);
 
-            var outputs = new List<FileOutput>() { new FileOutput() { FullFileName = "fileName", SasStrategy = SasResolutionStrategy.None, TargetUrl = "https://blob.foo/cont/blob" } };
+            var outputs = new List<FileOutput>() { new FileOutput() { Path = "fileName", SasStrategy = SasResolutionStrategy.None, TargetUrl = "https://blob.foo/cont/blob" } };
             var options = new BlobPipelineOptions();
 
             var newOptions = optimizer.Optimize(options, outputs);

--- a/src/Tes.Runner/Executor.cs
+++ b/src/Tes.Runner/Executor.cs
@@ -51,7 +51,7 @@ namespace Tes.Runner
                 return 0;
             }
 
-            var optimizedOptions = OptimizeBlobPipelineOptionsForUpload(blobPipelineOptions);
+            var optimizedOptions = OptimizeBlobPipelineOptionsForUpload(blobPipelineOptions, outputs);
 
             var bytesTransferred = await UploadOutputsAsync(optimizedOptions, outputs);
 
@@ -86,16 +86,16 @@ namespace Tes.Runner
             return await operationResolver.ResolveOutputsAsync();
         }
 
-        private BlobPipelineOptions OptimizeBlobPipelineOptionsForUpload(BlobPipelineOptions blobPipelineOptions)
+        private BlobPipelineOptions OptimizeBlobPipelineOptionsForUpload(BlobPipelineOptions blobPipelineOptions, List<UploadInfo> outputs)
         {
             var optimizedOptions =
-                PipelineOptionsOptimizer.OptimizeOptionsIfApplicable(blobPipelineOptions, tesNodeTask.Outputs);
+                PipelineOptionsOptimizer.OptimizeOptionsIfApplicable(blobPipelineOptions, outputs);
 
             ValidateBlockSize(optimizedOptions.BlockSizeBytes);
 
             LogStartConfig(optimizedOptions);
 
-            logger.LogInformation($"{tesNodeTask.Outputs?.Count} outputs to upload.");
+            logger.LogInformation($"{outputs.Count} outputs to upload.");
             return optimizedOptions;
         }
 

--- a/src/Tes.Runner/Executor.cs
+++ b/src/Tes.Runner/Executor.cs
@@ -14,7 +14,7 @@ namespace Tes.Runner
     {
         private readonly ILogger logger = PipelineLoggerFactory.Create<Executor>();
         private readonly NodeTask tesNodeTask;
-        private readonly ResolutionPolicyHandler resolutionPolicyHandler;
+        private readonly FileOperationResolver operationResolver;
 
         public Executor(NodeTask tesNodeTask)
         {
@@ -22,7 +22,7 @@ namespace Tes.Runner
 
             this.tesNodeTask = tesNodeTask;
 
-            resolutionPolicyHandler = new ResolutionPolicyHandler();
+            operationResolver = new FileOperationResolver(tesNodeTask);
         }
 
         public async Task<NodeTaskResult> ExecuteNodeContainerTaskAsync(DockerExecutor dockerExecutor)
@@ -83,7 +83,7 @@ namespace Tes.Runner
                 }
             }
 
-            return await resolutionPolicyHandler.ApplyResolutionPolicyAsync(tesNodeTask.Outputs);
+            return await operationResolver.ResolveOutputsAsync();
         }
 
         private BlobPipelineOptions OptimizeBlobPipelineOptionsForUpload(BlobPipelineOptions blobPipelineOptions)
@@ -149,7 +149,7 @@ namespace Tes.Runner
                 }
             }
 
-            return await resolutionPolicyHandler.ApplyResolutionPolicyAsync(tesNodeTask.Inputs);
+            return await operationResolver.ResolveInputsAsync();
         }
 
         private static void ValidateBlockSize(int blockSizeBytes)

--- a/src/Tes.Runner/Storage/FileOperationResolver.cs
+++ b/src/Tes.Runner/Storage/FileOperationResolver.cs
@@ -52,7 +52,7 @@ namespace Tes.Runner.Storage
                 {
                     SasStrategy = input.SasStrategy,
                     SourceUrl = input.SourceUrl,
-                    FullFileName = fileInfoProvider.GetFileName(input.FullFileName!),
+                    Path = fileInfoProvider.GetFileName(input.Path!),
                 });
             }
 
@@ -95,7 +95,7 @@ namespace Tes.Runner.Storage
 
         private IEnumerable<FileOutput> ExpandDirectoryOutput(FileOutput output)
         {
-            foreach (var file in fileInfoProvider.GetFilesInDirectory(output.FullFileName!))
+            foreach (var file in fileInfoProvider.GetFilesInDirectory(output.Path!))
             {
                 yield return CreateExpandedFileOutputWithCombinedTargetUrl(output, file);
             }
@@ -107,7 +107,7 @@ namespace Tes.Runner.Storage
             if (string.IsNullOrEmpty(output.PathPrefix))
             {
                 //outputs are optional, so if the file does not exist, we just skip it
-                if (fileInfoProvider.FileExists(output.FullFileName!))
+                if (fileInfoProvider.FileExists(output.Path!))
                 {
                     yield return CreateExpandedFileOutput(output);
                 }
@@ -115,7 +115,7 @@ namespace Tes.Runner.Storage
                 yield break;
             }
 
-            var path = RemovePrefixFromPath(output.FullFileName!, output.PathPrefix!);
+            var path = RemovePrefixFromPath(output.Path!, output.PathPrefix!);
 
             foreach (var file in fileInfoProvider.GetFilesInAllDirectories(output.PathPrefix!, path))
             {
@@ -127,7 +127,7 @@ namespace Tes.Runner.Storage
         {
             return new FileOutput()
             {
-                FullFileName = Environment.ExpandEnvironmentVariables(output.FullFileName!),
+                Path = Environment.ExpandEnvironmentVariables(output.Path!),
                 PathPrefix = output.PathPrefix,
                 TargetUrl = output.TargetUrl,
                 SasStrategy = output.SasStrategy,
@@ -138,7 +138,7 @@ namespace Tes.Runner.Storage
         {
             return new FileOutput()
             {
-                FullFileName = path,
+                Path = path,
                 PathPrefix = output.PathPrefix,
                 TargetUrl = ToCombinedTargetUrl(output, path),
                 SasStrategy = output.SasStrategy,

--- a/src/Tes.Runner/Storage/FileOperationResolver.cs
+++ b/src/Tes.Runner/Storage/FileOperationResolver.cs
@@ -1,0 +1,177 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Tes.Runner.Models;
+using Tes.Runner.Transfer;
+
+namespace Tes.Runner.Storage
+{
+    public class FileOperationResolver
+    {
+        private readonly NodeTask nodeTask;
+        private readonly ResolutionPolicyHandler resolutionPolicyHandler;
+        private readonly IFileInfoProvider fileInfoProvider;
+
+        public FileOperationResolver(NodeTask nodeTask) : this(nodeTask, new ResolutionPolicyHandler(), new DefaultFileInfoProvider())
+        {
+        }
+
+        public FileOperationResolver(NodeTask nodeTask, ResolutionPolicyHandler resolutionPolicyHandler,
+            IFileInfoProvider fileInfoProvider)
+        {
+            ArgumentNullException.ThrowIfNull(nodeTask);
+            ArgumentNullException.ThrowIfNull(resolutionPolicyHandler);
+            ArgumentNullException.ThrowIfNull(fileInfoProvider);
+
+            this.nodeTask = nodeTask;
+            this.resolutionPolicyHandler = resolutionPolicyHandler;
+            this.fileInfoProvider = fileInfoProvider;
+        }
+
+        public async Task<List<DownloadInfo>?> ResolveInputsAsync()
+        {
+            var expandedInputs = ExpandInputs();
+
+            return await resolutionPolicyHandler.ApplyResolutionPolicyAsync(expandedInputs);
+        }
+
+        public async Task<List<UploadInfo>?> ResolveOutputsAsync()
+        {
+            var expandedOutputs = ExpandOutputs();
+
+            return await resolutionPolicyHandler.ApplyResolutionPolicyAsync(expandedOutputs);
+        }
+
+        private List<FileInput> ExpandInputs()
+        {
+            var expandedInputs = new List<FileInput>();
+
+            foreach (var input in nodeTask.Inputs ?? Enumerable.Empty<FileInput>())
+            {
+                expandedInputs.Add(new FileInput
+                {
+                    SasStrategy = input.SasStrategy,
+                    SourceUrl = input.SourceUrl,
+                    FullFileName = fileInfoProvider.GetFileName(input.FullFileName!),
+                });
+            }
+
+            return expandedInputs;
+        }
+
+        private List<FileOutput> ExpandOutputs()
+        {
+            var outputs = new List<FileOutput>();
+
+            foreach (var output in nodeTask.Outputs ?? Enumerable.Empty<FileOutput>())
+            {
+                outputs.AddRange(ExpandOutput(output));
+            }
+
+            return outputs;
+        }
+
+        private IEnumerable<FileOutput> ExpandOutput(FileOutput output)
+        {
+            IEnumerable<FileOutput> expandedOutputs;
+
+            switch (output.FileType)
+            {
+                case FileType.Directory:
+                    expandedOutputs = ExpandDirectoryOutput(output);
+                    break;
+                case FileType.File:
+                    expandedOutputs = ExpandFileOutput(output);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(output.FileType), output.FileType, "File output type");
+            }
+
+            foreach (var fileOutput in expandedOutputs)
+            {
+                yield return fileOutput;
+            }
+        }
+
+        private IEnumerable<FileOutput> ExpandDirectoryOutput(FileOutput output)
+        {
+            foreach (var file in fileInfoProvider.GetFilesInDirectory(output.FullFileName!))
+            {
+                yield return CreateExpandedFileOutputWithCombinedTargetUrl(output, file);
+            }
+        }
+
+        private IEnumerable<FileOutput> ExpandFileOutput(FileOutput output)
+        {
+            //consider the output as a single file if the path prefix is not specified
+            if (string.IsNullOrEmpty(output.PathPrefix))
+            {
+                //outputs are optional, so if the file does not exist, we just skip it
+                if (fileInfoProvider.FileExists(output.FullFileName!))
+                {
+                    yield return CreateExpandedFileOutput(output);
+                }
+
+                yield break;
+            }
+
+            var path = RemovePrefixFromPath(output.FullFileName!, output.PathPrefix!);
+
+            foreach (var file in fileInfoProvider.GetFilesInAllDirectories(output.PathPrefix!, path))
+            {
+                yield return CreateExpandedFileOutputWithCombinedTargetUrl(output, file);
+            }
+        }
+
+        private static FileOutput CreateExpandedFileOutput(FileOutput output)
+        {
+            return new FileOutput()
+            {
+                FullFileName = Environment.ExpandEnvironmentVariables(output.FullFileName!),
+                PathPrefix = output.PathPrefix,
+                TargetUrl = output.TargetUrl,
+                SasStrategy = output.SasStrategy,
+                FileType = FileType.File,
+            };
+        }
+        private FileOutput CreateExpandedFileOutputWithCombinedTargetUrl(FileOutput output, string path)
+        {
+            return new FileOutput()
+            {
+                FullFileName = path,
+                PathPrefix = output.PathPrefix,
+                TargetUrl = ToCombinedTargetUrl(output, path),
+                SasStrategy = output.SasStrategy,
+                FileType = FileType.File,
+            };
+        }
+
+        private string ToCombinedTargetUrl(FileOutput output, string path)
+        {
+            var builder = new UriBuilder(output.TargetUrl!);
+
+            builder.Path = $"{builder.Path}{RemovePrefixFromPath(path, output.PathPrefix)}";
+
+            return builder.Uri.ToString();
+        }
+
+        private static string RemovePrefixFromPath(string path, string? prefix)
+        {
+            var expandedPath = Environment.ExpandEnvironmentVariables(path);
+
+            if (string.IsNullOrEmpty(prefix))
+            {
+                return expandedPath;
+            }
+
+            var expandedPrefix = Environment.ExpandEnvironmentVariables(prefix);
+
+            if (expandedPath.StartsWith(expandedPrefix))
+            {
+                return expandedPath.Substring(expandedPrefix.Length);
+            }
+
+            return expandedPath;
+        }
+    }
+}

--- a/src/Tes.Runner/Storage/ResolutionPolicyHandler.cs
+++ b/src/Tes.Runner/Storage/ResolutionPolicyHandler.cs
@@ -26,9 +26,9 @@ public class ResolutionPolicyHandler
 
         foreach (var output in testTaskOutputs)
         {
-            if (string.IsNullOrEmpty(output.FullFileName))
+            if (string.IsNullOrEmpty(output.Path))
             {
-                throw new ArgumentException("A task output is missing the full filename. Please check the task definition.");
+                throw new ArgumentException("A task output is missing the path property. Please check the task definition.");
             }
 
             list.Add(await CreateUploadInfoWithStrategyAsync(output));
@@ -61,21 +61,21 @@ public class ResolutionPolicyHandler
 
     private static async Task<DownloadInfo> CreateDownloadInfoWithStrategyAsync(FileInput input)
     {
-        if (string.IsNullOrEmpty(input.FullFileName))
+        if (string.IsNullOrEmpty(input.Path))
         {
-            throw new ArgumentException("A task input is missing the full filename. Please check the task definition.");
+            throw new ArgumentException("A task input is missing the path property. Please check the task definition.");
         }
 
         var uri = await ApplySasResolutionToUrlAsync(input.SourceUrl, input.SasStrategy);
 
-        return new DownloadInfo(input.FullFileName, uri);
+        return new DownloadInfo(input.Path, uri);
     }
 
     private static async Task<UploadInfo> CreateUploadInfoWithStrategyAsync(FileOutput output)
     {
         var uri = await ApplySasResolutionToUrlAsync(output.TargetUrl, output.SasStrategy);
 
-        return new UploadInfo(output.FullFileName!, uri);
+        return new UploadInfo(output.Path!, uri);
     }
 
     private static async Task<Uri> ApplySasResolutionToUrlAsync(string? sourceUrl, SasResolutionStrategy? strategy)

--- a/src/Tes.Runner/Storage/ResolutionPolicyHandler.cs
+++ b/src/Tes.Runner/Storage/ResolutionPolicyHandler.cs
@@ -26,23 +26,15 @@ public class ResolutionPolicyHandler
 
         foreach (var output in testTaskOutputs)
         {
-            if (IncludeOutput(output))
+            if (string.IsNullOrEmpty(output.FullFileName))
             {
-                list.Add(await CreateUploadInfoWithStrategyAsync(output));
+                throw new ArgumentException("A task output is missing the full filename. Please check the task definition.");
             }
+
+            list.Add(await CreateUploadInfoWithStrategyAsync(output));
         }
 
         return list;
-    }
-
-    private static bool IncludeOutput(FileOutput output)
-    {
-        if (string.IsNullOrEmpty(output.FullFileName))
-        {
-            throw new ArgumentException("A task output is missing the full filename. Please check the task definition.");
-        }
-
-        return output.Required.GetValueOrDefault() || File.Exists(output.FullFileName);
     }
 
     /// <summary>

--- a/src/Tes.Runner/Transfer/DefaultFileInfoProvider.cs
+++ b/src/Tes.Runner/Transfer/DefaultFileInfoProvider.cs
@@ -1,22 +1,32 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.Logging;
+
 namespace Tes.Runner.Transfer;
 
 public class DefaultFileInfoProvider : IFileInfoProvider
 {
+    private readonly ILogger logger = PipelineLoggerFactory.Create<DefaultFileInfoProvider>();
+
     public long GetFileSize(string fileName)
     {
+        logger.LogInformation($"Getting file size for file: {fileName}");
+
         return new FileInfo(Environment.ExpandEnvironmentVariables(fileName)).Length;
     }
 
     public string GetFileName(string fileName)
     {
+        logger.LogInformation($"Expanding file name: {fileName}");
+
         return Environment.ExpandEnvironmentVariables(fileName);
     }
 
     public bool FileExists(string fileName)
     {
+        logger.LogInformation($"Checking if file exists: {fileName}");
+
         var fileInfo = new FileInfo(Environment.ExpandEnvironmentVariables(fileName));
 
         return fileInfo.Exists;
@@ -24,11 +34,15 @@ public class DefaultFileInfoProvider : IFileInfoProvider
 
     public string[] GetFilesInAllDirectories(string path, string searchPattern)
     {
+        logger.LogInformation($"Searching for files in path: {path} with search pattern: {searchPattern}");
+
         return Directory.GetFiles(Environment.ExpandEnvironmentVariables(path), Environment.ExpandEnvironmentVariables(searchPattern), SearchOption.AllDirectories);
     }
 
     public string[] GetFilesInDirectory(string path)
     {
+        logger.LogDebug($"Searching for files in path: {path}");
+
         return Directory.GetFiles(Environment.ExpandEnvironmentVariables(path));
     }
 }

--- a/src/Tes.Runner/Transfer/DefaultFileInfoProvider.cs
+++ b/src/Tes.Runner/Transfer/DefaultFileInfoProvider.cs
@@ -9,4 +9,26 @@ public class DefaultFileInfoProvider : IFileInfoProvider
     {
         return new FileInfo(Environment.ExpandEnvironmentVariables(fileName)).Length;
     }
+
+    public string GetFileName(string fileName)
+    {
+        return Environment.ExpandEnvironmentVariables(fileName);
+    }
+
+    public bool FileExists(string fileName)
+    {
+        var fileInfo = new FileInfo(Environment.ExpandEnvironmentVariables(fileName));
+
+        return fileInfo.Exists;
+    }
+
+    public string[] GetFilesInAllDirectories(string path, string searchPattern)
+    {
+        return Directory.GetFiles(Environment.ExpandEnvironmentVariables(path), Environment.ExpandEnvironmentVariables(searchPattern), SearchOption.AllDirectories);
+    }
+
+    public string[] GetFilesInDirectory(string path)
+    {
+        return Directory.GetFiles(Environment.ExpandEnvironmentVariables(path));
+    }
 }

--- a/src/Tes.Runner/Transfer/IFileInfoProvider.cs
+++ b/src/Tes.Runner/Transfer/IFileInfoProvider.cs
@@ -10,4 +10,12 @@ namespace Tes.Runner.Transfer;
 public interface IFileInfoProvider
 {
     long GetFileSize(string fileName);
+
+    string GetFileName(string fileName);
+
+    bool FileExists(string fileName);
+
+    string[] GetFilesInAllDirectories(string path, string searchPattern);
+
+    string[] GetFilesInDirectory(string path);
 }

--- a/src/Tes.Runner/Transfer/IFileInfoProvider.cs
+++ b/src/Tes.Runner/Transfer/IFileInfoProvider.cs
@@ -4,18 +4,18 @@
 namespace Tes.Runner.Transfer;
 
 // A simple abstraction to the file stats information.
-// The main purpose of this is to facilitate testing of scenarios such as when the file size of very
-// large files are required and is not feasible to create temp test files e.g. a 500GiB file. 
+// The main purpose of this is to facilitate testing and provide a light abstraction on top of the file system
+// and enable future extensibility to support full glob POSIX semantics.
 
 public interface IFileInfoProvider
 {
     long GetFileSize(string fileName);
 
-    string GetFileName(string fileName);
+    string GetExpandedFileName(string fileName);
 
     bool FileExists(string fileName);
 
-    string[] GetFilesInAllDirectories(string path, string searchPattern);
+    string[] GetFilesBySearchPattern(string path, string searchPattern);
 
-    string[] GetFilesInDirectory(string path);
+    string[] GetAllFilesInDirectory(string path);
 }

--- a/src/Tes.Runner/Transfer/PipelineOptionsOptimizer.cs
+++ b/src/Tes.Runner/Transfer/PipelineOptionsOptimizer.cs
@@ -76,7 +76,7 @@ namespace Tes.Runner.Transfer
 
             foreach (var taskOutput in taskOutputs)
             {
-                var fileSize = fileInfoProvider.GetFileSize(taskOutput.FullFileName!);
+                var fileSize = fileInfoProvider.GetFileSize(taskOutput.Path!);
 
                 if (fileSize / (double)currentBlockSizeInBytes > BlobSizeUtils.MaxBlobBlocksCount)
                 {

--- a/src/Tes.Runner/Transfer/PipelineOptionsOptimizer.cs
+++ b/src/Tes.Runner/Transfer/PipelineOptionsOptimizer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Tes.Runner.Models;
-
 namespace Tes.Runner.Transfer
 {
     /// <summary>
@@ -34,9 +32,9 @@ namespace Tes.Runner.Transfer
         /// Creates new pipeline options with optimized values, if default values are provided
         /// </summary>
         /// <param name="options"><see cref="BlobPipelineOptions"/> to optimize</param>
-        /// <param name="taskOutputs">If provided, it will adjust the block size to accomodate the maximum file size of the output</param>
+        /// <param name="outputs">If provided, it will adjust the block size to accomodate the maximum file size of the output</param>
         /// <returns>An optimized instance of <see cref="BlobPipelineOptions"/>. If default values are not provided, returns original options</returns>
-        public BlobPipelineOptions Optimize(BlobPipelineOptions options, List<FileOutput>? taskOutputs = default)
+        public BlobPipelineOptions Optimize(BlobPipelineOptions options, List<UploadInfo>? outputs = default)
         {
 
             //only optimize if the transfer options are the default ones
@@ -44,9 +42,9 @@ namespace Tes.Runner.Transfer
             {
                 var blockSize = options.BlockSizeBytes;
 
-                if (taskOutputs?.Count > 0)
+                if (outputs?.Count > 0)
                 {
-                    blockSize = GetAdjustedBlockSizeInBytesForUploads(options.BlockSizeBytes, taskOutputs);
+                    blockSize = GetAdjustedBlockSizeInBytesForUploads(options.BlockSizeBytes, outputs);
                 }
 
                 return CreateOptimizedThreadingAndCapacityOptions(options, blockSize);
@@ -55,7 +53,7 @@ namespace Tes.Runner.Transfer
             return options;
         }
 
-        public static BlobPipelineOptions OptimizeOptionsIfApplicable(BlobPipelineOptions blobPipelineOptions, List<FileOutput>? taskOutputs)
+        public static BlobPipelineOptions OptimizeOptionsIfApplicable(BlobPipelineOptions blobPipelineOptions, List<UploadInfo>? outputs)
         {
             //optimization is only available for Linux
             //Windows supports an implementation of ISystemInfoProvider is required.
@@ -66,17 +64,17 @@ namespace Tes.Runner.Transfer
 
             var optimizer = new PipelineOptionsOptimizer(new LinuxSystemInfoProvider());
 
-            return optimizer.Optimize(blobPipelineOptions, taskOutputs);
+            return optimizer.Optimize(blobPipelineOptions, outputs);
         }
 
-        private int GetAdjustedBlockSizeInBytesForUploads(int currentBlockSizeInBytes, List<FileOutput> taskOutputs)
+        private int GetAdjustedBlockSizeInBytesForUploads(int currentBlockSizeInBytes, List<UploadInfo> outputs)
         {
 
             BlobSizeUtils.ValidateBlockSizeForUpload(currentBlockSizeInBytes);
 
-            foreach (var taskOutput in taskOutputs)
+            foreach (var output in outputs)
             {
-                var fileSize = fileInfoProvider.GetFileSize(taskOutput.Path!);
+                var fileSize = fileInfoProvider.GetFileSize(output.FullFilePath);
 
                 if (fileSize / (double)currentBlockSizeInBytes > BlobSizeUtils.MaxBlobBlocksCount)
                 {
@@ -85,7 +83,7 @@ namespace Tes.Runner.Transfer
                     var newBlockSizeInBytes = (((int)minIncrementUnits - (BlobSizeUtils.DefaultBlockSizeBytes / BlobSizeUtils.BlockSizeIncrementUnitInBytes)) * BlobSizeUtils.BlockSizeIncrementUnitInBytes) + BlobSizeUtils.DefaultBlockSizeBytes;
 
                     //try again with the new value and see if it works for all outputs. 
-                    return GetAdjustedBlockSizeInBytesForUploads(newBlockSizeInBytes, taskOutputs);
+                    return GetAdjustedBlockSizeInBytesForUploads(newBlockSizeInBytes, outputs);
                 }
             }
 

--- a/src/Tes.RunnerCLI/README.md
+++ b/src/Tes.RunnerCLI/README.md
@@ -98,7 +98,7 @@ The outputs are defined as a list of objects with the following fields:
 | `targetUrl` | The URL of the output file | Yes |
 | `sasStrategy` | The strategy to resolve the SAS token | Yes |
 | `pathPrefix` | The prefix of the output file. If provided, the `path` is used as a search pattern. This value is not included in the target URL of the files. Ignored if the `fileType` is `Directory` | No |
-| `fileType` | `File` or `Directory`. If the value is `Directory` value in the `path` property must be a directory. Files in the directory are uploaded. However sub-directores are ignored. | Yes |
+| `fileType` | `File` or `Directory`. If the value is `Directory` value in the `path` property must be a directory. All files in the directory structure are uploaded. | Yes |
 
 ## Download and Upload
 

--- a/src/Tes.RunnerCLI/README.md
+++ b/src/Tes.RunnerCLI/README.md
@@ -51,21 +51,54 @@ The operations are defined in a TES task file using ``JSON``
     ],
     "inputs": [
         {
-            "fullFileName": "<LOCAL_PATH>",
+            "path": "<PATH>",
             "sourceUrl": "<SOURCE_URL>",
-            "sasStrategy": "None"
+            "sasStrategy": "None",
         }
     ],
     "outputs": [
         {
-            "fullFileName": "<LOCAL_PATH>",
+            "path": "<PATH>",
             "targetUrl": "<TARGET_URL>",
             "sasStrategy": "None"
+            "pathPrefix": "<PATH_PREFIX>"
+            "fileType": "<FILE_TYPE>"
         }
     ]
 }
 ```
 
+The following table describes the fields in the TES task file:
+
+| Field | Description | Required |
+| --- | --- | --- |
+| `imageTag` | The tag of the Docker image to use | Yes, only for default command (execution) |
+| `imageName` | The name of the Docker image to use | Yes, only for default command (execution) |
+| `commandsToExecute` | The list of commands to execute | Yes, only for default command (execution) |
+| `inputs` | The list of input files to download | No |
+| `outputs` | The list of output files to upload | No |
+
+### Inputs
+
+The inputs are defined as a list of objects with the following fields:
+
+| Field | Description | Required |
+| --- | --- | --- |
+| `path` | The local path of the input file.  | Yes |
+| `sourceUrl` | The URL of the input file | Yes |
+| `sasStrategy` | The strategy to resolve the SAS token | Yes |
+
+### Outputs
+
+The outputs are defined as a list of objects with the following fields:
+
+| Field | Description | Required |
+| --- | --- | --- |
+| `path` | The local path of the output file, directory or the search pattern if the `pathPrefix` is provided  | Yes |
+| `targetUrl` | The URL of the output file | Yes |
+| `sasStrategy` | The strategy to resolve the SAS token | Yes |
+| `pathPrefix` | The prefix of the output file. If provided, the `path` is used as a search pattern. This value is not included in the target URL of the files. Ignored if the `fileType` is `Directory` | No |
+| `fileType` | `File` or `Directory`. If the value is `Directory` value in the `path` property must be a directory. Files in the directory are uploaded. However sub-directores are ignored. | Yes |
 
 ## Download and Upload
 

--- a/src/Tes.RunnerCLI/TesTask.json
+++ b/src/Tes.RunnerCLI/TesTask.json
@@ -6,17 +6,20 @@
         "Hello Docker!"
     ],
     "inputs": [
-        {
-            "fullFileName": "<LOCAL_PATH>",
-            "sourceUrl": "<SOURCE_URL>",
-            "sasStrategy": "None"
-        }
+      {
+        "fullFileName": "<LOCAL_PATH>",
+        "sourceUrl": "<SOURCE_URL>",
+        "fileType": "File",
+        "sasStrategy": "None",
+        "pathPrefix": "<PATH_PREFIX>"
+      }
     ],
     "outputs": [
-        {
-            "fullFileName": "<LOCAL_PATH>",
-            "targetUrl": "<TARGET_URL>",
-            "sasStrategy": "None"
-        }
+      {
+        "fullFileName": "<LOCAL_PATH>",
+        "targetUrl": "<TARGET_URL>",
+        "sasStrategy": "None",
+        "fileType": "File"
+      }
     ]
 }

--- a/src/Tes.RunnerCLI/TesTask.json
+++ b/src/Tes.RunnerCLI/TesTask.json
@@ -7,7 +7,7 @@
     ],
     "inputs": [
       {
-        "fullFileName": "<LOCAL_PATH>",
+        "path": "<LOCAL_PATH>",
         "sourceUrl": "<SOURCE_URL>",
         "fileType": "File",
         "sasStrategy": "None",
@@ -16,7 +16,7 @@
     ],
     "outputs": [
       {
-        "fullFileName": "<LOCAL_PATH>",
+        "path": "<LOCAL_PATH>",
         "targetUrl": "<TARGET_URL>",
         "sasStrategy": "None",
         "fileType": "File"

--- a/src/Tes/Models/TesOutput.cs
+++ b/src/Tes/Models/TesOutput.cs
@@ -61,6 +61,12 @@ namespace Tes.Models
         public TesFileType Type { get; set; }
 
         /// <summary>
+        /// Gets or Sets Path Prefix
+        /// </summary>
+        [DataMember(Name = "pathPrefix")]
+        public string PathPrefix { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -72,6 +78,7 @@ namespace Tes.Models
                 .Append("  Url: ").Append(Url).Append('\n')
                 .Append("  Path: ").Append(Path).Append('\n')
                 .Append("  Type: ").Append(Type).Append('\n')
+                .Append("  PathPrefix: ").Append(PathPrefix).Append('\n')
                 .Append("}\n")
                 .ToString();
 
@@ -129,7 +136,11 @@ namespace Tes.Models
                 (
                     Type == other.Type ||
                     Type.Equals(other.Type)
-                ),
+                ) &&
+                (
+                    PathPrefix == other.PathPrefix || 
+                    PathPrefix.Equals(other.PathPrefix)
+                    ),
             };
 
         /// <summary>
@@ -160,6 +171,11 @@ namespace Tes.Models
                 if (Path is not null)
                 {
                     hashCode = hashCode * 59 + Path.GetHashCode();
+                }
+
+                if (PathPrefix is not null)
+                {
+                    hashCode = hashCode * 59 + PathPrefix.GetHashCode();
                 }
 
                 hashCode = hashCode * 59 + Type.GetHashCode();

--- a/src/Tes/Models/TesOutput.cs
+++ b/src/Tes/Models/TesOutput.cs
@@ -138,7 +138,7 @@ namespace Tes.Models
                     Type.Equals(other.Type)
                 ) &&
                 (
-                    PathPrefix == other.PathPrefix || 
+                    PathPrefix == other.PathPrefix ||
                     PathPrefix.Equals(other.PathPrefix)
                     ),
             };

--- a/src/TesApi.Tests/BatchSchedulerTests.cs
+++ b/src/TesApi.Tests/BatchSchedulerTests.cs
@@ -1577,7 +1577,7 @@ namespace TesApi.Tests
             var fileInputs = JsonConvert.DeserializeObject<Tes.Runner.Models.NodeTask>(downloadFilesScriptContent)?.Inputs ?? Enumerable.Empty<Tes.Runner.Models.FileInput>().ToList();
 
             return fileInputs
-                .Select(f => new FileToDownload { LocalPath = f.FullFileName, StorageUrl = f.SourceUrl });
+                .Select(f => new FileToDownload { LocalPath = f.Path, StorageUrl = f.SourceUrl });
         }
 
         private static TestServices.TestServiceProvider<IBatchScheduler> GetServiceProvider(AzureProxyReturnValues azureProxyReturn = default)

--- a/src/TesApi.Tests/expectedBasicJsonResult.json
+++ b/src/TesApi.Tests/expectedBasicJsonResult.json
@@ -19,7 +19,8 @@
       "description": "string",
       "url": "string",
       "path": "string",
-      "type": "FILE"
+      "type": "FILE",
+      "pathPrefix": "string"
     }
   ],
   "resources": {

--- a/src/TesApi.Tests/expectedFullJsonResult.json
+++ b/src/TesApi.Tests/expectedFullJsonResult.json
@@ -20,7 +20,8 @@
       "description": "string",
       "url": "string",
       "path": "string",
-      "type": "FILE"
+      "type": "FILE",
+      "pathPrefix": "string"
     }
   ],
   "resources": {

--- a/src/TesApi.Tests/tesTaskExample.json
+++ b/src/TesApi.Tests/tesTaskExample.json
@@ -19,7 +19,8 @@
       "description": "string",
       "url": "string",
       "path": "string",
-      "type": "FILE"
+      "type": "FILE",
+      "pathPrefix": "string"
     }
   ],
   "resources": {

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -1083,7 +1083,7 @@ namespace TesApi.Web
             var uploadMetricsScriptSasUrl = await storageAccessProvider.GetInternalTesTaskBlobUrlAsync(task, UploadFilesScriptFileName, cancellationToken);
             var uploadMetricsScriptContent = new NodeTask
             {
-                Outputs = new List<FileOutput>() { new FileOutput { Required = true, FullFileName = metricsName, TargetUrl = uploadMetricsScriptSasUrl, FileType = FileType.File, SasStrategy = SasResolutionStrategy.None } }
+                Outputs = new List<FileOutput>() { new FileOutput { Path = metricsName, TargetUrl = uploadMetricsScriptSasUrl, FileType = FileType.File, SasStrategy = SasResolutionStrategy.None } }
             };
 
             sb.AppendLinuxLine($"write_ts DownloadStart && \\");

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -1018,7 +1018,7 @@ namespace TesApi.Web
             {
                 MetricsFilename = metricsName,
                 OutputsMetricsFormat = "FileUploadSizeInBytes={Size}",
-                Outputs = filesToUpload.Select(f => new FileOutput { TargetUrl = f.Url, Path = LocalizeLocalPath(f.Path), FileType = ConvertFileType(f.Type), SasStrategy = SasResolutionStrategy.None, PathPrefix = f.PathPrefix}).ToList()
+                Outputs = filesToUpload.Select(f => new FileOutput { TargetUrl = f.Url, Path = LocalizeLocalPath(f.Path), FileType = ConvertFileType(f.Type), SasStrategy = SasResolutionStrategy.None, PathPrefix = f.PathPrefix }).ToList()
             };
 
             var executor = task.Executors.First();

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -1018,7 +1018,7 @@ namespace TesApi.Web
             {
                 MetricsFilename = metricsName,
                 OutputsMetricsFormat = "FileUploadSizeInBytes={Size}",
-                Outputs = filesToUpload.Select(f => new FileOutput { TargetUrl = f.Url, Path = LocalizeLocalPath(f.Path), FileType = ConvertFileType(f.Type), SasStrategy = SasResolutionStrategy.None }).ToList()
+                Outputs = filesToUpload.Select(f => new FileOutput { TargetUrl = f.Url, Path = LocalizeLocalPath(f.Path), FileType = ConvertFileType(f.Type), SasStrategy = SasResolutionStrategy.None, PathPrefix = f.PathPrefix}).ToList()
             };
 
             var executor = task.Executors.First();

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -993,7 +993,7 @@ namespace TesApi.Web
             {
                 MetricsFilename = metricsName,
                 InputsMetricsFormat = "FileDownloadSizeInBytes={Size}",
-                Inputs = filesToDownload.Select(f => new FileInput { SourceUrl = f.Url, FullFileName = LocalizeLocalPath(f.Path), SasStrategy = SasResolutionStrategy.None }).ToList()
+                Inputs = filesToDownload.Select(f => new FileInput { SourceUrl = f.Url, Path = LocalizeLocalPath(f.Path), SasStrategy = SasResolutionStrategy.None }).ToList()
             };
 
             var filesToUpload = Array.Empty<TesOutput>();
@@ -1018,7 +1018,7 @@ namespace TesApi.Web
             {
                 MetricsFilename = metricsName,
                 OutputsMetricsFormat = "FileUploadSizeInBytes={Size}",
-                Outputs = filesToUpload.Select(f => new FileOutput { TargetUrl = f.Url, FullFileName = LocalizeLocalPath(f.Path), FileType = ConvertFileType(f.Type), SasStrategy = SasResolutionStrategy.None }).ToList()
+                Outputs = filesToUpload.Select(f => new FileOutput { TargetUrl = f.Url, Path = LocalizeLocalPath(f.Path), FileType = ConvertFileType(f.Type), SasStrategy = SasResolutionStrategy.None }).ToList()
             };
 
             var executor = task.Executors.First();


### PR DESCRIPTION
Closes #245
Addresses #8

This PR includes:
 - A new class: `FileOperationResolver` that performs the resolution process for inputs and outputs of the runner task. 
   -  The resolution process consists of: 
      - Expanding, directories or paths with wildcards (if a `path_prefix` is provided).
         - Wildcard support is limited to the functionality of the standard .NET library (`Directory.GetFiles()`).
      - Apply the SAS resolution strategy for each expanded item.
- Additional changes:
  - Renamed, `FullFileName` property to `Path` in the runner task model (`NodeTask`), to better align with the TES spec and its semantics.
  - Added the property `PathPrefix` to the `TestOut` model in the Web API - 1.1 prerequisite.
