### PR TITLE
Prune all Docker images (not just dangling ones) in clean-executor.sh

### DIFF
--- a/src/TesApi.Web/scripts/clean-executor.sh
+++ b/src/TesApi.Web/scripts/clean-executor.sh
@@ -2,4 +2,4 @@ cd "$(dirname "$0")"
 if [ "$1" != "{TaskExecutor}" ]; then docker rmi {TaskExecutor} -f; fi || :
 rm -fdr wd/{ExecutionPathPrefix} || :
 sudo docker container prune -f || :
-sudo docker system prune --volumes -f || :
+sudo docker system prune -a --volumes -f || :


### PR DESCRIPTION
https://github.com/microsoft/CromwellOnAzure/issues/664

Previously, the script was not specifying to prune "all" the images:
https://docs.docker.com/engine/reference/commandline/system_prune/

This may not have any effect, since the containers are deleted in the previous command, and therefore all images are considered dangling, however, it's prudent to include it in the event of an edge case