### PR TITLE
[275] Removes default storage account dependency when running in Terra

### DIFF
--- a/src/TesApi.Tests/BatchSchedulerTests.cs
+++ b/src/TesApi.Tests/BatchSchedulerTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Batch;
 using Microsoft.Azure.Batch.Common;
@@ -1488,6 +1489,9 @@ namespace TesApi.Tests
         private static Action<Mock<IAzureProxy>> GetMockAzureProxy(AzureProxyReturnValues azureProxyReturnValues)
             => azureProxy =>
             {
+                azureProxy.Setup(a => a.BlobExistsAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(true);
+
                 azureProxy.Setup(a => a.GetActivePoolsAsync(It.IsAny<string>()))
                     .Returns(AsyncEnumerable.Empty<CloudPool>());
 

--- a/src/TesApi.Tests/ConfigurationUtilsTests.cs
+++ b/src/TesApi.Tests/ConfigurationUtilsTests.cs
@@ -104,6 +104,7 @@ namespace TesApi.Tests
                 }
              };
 
+            azureProxy.Setup(a => a.BlobExistsAsync(It.IsAny<Uri>(), It.IsAny<System.Threading.CancellationToken>())).Returns(Task.FromResult(true));
             azureProxy.Setup(a => a.DownloadBlobAsync(It.IsAny<Uri>(), It.IsAny<System.Threading.CancellationToken>())).Returns(Task.FromResult(allowedVmSizesFileContent));
             azureProxy.Setup(a => a.GetStorageAccountInfoAsync("defaultstorageaccount", It.IsAny<System.Threading.CancellationToken>())).Returns(Task.FromResult(storageAccountInfos["defaultstorageaccount"]));
             azureProxy.Setup(a => a.GetStorageAccountKeyAsync(It.IsAny<StorageAccountInfo>(), It.IsAny<System.Threading.CancellationToken>())).Returns(Task.FromResult("Key1"));

--- a/src/TesApi.Tests/Storage/DefaultStorageAccessProviderTests.cs
+++ b/src/TesApi.Tests/Storage/DefaultStorageAccessProviderTests.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Tes.Models;
+using TesApi.Web;
+using TesApi.Web.Options;
+using TesApi.Web.Storage;
+
+namespace TesApi.Tests.Storage
+{
+    [TestClass, TestCategory("Unit")]
+    public class DefaultStorageAccessProviderTests
+    {
+        private DefaultStorageAccessProvider defaultStorageAccessProvider;
+        private Mock<IAzureProxy> azureProxyMock;
+        private StorageOptions storageOptions;
+        private StorageAccountInfo storageAccountInfo;
+        private const string DefaultStorageAccountName = "defaultstorage";
+        private const string StorageAccountBlobEndpoint = $"https://{DefaultStorageAccountName}.blob.windows.net";
+
+        [TestInitialize]
+        public void Setup()
+        {
+            azureProxyMock = new Mock<IAzureProxy>();
+            storageOptions = new StorageOptions() { DefaultAccountName = DefaultStorageAccountName };
+            var subscriptionId = Guid.NewGuid().ToString();
+            storageAccountInfo = new StorageAccountInfo()
+            {
+                BlobEndpoint = StorageAccountBlobEndpoint,
+                Name = DefaultStorageAccountName,
+                Id = $"/subscriptions/{subscriptionId}/resourceGroups/mrg/providers/Microsoft.Storage/storageAccounts/{DefaultStorageAccountName}",
+                SubscriptionId = subscriptionId
+            };
+            azureProxyMock.Setup(p => p.GetStorageAccountKeyAsync(It.IsAny<StorageAccountInfo>(), It.IsAny<CancellationToken>())).ReturnsAsync(GenerateRandomTestAzureStorageKey());
+            azureProxyMock.Setup(p => p.GetStorageAccountInfoAsync(It.Is<string>(s => s.Equals(DefaultStorageAccountName)), It.IsAny<CancellationToken>())).ReturnsAsync(storageAccountInfo);
+            defaultStorageAccessProvider = new DefaultStorageAccessProvider(NullLogger<DefaultStorageAccessProvider>.Instance, Options.Create(storageOptions), azureProxyMock.Object);
+        }
+
+        [TestMethod]
+        [DataRow("script/foo.sh")]
+        [DataRow("/script/foo.sh")]
+        public async Task GetInternalTesTaskBlobUrlAsync_BlobPathIsProvided_ReturnsValidURLWithDefaultStorageAccountTesInternalContainerAndTaskId(
+            string blobName)
+        {
+            var task = new TesTask { Name = "taskName", Id = Guid.NewGuid().ToString() };
+            var url = await defaultStorageAccessProvider.GetInternalTesTaskBlobUrlAsync(task, blobName, CancellationToken.None);
+
+            Assert.IsNotNull(url);
+            var uri = new Uri(url);
+            Assert.AreEqual($"{StorageAccountBlobEndpoint}{StorageAccessProvider.TesExecutionsPathPrefix}/{task.Id}/{blobName.TrimStart('/')}", ToHostWithAbsolutePathOnly(uri));
+        }
+
+        private static string ToHostWithAbsolutePathOnly(Uri uri)
+        {
+            return $"{uri.Scheme}://{uri.Host}{uri.AbsolutePath}";
+        }
+
+        [TestMethod]
+        [DataRow("script/foo.sh")]
+        [DataRow("/script/foo.sh")]
+        public async Task GetInternalTesTaskBlobUrlAsync_BlobPathAndInternalPathPrefixIsProvided_ReturnsValidURLWithDefaultStorageAccountAndInternalPathPrefixAppended(
+            string blobName)
+        {
+            var internalPathPrefix = "internalPathPrefix";
+
+            var task = new TesTask { Name = "taskName", Id = Guid.NewGuid().ToString() };
+            task.Resources = new TesResources();
+            task.Resources.BackendParameters = new Dictionary<string, string>
+            {
+                { TesResources.SupportedBackendParameters.internal_path_prefix.ToString(), internalPathPrefix }
+            };
+            var url = await defaultStorageAccessProvider.GetInternalTesTaskBlobUrlAsync(task, blobName, CancellationToken.None);
+
+            Assert.IsNotNull(url);
+            var uri = new Uri(url);
+            Assert.AreEqual($"{StorageAccountBlobEndpoint}/{internalPathPrefix}/{blobName.TrimStart('/')}", ToHostWithAbsolutePathOnly(uri));
+        }
+
+        private static string GenerateRandomTestAzureStorageKey()
+        {
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+            var length = 64;
+            var random = new Random();
+            var result = new StringBuilder(length);
+
+            for (int i = 0; i < length; i++)
+            {
+                result.Append(chars[random.Next(chars.Length)]);
+            }
+
+            return result.ToString();
+        }
+    }
+}

