### PR TITLE
[277] SocketException is now retriable

### DIFF
--- a/src/Tes.Runner.Test/Transfer/BlobBlockApiHttpUtilsTests.cs
+++ b/src/Tes.Runner.Test/Transfer/BlobBlockApiHttpUtilsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Net;
+using System.Net.Sockets;
 using System.Xml;
 using Moq;
 using Moq.Protected;
@@ -81,6 +82,7 @@ namespace Tes.Runner.Test.Transfer
         [DataTestMethod]
         [DataRow(typeof(TimeoutException))]
         [DataRow(typeof(IOException))]
+        [DataRow(typeof(SocketException))]
         public async Task ExecuteHttpRequestAsync_TaskIsCancelledWithRetriableException_RetriesAndSucceeds(
             Type innerExceptionType)
         {

--- a/src/Tes.Runner/Transfer/BlobBlockApiHttpUtils.cs
+++ b/src/Tes.Runner/Transfer/BlobBlockApiHttpUtils.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Sockets;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Polly;
@@ -165,10 +166,11 @@ public class BlobBlockApiHttpUtils
             return false;
         }
 
-        if (ex is TimeoutException or IOException)
+        if (ex is TimeoutException or IOException or SocketException)
         {
             return true;
         }
+
 
         return ContainsRetriableException(ex.InnerException);
     }

--- a/src/Tes.Runner/Transfer/BlobOperationPipeline.cs
+++ b/src/Tes.Runner/Transfer/BlobOperationPipeline.cs
@@ -53,7 +53,6 @@ public abstract class BlobOperationPipeline : IBlobPipeline
 
     protected async Task<long> ExecutePipelineAsync(List<BlobOperationInfo> operations)
     {
-        var cancellationTokenSource = new CancellationTokenSource();
         var pipelineTasks = new List<Task>
         {
             partsProducer.StartPartsProducersAsync(operations, ReadBufferChannel),
@@ -89,7 +88,7 @@ public abstract class BlobOperationPipeline : IBlobPipeline
             var completedTask = await Task.WhenAny(taskList);
             if (completedTask.IsFaulted)
             {
-                throw completedTask.Exception!.InnerException!;
+                throw completedTask.Exception?.InnerException!;
             }
             if (completedTask.IsCanceled)
             {


### PR DESCRIPTION
Closes: #277 

This PR includes:
 - Runner retries when a SocketException is thrown under load.
 - Fails fast when any of the top-level processors fails. 