### PR TITLE
[145] Azure resource manager SAS resolution for inputs and outputs. 

### DIFF
--- a/src/CommonUtilities/Models/NodeTask.cs
+++ b/src/CommonUtilities/Models/NodeTask.cs
@@ -37,7 +37,7 @@ namespace Tes.Runner.Models
     public enum SasResolutionStrategy
     {
         None,
-        StorageAccountNameAndKey,
+        AzureResourceManager,
         TerraWsm,
         SchemeConverter,
     }

--- a/src/Tes.Runner.Test/RunnerTestUtils.cs
+++ b/src/Tes.Runner.Test/RunnerTestUtils.cs
@@ -176,6 +176,20 @@ public class RunnerTestUtils
         }
     }
 
+    public static string GenerateRandomTestAzureStorageKey()
+    {
+        const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        var length = 64;
+        var random = new Random();
+        var result = new StringBuilder(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            result.Append(chars[random.Next(chars.Length)]);
+        }
+
+        return result.ToString();
+    }
     public const int MemBuffersCapacity = 20;
     public const int PipelineBufferCapacity = 20;
 }

--- a/src/Tes.Runner.Test/Storage/ArmSasResolutionStrategyTests.cs
+++ b/src/Tes.Runner.Test/Storage/ArmSasResolutionStrategyTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
+using Moq;
+using Tes.Runner.Storage;
+
+namespace Tes.Runner.Test.Storage
+{
+    [TestClass, TestCategory("Unit")]
+    public class ArmSasResolutionStrategyTests
+    {
+        private Mock<BlobServiceClient> mockBlobServiceClient = null!;
+        private ArmSasResolutionStrategy armSasResolutionStrategy = null!;
+        private UserDelegationKey userDelegationKey = null!;
+        const string StorageAccountName = "foo";
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            mockBlobServiceClient = new Mock<BlobServiceClient>();
+            armSasResolutionStrategy = new ArmSasResolutionStrategy(_ => mockBlobServiceClient.Object);
+            userDelegationKey = BlobsModelFactory.UserDelegationKey(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow.AddHours(1), "SIGNED_SERVICE", "V1_0", RunnerTestUtils.GenerateRandomTestAzureStorageKey());
+            mockBlobServiceClient.Setup(c => c.GetUserDelegationKey(It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+                .Returns(Azure.Response.FromValue(userDelegationKey, null!));
+
+        }
+
+        [TestMethod]
+        [DataRow($"https://{StorageAccountName}.blob.core.windows.net")]
+        [DataRow($"https://{StorageAccountName}.blob.core.windows.net/cont")]
+        [DataRow($"https://{StorageAccountName}.blob.core.windows.net/cont/blob")]
+        public async Task CreateSasTokenWithStrategyAsync_ValidBlobStorageUrl_SasTokenIsGenerated(string sourceUrl)
+        {
+            var sasTokenUrl = await armSasResolutionStrategy.CreateSasTokenWithStrategyAsync(sourceUrl, BlobSasPermissions.Read);
+
+            Assert.IsNotNull(sasTokenUrl);
+            var blobUri = new Uri(sourceUrl);
+            Assert.AreEqual(blobUri.Host, sasTokenUrl.Host);
+            Assert.IsTrue(!string.IsNullOrEmpty(sasTokenUrl.Query));
+        }
+
+        [TestMethod]
+        [DataRow($"https://storage.core.windows.net")]
+        [DataRow($"https://foo.bar/cont")]
+        [DataRow($"s3://foo.s3.bar")]
+        public async Task CreateSasTokenWithStrategyAsync_InvalidBlobStorageUrl_UrlIsReturnAsIs(string sourceUrl)
+        {
+            var transformedUrl = await armSasResolutionStrategy.CreateSasTokenWithStrategyAsync(sourceUrl, BlobSasPermissions.Read);
+
+            Assert.IsNotNull(transformedUrl);
+            var blobUri = new Uri(sourceUrl);
+            Assert.AreEqual(blobUri.AbsoluteUri, transformedUrl.AbsoluteUri);
+        }
+
+        [TestMethod]
+        public async Task CreateSasTokenWithStrategyAsyncTest_CallTwiceForSameStorageAccount_CachesKey()
+        {
+            var sourceUrl = $"https://{StorageAccountName}.blob.core.windows.net";
+
+            var sasTokenUrl1 = await armSasResolutionStrategy.CreateSasTokenWithStrategyAsync(sourceUrl, BlobSasPermissions.Read);
+            var sasTokenUrl2 = await armSasResolutionStrategy.CreateSasTokenWithStrategyAsync(sourceUrl, BlobSasPermissions.Read);
+
+
+            Assert.IsNotNull(sasTokenUrl1);
+            Assert.IsNotNull(sasTokenUrl2);
+            Assert.AreEqual(sasTokenUrl1, sasTokenUrl2);
+            mockBlobServiceClient.Verify(c => c.GetUserDelegationKey(It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/src/Tes.Runner.Test/Storage/ArmSasResolutionStrategyTests.cs
+++ b/src/Tes.Runner.Test/Storage/ArmSasResolutionStrategyTests.cs
@@ -24,8 +24,8 @@ namespace Tes.Runner.Test.Storage
             armSasResolutionStrategy = new ArmSasResolutionStrategy(_ => mockBlobServiceClient.Object);
             userDelegationKey = BlobsModelFactory.UserDelegationKey(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), DateTimeOffset.UtcNow,
                 DateTimeOffset.UtcNow.AddHours(1), "SIGNED_SERVICE", "V1_0", RunnerTestUtils.GenerateRandomTestAzureStorageKey());
-            mockBlobServiceClient.Setup(c => c.GetUserDelegationKey(It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
-                .Returns(Azure.Response.FromValue(userDelegationKey, null!));
+            mockBlobServiceClient.Setup(c => c.GetUserDelegationKeyAsync(It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Azure.Response.FromValue(userDelegationKey, null!));
 
         }
 
@@ -68,7 +68,7 @@ namespace Tes.Runner.Test.Storage
             Assert.IsNotNull(sasTokenUrl1);
             Assert.IsNotNull(sasTokenUrl2);
             Assert.AreEqual(sasTokenUrl1, sasTokenUrl2);
-            mockBlobServiceClient.Verify(c => c.GetUserDelegationKey(It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()), Times.Once);
+            mockBlobServiceClient.Verify(c => c.GetUserDelegationKeyAsync(It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }

--- a/src/Tes.Runner.Test/Storage/CloudProviderSchemeConverterTests.cs
+++ b/src/Tes.Runner.Test/Storage/CloudProviderSchemeConverterTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Storage.Sas;
 using Tes.Runner.Storage;
 
 namespace Tes.Runner.Test.Storage
@@ -17,7 +18,7 @@ namespace Tes.Runner.Test.Storage
         {
             var provider = new CloudProviderSchemeConverter();
 
-            var result = await provider.CreateSasTokenWithStrategyAsync(sourceUri);
+            var result = await provider.CreateSasTokenWithStrategyAsync(sourceUri, BlobSasPermissions.All);
 
             Assert.IsNotNull(result);
             Assert.AreEqual(result.AbsoluteUri, new Uri(expectedUri).AbsoluteUri);

--- a/src/Tes.Runner/Storage/ArmSasResolutionStrategy.cs
+++ b/src/Tes.Runner/Storage/ArmSasResolutionStrategy.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Runtime.InteropServices;
-using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;

--- a/src/Tes.Runner/Storage/ArmSasResolutionStrategy.cs
+++ b/src/Tes.Runner/Storage/ArmSasResolutionStrategy.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
+using Microsoft.Extensions.Logging;
+using Tes.Runner.Transfer;
+
+namespace Tes.Runner.Storage
+{
+    public class ArmSasResolutionStrategy : ISasResolutionStrategy
+    {
+        const string StorageHostSuffix = ".blob.core.windows.net";
+        const int BlobSasTokenExpirationInHours = 48;
+        const int UserDelegationKeyExpirationInHours = 1;
+
+        private readonly ILogger logger = PipelineLoggerFactory.Create<ArmSasResolutionStrategy>();
+        private readonly Dictionary<string, UserDelegationKey> userDelegationKeyDictionary;
+        private readonly SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1, 1);
+        private readonly Func<Uri, BlobServiceClient> blobServiceClientFactory;
+
+        public ArmSasResolutionStrategy(Func<Uri, BlobServiceClient> blobServiceClientFactory)
+        {
+            ArgumentNullException.ThrowIfNull(blobServiceClientFactory);
+
+            this.blobServiceClientFactory = blobServiceClientFactory;
+            userDelegationKeyDictionary = new Dictionary<string, UserDelegationKey>();
+        }
+
+        public Task<Uri> CreateSasTokenWithStrategyAsync(string sourceUrl, BlobSasPermissions blobSasPermissions)
+        {
+            ArgumentNullException.ThrowIfNull(sourceUrl);
+
+            if (!IsValidAzureStorageAccountUri(sourceUrl))
+            {
+                var uri = new Uri(sourceUrl);
+                logger.LogWarning($"The URL provide is not a valid storage account. The resolution strategy won't be applied. Host: {uri.Host}");
+
+                return Task.FromResult(uri);
+            }
+
+            return Task.FromResult(GetStorageUriWithSasToken(sourceUrl, blobSasPermissions));
+        }
+
+        private Uri GetStorageUriWithSasToken(string sourceUrl, BlobSasPermissions permissions)
+        {
+            try
+            {
+                var blobUrl = new BlobUriBuilder(new Uri(sourceUrl));
+                var blobServiceClient = blobServiceClientFactory(blobUrl.ToUri());
+
+                var userKey = GetUserDelegationKey(blobServiceClient, blobUrl.AccountName);
+
+                var sasBuilder = new BlobSasBuilder()
+                {
+                    BlobContainerName = blobUrl.BlobContainerName,
+                    BlobName = blobUrl.BlobName,
+                    Resource = "b",
+                    ExpiresOn = DateTimeOffset.UtcNow.AddHours(BlobSasTokenExpirationInHours)
+                };
+
+                sasBuilder.SetPermissions(permissions);
+
+                var blobUriWithSas = new BlobUriBuilder(blobUrl.ToUri())
+                {
+                    Sas = sasBuilder.ToSasQueryParameters(userKey, blobUrl.AccountName)
+                };
+
+                return blobUriWithSas.ToUri();
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error while creating SAS token for blob storage");
+                throw;
+            }
+        }
+
+        private UserDelegationKey GetUserDelegationKey(BlobServiceClient blobServiceClient, string storageAccountName)
+        {
+            try
+            {
+                semaphoreSlim.Wait();
+
+                var userDelegationKey = userDelegationKeyDictionary.GetValueOrDefault(storageAccountName);
+
+                if (userDelegationKey is null || userDelegationKey.SignedExpiresOn < DateTimeOffset.UtcNow)
+                {
+                    userDelegationKey = blobServiceClient.GetUserDelegationKey(DateTimeOffset.UtcNow,
+                        DateTimeOffset.UtcNow.AddHours(UserDelegationKeyExpirationInHours));
+
+                    userDelegationKeyDictionary[storageAccountName] = userDelegationKey;
+                }
+
+                return userDelegationKey;
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error while getting user delegation key");
+                throw;
+            }
+            finally
+            {
+                semaphoreSlim.Release();
+            }
+        }
+
+        private static bool IsValidAzureStorageAccountUri(string uri)
+        {
+            return Uri.TryCreate(uri, UriKind.Absolute, out var result) &&
+                   result.Scheme == "https" &&
+                   result.Host.EndsWith(StorageHostSuffix);
+        }
+    }
+}

--- a/src/Tes.Runner/Storage/CloudProviderSchemeConverter.cs
+++ b/src/Tes.Runner/Storage/CloudProviderSchemeConverter.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Storage.Sas;
+
 namespace Tes.Runner.Storage
 {
     public class CloudProviderSchemeConverter : ISasResolutionStrategy
@@ -8,7 +10,7 @@ namespace Tes.Runner.Storage
         private const string GcpHost = "storage.googleapis.com";
         private const string AwsSuffix = ".s3.amazonaws.com";
 
-        public Task<Uri> CreateSasTokenWithStrategyAsync(string sourceUrl)
+        public Task<Uri> CreateSasTokenWithStrategyAsync(string sourceUrl, BlobSasPermissions blobSasPermissions)
         {
             var sourceUri = new Uri(sourceUrl);
 

--- a/src/Tes.Runner/Storage/ISasResolutionStrategy.cs
+++ b/src/Tes.Runner/Storage/ISasResolutionStrategy.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Storage.Sas;
+
 namespace Tes.Runner.Storage
 {
     public interface ISasResolutionStrategy
     {
-        Task<Uri> CreateSasTokenWithStrategyAsync(string sourceUrl);
+        Task<Uri> CreateSasTokenWithStrategyAsync(string sourceUrl, BlobSasPermissions blobSasPermissions);
     }
 }

--- a/src/Tes.Runner/Storage/PassThroughSasResolutionStrategy.cs
+++ b/src/Tes.Runner/Storage/PassThroughSasResolutionStrategy.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Storage.Sas;
+
 namespace Tes.Runner.Storage
 {
     public class PassThroughSasResolutionStrategy : ISasResolutionStrategy
     {
-        public Task<Uri> CreateSasTokenWithStrategyAsync(string sourceUrl)
+        public Task<Uri> CreateSasTokenWithStrategyAsync(string sourceUrl, BlobSasPermissions blobSasPermissions)
         {
             ArgumentException.ThrowIfNullOrEmpty(sourceUrl);
 

--- a/src/Tes.Runner/Storage/SasResolutionStrategyFactory.cs
+++ b/src/Tes.Runner/Storage/SasResolutionStrategyFactory.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Identity;
+using Azure.Storage.Blobs;
 using Tes.Runner.Models;
 
 namespace Tes.Runner.Storage
@@ -15,6 +17,8 @@ namespace Tes.Runner.Storage
                     return new PassThroughSasResolutionStrategy();
                 case SasResolutionStrategy.SchemeConverter:
                     return new CloudProviderSchemeConverter();
+                case SasResolutionStrategy.AzureResourceManager:
+                    return new ArmSasResolutionStrategy(u => new BlobServiceClient(u, new DefaultAzureCredential()));
             }
 
             throw new NotImplementedException();

--- a/src/Tes.Runner/Tes.Runner.csproj
+++ b/src/Tes.Runner/Tes.Runner.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.8.2" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
     <PackageReference Include="Docker.DotNet" Version="3.125.14" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />

--- a/src/TesApi.Web/TesApi.Web.csproj
+++ b/src/TesApi.Web/TesApi.Web.csproj
@@ -9,7 +9,7 @@
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </PropertyGroup>
 
-  <ItemGroup>
+    <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.8.2" />

--- a/src/TesApi.Web/TesApi.Web.csproj
+++ b/src/TesApi.Web/TesApi.Web.csproj
@@ -8,7 +8,6 @@
     <AssemblyName>tesapi</AssemblyName>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </PropertyGroup>
-
     <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />


### PR DESCRIPTION
Closes: #145 

This PR includes:
 - A new SAS resolution strategy for TES runner's inputs and outputs: `ArmSasResolutionStrategy`. 
   - Uses a user delegated key to create the SAS URLs for inputs and outputs. 
   - Uses the default credential provider of the SDK which uses MI, if set and configured the required permissions, to get the user delegated key.
 - SAS URLs are created according to the principle of least privilege - downloads are read-only, uploads have read, write and create permissions. 