--- a/src/TesApi.Tests/TerraApiStubData.cs
+++ b/src/TesApi.Tests/TerraApiStubData.cs
@@ -15,14 +15,17 @@ public class TerraApiStubData
     public const string WsmApiHost = "https://wsm.host";
     public const string ResourceGroup = "mrg-terra-dev-previ-20191228";
     public const string WorkspaceAccountName = "lzaccount1";
-    public const string WorkspaceStorageContainerName = "sc-ef9fed44-dba6-4825-868c-b00208522382";
     public const string SasToken = "SASTOKENSTUB=";
+    private const string WorkspaceIdValue = "41aa9346-670f-4206-8b6f-6b921a564bdd";
+
+    public const string WorkspaceStorageContainerName = $"sc-{WorkspaceIdValue}";
     public const string WsmGetSasResponseStorageUrl = $"https://{WorkspaceAccountName}.blob.core.windows.net/{WorkspaceStorageContainerName}";
 
     public Guid LandingZoneId { get; } = Guid.NewGuid();
     public Guid SubscriptionId { get; } = Guid.NewGuid();
-    public Guid WorkspaceId { get; } = Guid.NewGuid();
     public Guid ContainerResourceId { get; } = Guid.NewGuid();
+    public Guid WorkspaceId { get; } = Guid.Parse(WorkspaceIdValue);
+
     public string BatchAccountName => "lzee170c71b6cf678cfca744";
     public string Region => "westus3";
     public string BatchAccountId =>
@@ -310,7 +313,7 @@ public class TerraApiStubData
             Common = new ApiCommon(),
             AzureBatchPool = new ApiAzureBatchPool()
             {
-                UserAssignedIdentities = new ApiUserAssignedIdentity[]
+                UserAssignedIdentities = new[]
                 {
                     new ApiUserAssignedIdentity()
                     {

--- a/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
+++ b/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Tes.Models;
 using TesApi.Web;
 using TesApi.Web.Management.Clients;
 using TesApi.Web.Management.Configuration;
@@ -123,6 +124,36 @@ namespace TesApi.Tests
             var uri = new Uri(url);
 
             Assert.AreEqual(uri.AbsolutePath, $"/{TerraApiStubData.WorkspaceStorageContainerName}/blobName");
+        }
+
+        [TestMethod]
+        [DataRow("script/foo.sh")]
+        [DataRow("/script/foo.sh")]
+        public async Task GetInternalTesBlobUrlAsync_BlobPathIsProvided_ReturnsValidURLWithWsmContainerAndTesPrefixAppended(
+            string blobName)
+        {
+            SetUpTerraApiClient();
+
+            var url = await terraStorageAccessProvider.GetInternalTesBlobUrlAsync(blobName, CancellationToken.None);
+
+            Assert.IsNotNull(url);
+            var uri = new Uri(url);
+            Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}{StorageAccessProvider.TesExecutionsPathPrefix}/{blobName.TrimStart('/')}", uri.AbsolutePath);
+        }
+
+        [TestMethod]
+        [DataRow("script/foo.sh")]
+        [DataRow("/script/foo.sh")]
+        public async Task GetInternalTesTaskBlobUrlAsync_BlobPathIsProvided_ReturnsValidURLWithWsmContainerTaskIdAndTesPrefixAppended(
+            string blobName)
+        {
+            SetUpTerraApiClient();
+            var task = new TesTask { Name = "taskName", Id = Guid.NewGuid().ToString() };
+            var url = await terraStorageAccessProvider.GetInternalTesTaskBlobUrlAsync(task, blobName, CancellationToken.None);
+
+            Assert.IsNotNull(url);
+            var uri = new Uri(url);
+            Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}{StorageAccessProvider.TesExecutionsPathPrefix}/{task.Id}/{blobName.TrimStart('/')}", uri.AbsolutePath);
         }
     }
 }

--- a/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
+++ b/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -154,6 +155,28 @@ namespace TesApi.Tests
             Assert.IsNotNull(url);
             var uri = new Uri(url);
             Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}{StorageAccessProvider.TesExecutionsPathPrefix}/{task.Id}/{blobName.TrimStart('/')}", uri.AbsolutePath);
+        }
+
+        [TestMethod]
+        [DataRow("script/foo.sh")]
+        [DataRow("/script/foo.sh")]
+        public async Task GetInternalTesTaskBlobUrlAsync_BlobPathAndInternalPathPrefixIsProvided_ReturnsValidURLWithWsmContainerTaskIdAndInternalPathPrefixAppended(
+            string blobName)
+        {
+            var internalPathPrefix = "internalPathPrefix";
+
+            SetUpTerraApiClient();
+            var task = new TesTask { Name = "taskName", Id = Guid.NewGuid().ToString() };
+            task.Resources = new TesResources();
+            task.Resources.BackendParameters = new Dictionary<string, string>
+            {
+                { TesResources.SupportedBackendParameters.internal_path_prefix.ToString(), internalPathPrefix }
+            };
+            var url = await terraStorageAccessProvider.GetInternalTesTaskBlobUrlAsync(task, blobName, CancellationToken.None);
+
+            Assert.IsNotNull(url);
+            var uri = new Uri(url);
+            Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}/{internalPathPrefix}/{blobName.TrimStart('/')}", uri.AbsolutePath);
         }
     }
 }

--- a/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
+++ b/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
@@ -139,7 +139,7 @@ namespace TesApi.Tests
 
             Assert.IsNotNull(url);
             var uri = new Uri(url);
-            Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}{StorageAccessProvider.TesExecutionsPathPrefix}/{blobName.TrimStart('/')}", uri.AbsolutePath);
+            Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}/{terraOptions.AppId}{StorageAccessProvider.TesExecutionsPathPrefix}/{blobName.TrimStart('/')}", uri.AbsolutePath);
         }
 
         [TestMethod]
@@ -154,7 +154,7 @@ namespace TesApi.Tests
 
             Assert.IsNotNull(url);
             var uri = new Uri(url);
-            Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}{StorageAccessProvider.TesExecutionsPathPrefix}/{task.Id}/{blobName.TrimStart('/')}", uri.AbsolutePath);
+            Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}/{terraOptions.AppId}{StorageAccessProvider.TesExecutionsPathPrefix}/{task.Id}/{blobName.TrimStart('/')}", uri.AbsolutePath);
         }
 
         [TestMethod]

--- a/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
+++ b/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
@@ -14,6 +14,7 @@ using TesApi.Web;
 using TesApi.Web.Management.Clients;
 using TesApi.Web.Management.Configuration;
 using TesApi.Web.Management.Models.Terra;
+using TesApi.Web.Options;
 using TesApi.Web.Storage;
 
 namespace TesApi.Tests
@@ -31,6 +32,7 @@ namespace TesApi.Tests
         private TerraApiStubData terraApiStubData;
         private Mock<IOptions<TerraOptions>> optionsMock;
         private TerraOptions terraOptions;
+        private BatchSchedulingOptions batchSchedulingOptions;
 
         [TestInitialize]
         public void SetUp()
@@ -39,10 +41,11 @@ namespace TesApi.Tests
             wsmApiClientMock = new Mock<TerraWsmApiClient>();
             optionsMock = new Mock<IOptions<TerraOptions>>();
             terraOptions = terraApiStubData.GetTerraOptions();
+            batchSchedulingOptions = new BatchSchedulingOptions() { Prefix = Guid.NewGuid().ToString() };
             optionsMock.Setup(o => o.Value).Returns(terraOptions);
             azureProxyMock = new Mock<IAzureProxy>();
             terraStorageAccessProvider = new TerraStorageAccessProvider(NullLogger<TerraStorageAccessProvider>.Instance,
-                optionsMock.Object, azureProxyMock.Object, wsmApiClientMock.Object);
+                optionsMock.Object, azureProxyMock.Object, wsmApiClientMock.Object, batchSchedulingOptions);
         }
 
         [TestMethod]
@@ -139,7 +142,7 @@ namespace TesApi.Tests
 
             Assert.IsNotNull(url);
             var uri = new Uri(url);
-            Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}/{terraOptions.AppId}{StorageAccessProvider.TesExecutionsPathPrefix}/{blobName.TrimStart('/')}", uri.AbsolutePath);
+            Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}/{batchSchedulingOptions.Prefix}{StorageAccessProvider.TesExecutionsPathPrefix}/{blobName.TrimStart('/')}", uri.AbsolutePath);
         }
 
         [TestMethod]
@@ -154,7 +157,7 @@ namespace TesApi.Tests
 
             Assert.IsNotNull(url);
             var uri = new Uri(url);
-            Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}/{terraOptions.AppId}{StorageAccessProvider.TesExecutionsPathPrefix}/{task.Id}/{blobName.TrimStart('/')}", uri.AbsolutePath);
+            Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}/{batchSchedulingOptions.Prefix}{StorageAccessProvider.TesExecutionsPathPrefix}/{task.Id}/{blobName.TrimStart('/')}", uri.AbsolutePath);
         }
 
         [TestMethod]

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -965,18 +965,7 @@ namespace TesApi.Web
                 .Where(f => f?.Url?.StartsWith("drs://", StringComparison.OrdinalIgnoreCase) == true)
                 .ToList();
 
-            //foreach (var output in task.Outputs)
-            //{
-            //    if (!output.Path.StartsWith($"{CromwellPathPrefix}/", StringComparison.OrdinalIgnoreCase) && !output.Path.StartsWith($"{ExecutionsPathPrefix}/", StringComparison.OrdinalIgnoreCase))
-            //    {
-            //        throw new TesException("InvalidOutputPath", $"Unsupported output path '{output.Path}' for task Id {task.Id}. Must start with {CromwellPathPrefix} or {ExecutionsPathPrefix}");
-            //    }
-            //}
-
-            //var storageUploadPath = GetStorageUploadPath(task);
             var metricsName = "metrics.txt";
-            //var metricsPath = $"/{storageUploadPath}/{metricsName}";
-            //var metricsUrl = new Uri(await storageAccessProvider.MapLocalPathToSasUrlAsync(metricsPath, cancellationToken, getContainerSas: true));
 
             var additionalInputFiles = new List<TesInput>();
             // TODO: Cromwell bug: Cromwell command write_tsv() generates a file in the execution directory, for example execution/write_tsv_3922310b441805fc43d52f293623efbc.tmp. These are not passed on to TES inputs.
@@ -1000,7 +989,6 @@ namespace TesApi.Web
                 .Union(additionalInputFiles)
                 .Select(async f => await GetTesInputFileUrlAsync(f, task, queryStringsToRemoveFromLocalFilePaths, cancellationToken)));
 
-            //var downloadFilesScriptPath = $"/{storageUploadPath}/{DownloadFilesScriptFileName}";
             var downloadFilesScriptContent = new NodeTask
             {
                 MetricsFilename = metricsName,
@@ -1023,7 +1011,6 @@ namespace TesApi.Web
                         }));
             }
 
-            //var uploadFilesScriptPath = $"/{storageUploadPath}/{UploadFilesScriptFileName}";
             // Ignore missing stdout/stderr files. CWL workflows have an issue where if the stdout/stderr are redirected, they are still listed in the TES outputs
             // Ignore any other missing files and directories. WDL tasks can have optional output files.
             // Implementation: do not set Required to True (it defaults to False)
@@ -1047,7 +1034,6 @@ namespace TesApi.Web
             var executorImageIsPublic = containerRegistryProvider.IsImagePublic(executor.Image);
             var dockerInDockerImageIsPublic = containerRegistryProvider.IsImagePublic(dockerInDockerImageName);
 
-            //var batchScriptPath = $"/{storageUploadPath}/{BatchScriptFileName}";
             var sb = new StringBuilder();
 
             sb.AppendLinuxLine($"write_kv() {{ echo \"$1=$2\" >> $AZ_BATCH_TASK_WORKING_DIR/metrics.txt; }} && \\");  // Function that appends key=value pair to metrics.txt file

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -370,7 +370,7 @@ namespace TesApi.Web
         /// <inheritdoc/>
         public async Task UploadTaskRunnerIfNeeded(CancellationToken cancellationToken)
         {
-            var blobUri = new Uri(await storageAccessProvider.GetInternalTesBlobUrlAsync(NodeRunnerTaskInfoFilename, cancellationToken));
+            var blobUri = new Uri(await storageAccessProvider.GetInternalTesBlobUrlAsync(NodeTaskRunnerFilename, cancellationToken));
             var blobProperties = await azureProxy.GetBlobPropertiesAsync(blobUri, cancellationToken);
             if (!(await File.ReadAllTextAsync(Path.Combine(AppContext.BaseDirectory, $"scripts/{NodeTaskRunnerMD5HashFilename}"), cancellationToken)).Trim().Equals(blobProperties?.ContentMD5, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/TesApi.Web/ConfigurationUtils.cs
+++ b/src/TesApi.Web/ConfigurationUtils.cs
@@ -72,8 +72,6 @@ namespace TesApi.Web
         /// <returns></returns>
         public async Task<List<string>> ProcessAllowedVmSizesConfigurationFileAsync(CancellationToken cancellationToken)
         {
-            // var supportedVmSizesFilePath = $"/{defaultStorageAccountName}/configuration/supported-vm-sizes";
-            // var allowedVmSizesFilePath = $"/{defaultStorageAccountName}/configuration/allowed-vm-sizes";
             var supportedVmSizesUrl = new Uri(await storageAccessProvider.GetInternalTesBlobUrlAsync("/configuration/supported-vm-sizes", cancellationToken));
             var allowedVmSizesUrl = new Uri(await storageAccessProvider.GetInternalTesBlobUrlAsync("/configuration/allowed-vm-sizes", cancellationToken));
 

--- a/src/TesApi.Web/Management/Configuration/TerraOptions.cs
+++ b/src/TesApi.Web/Management/Configuration/TerraOptions.cs
@@ -15,7 +15,6 @@ public class TerraOptions
     /// </summary>
     public const string SectionName = "Terra";
     private const int DefaultSasTokenExpirationInSeconds = 60 * 24 * 3; // 3 days
-    private static readonly string DefaultAppId = Guid.NewGuid().ToString();
 
     /// <summary>
     /// Landing zone id containing the Tes back-end resources
@@ -61,9 +60,4 @@ public class TerraOptions
     /// Sas token allowed Ip ranges
     /// </summary>
     public string SasAllowedIpRange { get; set; }
-
-    /// <summary>
-    /// Unique identifier of the TES instance running in Terra
-    /// </summary>
-    public string AppId { get; set; } = DefaultAppId;
 }

--- a/src/TesApi.Web/Management/Configuration/TerraOptions.cs
+++ b/src/TesApi.Web/Management/Configuration/TerraOptions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-
 namespace TesApi.Web.Management.Configuration;
 
 /// <summary>

--- a/src/TesApi.Web/Management/Configuration/TerraOptions.cs
+++ b/src/TesApi.Web/Management/Configuration/TerraOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+
 namespace TesApi.Web.Management.Configuration;
 
 /// <summary>
@@ -13,6 +15,7 @@ public class TerraOptions
     /// </summary>
     public const string SectionName = "Terra";
     private const int DefaultSasTokenExpirationInSeconds = 60 * 24 * 3; // 3 days
+    private static readonly string DefaultAppId = Guid.NewGuid().ToString();
 
     /// <summary>
     /// Landing zone id containing the Tes back-end resources
@@ -49,7 +52,7 @@ public class TerraOptions
     /// </summary>
     public string WorkspaceId { get; set; }
 
-    /// <summary>
+    /// <summary>`
     /// Sas token expiration in seconds
     /// </summary>
     public int SasTokenExpirationInSeconds { get; set; } = DefaultSasTokenExpirationInSeconds;
@@ -58,4 +61,9 @@ public class TerraOptions
     /// Sas token allowed Ip ranges
     /// </summary>
     public string SasAllowedIpRange { get; set; }
+
+    /// <summary>
+    /// Unique identifier of the TES instance running in Terra
+    /// </summary>
+    public string AppId { get; set; } = DefaultAppId;
 }

--- a/src/TesApi.Web/Storage/DefaultStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/DefaultStorageAccessProvider.cs
@@ -174,7 +174,9 @@ namespace TesApi.Web.Storage
             if (task.Resources?.ContainsBackendParameterValue(TesResources.SupportedBackendParameters
                     .internal_path_prefix) == true)
             {
-                return await MapLocalPathToSasUrlAsync($"/{defaultStorageAccountName}/{task.Resources.GetBackendParameterValue(TesResources.SupportedBackendParameters.internal_path_prefix).Trim('/')}", cancellationToken, true);
+                var blobPathWithPathPrefix =
+                    $"/{defaultStorageAccountName}/{task.Resources.GetBackendParameterValue(TesResources.SupportedBackendParameters.internal_path_prefix).Trim('/')}{normalizedBlobPath}";
+                return await MapLocalPathToSasUrlAsync(blobPathWithPathPrefix, cancellationToken, true);
             }
 
             return await GetInternalTesBlobUrlAsync($"/{task.Id}{normalizedBlobPath}", cancellationToken);

--- a/src/TesApi.Web/Storage/DefaultStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/DefaultStorageAccessProvider.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using System.Web;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Identity.Client;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Auth;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -56,17 +55,6 @@ namespace TesApi.Web.Storage
                 })
                 .Where(storageAccountInfo => storageAccountInfo is not null)
                 .ToList();
-        }
-
-        /// <inheritdoc />
-        public override async Task<string> UploadAsInternalTesTaskBlobAsync(TesTask tesTask, string blobPath, string content,
-            CancellationToken cancellationToken)
-        {
-            var url = await GetInternalTesTaskBlobUrlAsync(tesTask, blobPath, cancellationToken);
-            var uri = new Uri(url);
-            await AzureProxy.UploadBlobAsync(uri, content, cancellationToken);
-
-            return url;
         }
 
         /// <inheritdoc />
@@ -165,13 +153,13 @@ namespace TesApi.Web.Storage
         }
 
         /// <inheritdoc />
-        public override async Task<string> GetTesInternalBlobUrlAsync(string blobPath, CancellationToken cancellationToken)
+        public override async Task<string> GetInternalTesBlobUrlAsync(string blobPath, CancellationToken cancellationToken)
         {
             var normalizedBlobPath = NormalizedBlobPath(blobPath);
 
             return await MapLocalPathToSasUrlAsync($"/{defaultStorageAccountName}{TesExecutionsPathPrefix}{normalizedBlobPath}", cancellationToken, true);
         }
-        
+
 
         private static string NormalizedBlobPath(string blobPath)
         {
@@ -189,7 +177,7 @@ namespace TesApi.Web.Storage
                 return await MapLocalPathToSasUrlAsync($"/{defaultStorageAccountName}/{task.Resources.GetBackendParameterValue(TesResources.SupportedBackendParameters.internal_path_prefix).Trim('/')}", cancellationToken, true);
             }
 
-            return await GetTesInternalBlobUrlAsync($"/{task.Id}{normalizedBlobPath}", cancellationToken);
+            return await GetInternalTesBlobUrlAsync($"/{task.Id}{normalizedBlobPath}", cancellationToken);
         }
 
         private async Task<bool> TryGetStorageAccountInfoAsync(string accountName, CancellationToken cancellationToken, Action<StorageAccountInfo> onSuccess = null)

--- a/src/TesApi.Web/Storage/IStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/IStorageAccessProvider.cs
@@ -22,6 +22,14 @@ namespace TesApi.Web.Storage
         public Task<string> DownloadBlobAsync(string blobRelativePath, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Retrieves file content
+        /// </summary>
+        /// <param name="blobAbsoluteUrl">Blob storage URL with a SAS token</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> for controlling the lifetime of the asynchronous operation.</param>
+        /// <returns>The content of the file</returns>
+        public Task<string> DownloadBlobAsync(Uri blobAbsoluteUrl, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Updates the content of the file, creating the file if necessary
         /// </summary>
         /// <param name="blobRelativePath">Path to the file in form of /storageaccountname/container/path</param>
@@ -31,14 +39,13 @@ namespace TesApi.Web.Storage
         public Task UploadBlobAsync(string blobRelativePath, string content, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Uploads the content of as an internal TES task Blob.
+        /// Uploads the content as Blob to the provided Blob URL
         /// </summary>
-        /// <param name="tesTask"></param>
-        /// <param name="blobPath"></param>
-        /// <param name="content"></param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="blobAbsoluteUrl">Absolute Blob Storage URL with a SAS token</param>
+        /// <param name="content">Blob content</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> for controlling the lifetime of the asynchronous operation.</param>
         /// <returns></returns>
-        public Task<string> UploadAsInternalTesTaskBlobAsync(TesTask tesTask, string blobPath, string content, CancellationToken cancellationToken);
+        public Task<string> UploadBlobAsync(Uri blobAbsoluteUrl, string content, CancellationToken cancellationToken);
 
         /// <summary>
         /// Updates the content of the file, creating the file if necessary
@@ -77,11 +84,12 @@ namespace TesApi.Web.Storage
         /// <param name="blobPath"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public Task<string> GetTesInternalBlobUrlAsync(string blobPath, CancellationToken cancellationToken);
+        public Task<string> GetInternalTesBlobUrlAsync(string blobPath, CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns an Azure Storage Blob URL with a SAS token for the specified blob path in the internal storage location.
         /// </summary>
+        /// <param name="task"></param>
         /// <param name="blobPath"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>

--- a/src/TesApi.Web/Storage/IStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/IStorageAccessProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Tes.Models;
 
 namespace TesApi.Web.Storage
 {
@@ -28,6 +29,16 @@ namespace TesApi.Web.Storage
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> for controlling the lifetime of the asynchronous operation.</param>
         /// <returns></returns>
         public Task UploadBlobAsync(string blobRelativePath, string content, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Uploads the content of as an internal TES task Blob.
+        /// </summary>
+        /// <param name="tesTask"></param>
+        /// <param name="blobPath"></param>
+        /// <param name="content"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<string> UploadAsInternalTesTaskBlobAsync(TesTask tesTask, string blobPath, string content, CancellationToken cancellationToken);
 
         /// <summary>
         /// Updates the content of the file, creating the file if necessary
@@ -59,5 +70,21 @@ namespace TesApi.Web.Storage
         /// <param name="getContainerSas">Get the container SAS even if path is longer than two parts</param>
         /// <returns>An Azure Block Blob or Container URL with SAS token</returns>
         public Task<string> MapLocalPathToSasUrlAsync(string path, CancellationToken cancellationToken, bool getContainerSas = false);
+
+        /// <summary>
+        /// Returns an Azure Storage Blob URL with a SAS token for the specified blob path in the TES internal storage location
+        /// </summary>
+        /// <param name="blobPath"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<string> GetTesInternalBlobUrlAsync(string blobPath, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Returns an Azure Storage Blob URL with a SAS token for the specified blob path in the internal storage location.
+        /// </summary>
+        /// <param name="blobPath"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<string> GetInternalTesTaskBlobUrlAsync(TesTask task, string blobPath, CancellationToken cancellationToken);
     }
 }

--- a/src/TesApi.Web/Storage/IStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/IStorageAccessProvider.cs
@@ -45,7 +45,7 @@ namespace TesApi.Web.Storage
         /// <param name="content">Blob content</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> for controlling the lifetime of the asynchronous operation.</param>
         /// <returns></returns>
-        public Task<string> UploadBlobAsync(Uri blobAbsoluteUrl, string content, CancellationToken cancellationToken);
+        public Task UploadBlobAsync(Uri blobAbsoluteUrl, string content, CancellationToken cancellationToken);
 
         /// <summary>
         /// Updates the content of the file, creating the file if necessary

--- a/src/TesApi.Web/Storage/StorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/StorageAccessProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Tes.Models;
 
 namespace TesApi.Web.Storage;
 
@@ -17,6 +18,12 @@ public abstract class StorageAccessProvider : IStorageAccessProvider
     /// Cromwell path prefix
     /// </summary>
     protected const string CromwellPathPrefix = "/cromwell-executions/";
+
+    /// <summary>
+    /// TES path for internal execution files
+    /// </summary>
+    protected const string TesExecutionsPathPrefix = "/tes-internal";
+
     /// <summary>
     /// Logger instance. 
     /// </summary>
@@ -55,6 +62,10 @@ public abstract class StorageAccessProvider : IStorageAccessProvider
         => await this.AzureProxy.UploadBlobAsync(new Uri(await MapLocalPathToSasUrlAsync(blobRelativePath, cancellationToken, true)), content, cancellationToken);
 
     /// <inheritdoc />
+    public abstract Task<string> UploadAsInternalTesTaskBlobAsync(TesTask tesTask, string blobPath, string content,
+        CancellationToken cancellationToken);
+
+    /// <inheritdoc />
     public async Task UploadBlobFromFileAsync(string blobRelativePath, string sourceLocalFilePath, CancellationToken cancellationToken)
         => await this.AzureProxy.UploadBlobFromFileAsync(new Uri(await MapLocalPathToSasUrlAsync(blobRelativePath, cancellationToken, true)), sourceLocalFilePath, cancellationToken);
 
@@ -63,6 +74,12 @@ public abstract class StorageAccessProvider : IStorageAccessProvider
 
     /// <inheritdoc />
     public abstract Task<string> MapLocalPathToSasUrlAsync(string path, CancellationToken cancellationToken, bool getContainerSas = false);
+
+    /// <inheritdoc />
+    public abstract Task<string> GetTesInternalBlobUrlAsync(string blobPath, CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public abstract Task<string> GetInternalTesTaskBlobUrlAsync(TesTask task, string blobPath, CancellationToken cancellationToken);
 
     /// <summary>
     /// Tries to parse the input into a Http Url. 

--- a/src/TesApi.Web/Storage/StorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/StorageAccessProvider.cs
@@ -60,6 +60,11 @@ public abstract class StorageAccessProvider : IStorageAccessProvider
     /// <inheritdoc />
     public async Task<string> DownloadBlobAsync(Uri blobAbsoluteUrl, CancellationToken cancellationToken)
     {
+        if (!await AzureProxy.BlobExistsAsync(blobAbsoluteUrl, cancellationToken))
+        {
+            return default;
+        }
+
         return await AzureProxy.DownloadBlobAsync(blobAbsoluteUrl, cancellationToken);
     }
 

--- a/src/TesApi.Web/Storage/StorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/StorageAccessProvider.cs
@@ -83,14 +83,12 @@ public abstract class StorageAccessProvider : IStorageAccessProvider
         => await this.AzureProxy.UploadBlobAsync(new Uri(await MapLocalPathToSasUrlAsync(blobRelativePath, cancellationToken, true)), content, cancellationToken);
 
     /// <inheritdoc />
-    public async Task<string> UploadBlobAsync(Uri blobAbsoluteUrl, string content,
+    public async Task UploadBlobAsync(Uri blobAbsoluteUrl, string content,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(blobAbsoluteUrl);
 
         await AzureProxy.UploadBlobAsync(blobAbsoluteUrl, content, cancellationToken);
-
-        return blobAbsoluteUrl.ToString();
     }
 
     /// <inheritdoc />

--- a/src/TesApi.Web/Storage/StorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/StorageAccessProvider.cs
@@ -22,7 +22,7 @@ public abstract class StorageAccessProvider : IStorageAccessProvider
     /// <summary>
     /// TES path for internal execution files
     /// </summary>
-    protected const string TesExecutionsPathPrefix = "/tes-internal";
+    public const string TesExecutionsPathPrefix = "/tes-internal";
 
     /// <summary>
     /// Logger instance. 
@@ -58,12 +58,25 @@ public abstract class StorageAccessProvider : IStorageAccessProvider
     }
 
     /// <inheritdoc />
+    public async Task<string> DownloadBlobAsync(Uri blobAbsoluteUrl, CancellationToken cancellationToken)
+    {
+        return await AzureProxy.DownloadBlobAsync(blobAbsoluteUrl, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task UploadBlobAsync(string blobRelativePath, string content, CancellationToken cancellationToken)
         => await this.AzureProxy.UploadBlobAsync(new Uri(await MapLocalPathToSasUrlAsync(blobRelativePath, cancellationToken, true)), content, cancellationToken);
 
     /// <inheritdoc />
-    public abstract Task<string> UploadAsInternalTesTaskBlobAsync(TesTask tesTask, string blobPath, string content,
-        CancellationToken cancellationToken);
+    public async Task<string> UploadBlobAsync(Uri blobAbsoluteUrl, string content,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(blobAbsoluteUrl);
+
+        await AzureProxy.UploadBlobAsync(blobAbsoluteUrl, content, cancellationToken);
+
+        return blobAbsoluteUrl.ToString();
+    }
 
     /// <inheritdoc />
     public async Task UploadBlobFromFileAsync(string blobRelativePath, string sourceLocalFilePath, CancellationToken cancellationToken)
@@ -76,7 +89,7 @@ public abstract class StorageAccessProvider : IStorageAccessProvider
     public abstract Task<string> MapLocalPathToSasUrlAsync(string path, CancellationToken cancellationToken, bool getContainerSas = false);
 
     /// <inheritdoc />
-    public abstract Task<string> GetTesInternalBlobUrlAsync(string blobPath, CancellationToken cancellationToken);
+    public abstract Task<string> GetInternalTesBlobUrlAsync(string blobPath, CancellationToken cancellationToken);
 
     /// <inheritdoc />
     public abstract Task<string> GetInternalTesTaskBlobUrlAsync(TesTask task, string blobPath, CancellationToken cancellationToken);

--- a/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
@@ -14,6 +14,7 @@ using Tes.Models;
 using TesApi.Web.Management.Clients;
 using TesApi.Web.Management.Configuration;
 using TesApi.Web.Management.Models.Terra;
+using TesApi.Web.Options;
 
 namespace TesApi.Web.Storage
 {
@@ -23,6 +24,7 @@ namespace TesApi.Web.Storage
     public class TerraStorageAccessProvider : StorageAccessProvider
     {
         private readonly TerraOptions terraOptions;
+        private readonly BatchSchedulingOptions batchSchedulingOptions;
         private readonly TerraWsmApiClient terraWsmApiClient;
         private const string SasBlobPermissions = "racw";
         private const string SasContainerPermissions = "racwl";
@@ -35,14 +37,18 @@ namespace TesApi.Web.Storage
         /// <param name="logger">Logger <see cref="ILogger"/></param>
         /// <param name="terraOptions"><see cref="TerraOptions"/></param>
         /// <param name="azureProxy">Azure proxy <see cref="IAzureProxy"/></param>
-        /// <param name="terraWsmApiClient"><see cref="terraWsmApiClient"/></param>
+        /// <param name="terraWsmApiClient"><see cref="TerraWsmApiClient"/></param>
+        /// <param name="batchSchedulingOptions"><see cref="BatchSchedulingOptions"/>></param>
         public TerraStorageAccessProvider(ILogger<TerraStorageAccessProvider> logger,
-            IOptions<TerraOptions> terraOptions, IAzureProxy azureProxy, TerraWsmApiClient terraWsmApiClient) : base(
+            IOptions<TerraOptions> terraOptions, IAzureProxy azureProxy, TerraWsmApiClient terraWsmApiClient, BatchSchedulingOptions batchSchedulingOptions) : base(
             logger, azureProxy)
         {
             ArgumentNullException.ThrowIfNull(terraOptions);
+            ArgumentNullException.ThrowIfNull(batchSchedulingOptions);
+            ArgumentNullException.ThrowIfNull(batchSchedulingOptions.Prefix, nameof(batchSchedulingOptions.Prefix));
 
             this.terraWsmApiClient = terraWsmApiClient;
+            this.batchSchedulingOptions = batchSchedulingOptions;
             this.terraOptions = terraOptions.Value;
         }
 
@@ -122,7 +128,7 @@ namespace TesApi.Web.Storage
 
         private string GetInternalTesPath()
         {
-            return $"{terraOptions.AppId.Trim('/')}{TesExecutionsPathPrefix}";
+            return $"{batchSchedulingOptions.Prefix.Trim('/')}{TesExecutionsPathPrefix}";
         }
 
         private TerraBlobInfo GetTerraBlobInfoForInternalTesTask(TesTask task, string blobPath)

--- a/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Web;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Tes.Models;
 using TesApi.Web.Management.Clients;
 using TesApi.Web.Management.Configuration;
 using TesApi.Web.Management.Models.Terra;
@@ -89,6 +90,18 @@ namespace TesApi.Web.Storage
             }
 
             return await GetMappedSasUrlFromWsmAsync(terraBlobInfo, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public override Task<string> GetTesInternalBlobUrlAsync(string blobPath, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override Task<string> GetInternalTesTaskBlobUrlAsync(TesTask task, string blobPath, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
@@ -111,7 +111,8 @@ namespace TesApi.Web.Storage
 
         private TerraBlobInfo GetTerraBlobInfoForInternalTes(string blobPath)
         {
-            var internalPath = TesExecutionsPathPrefix;
+            var internalPath = GetInternalTesPath();
+
             if (!string.IsNullOrEmpty(blobPath))
             {
                 internalPath += $"/{blobPath.TrimStart('/')}";
@@ -119,9 +120,14 @@ namespace TesApi.Web.Storage
             return new TerraBlobInfo(Guid.Parse(terraOptions.WorkspaceId), Guid.Parse(terraOptions.WorkspaceStorageContainerResourceId), terraOptions.WorkspaceStorageContainerName, internalPath);
         }
 
+        private string GetInternalTesPath()
+        {
+            return $"{terraOptions.AppId.Trim('/')}{TesExecutionsPathPrefix}";
+        }
+
         private TerraBlobInfo GetTerraBlobInfoForInternalTesTask(TesTask task, string blobPath)
         {
-            var internalPath = $"{TesExecutionsPathPrefix}/{task.Id}";
+            var internalPath = $"{GetInternalTesPath()}/{task.Id}";
 
             if (task.Resources != null && task.Resources.ContainsBackendParameterValue(TesResources.SupportedBackendParameters.internal_path_prefix))
             {


### PR DESCRIPTION
Closes: #275

This PR includes:
 - New methods in `IStorageAccessProvider` to handle storage URL creation and I/O operations for TES internal and TES tasks internal files. 
      -  These methods remove the dependency of the local path mapping to URLs in the scheduler and config utils to facilitate the upcoming refactoring for the TES runner. 
      - For Terra, the destination is: `<LZ storage account>/<workspace-container>/<batchscheduling-prefix>/tes-internal` or `<LZ storage account>/<workspace-container>/<batchscheduling-prefix>/tes-internal/<task-id>`
        - These values can be overwritten by setting the `internal_path_prefix`
-  Config files for allowed and supported VMs are now in ` /tes-internal/configuration/` and `internal_path_prefix` is used if provided.
