### PR TITLE
[303] Md5HashListProvider does not allocate extra byte array when calculating a buffer's hash list

### DIFF
--- a/src/Tes.Runner/Transfer/Md5HashListProvider.cs
+++ b/src/Tes.Runner/Transfer/Md5HashListProvider.cs
@@ -65,7 +65,7 @@ namespace Tes.Runner.Transfer
                 blockHashList[item] = CreateBlockMd5CheckSumValue(pipelineBuffer.Data, i, blockLength);
                 item++;
             }
-            return String.Join("",blockHashList);
+            return String.Join("", blockHashList);
         }
     }
 }

--- a/src/Tes.Runner/Transfer/Md5HashListProvider.cs
+++ b/src/Tes.Runner/Transfer/Md5HashListProvider.cs
@@ -18,7 +18,7 @@ namespace Tes.Runner.Transfer
 
         public string CalculateAndAddBlockHash(PipelineBuffer pipelineBuffer)
         {
-            var hash = CreateBufferHashList(pipelineBuffer.Data[0..pipelineBuffer.Length]);
+            var hash = CreateBufferHashList(pipelineBuffer);
 
             if (!hashesDictionary.TryAdd(pipelineBuffer.Ordinal, hash))
             {
@@ -55,15 +55,17 @@ namespace Tes.Runner.Transfer
             return BitConverter.ToString(md5Provider.ComputeHash(buffer, offset, length)).Replace("-", "").ToLowerInvariant();
         }
 
-        private string CreateBufferHashList(byte[] buffer)
+        private string CreateBufferHashList(PipelineBuffer pipelineBuffer)
         {
-            var stringBuilder = new StringBuilder();
-            for (var i = 0; i < buffer.Length; i += BlobSizeUtils.BlockSizeIncrementUnitInBytes)
+            var blockHashList = new string[pipelineBuffer.Length / BlobSizeUtils.BlockSizeIncrementUnitInBytes];
+            var item = 0;
+            for (var i = 0; i < pipelineBuffer.Length; i += BlobSizeUtils.BlockSizeIncrementUnitInBytes)
             {
-                var blockLength = Math.Min(BlobSizeUtils.BlockSizeIncrementUnitInBytes, buffer.Length - i);
-                stringBuilder.Append(CreateBlockMd5CheckSumValue(buffer, i, blockLength));
+                var blockLength = Math.Min(BlobSizeUtils.BlockSizeIncrementUnitInBytes, pipelineBuffer.Length - i);
+                blockHashList[item] = CreateBlockMd5CheckSumValue(pipelineBuffer.Data, i, blockLength);
+                item++;
             }
-            return stringBuilder.ToString();
+            return String.Join("",blockHashList);
         }
     }
 }

--- a/src/Tes.Runner/Transfer/Md5HashListProvider.cs
+++ b/src/Tes.Runner/Transfer/Md5HashListProvider.cs
@@ -57,15 +57,13 @@ namespace Tes.Runner.Transfer
 
         private string CreateBufferHashList(PipelineBuffer pipelineBuffer)
         {
-            var blockHashList = new string[pipelineBuffer.Length / BlobSizeUtils.BlockSizeIncrementUnitInBytes];
-            var item = 0;
+            var stringBuilder = new StringBuilder();
             for (var i = 0; i < pipelineBuffer.Length; i += BlobSizeUtils.BlockSizeIncrementUnitInBytes)
             {
                 var blockLength = Math.Min(BlobSizeUtils.BlockSizeIncrementUnitInBytes, pipelineBuffer.Length - i);
-                blockHashList[item] = CreateBlockMd5CheckSumValue(pipelineBuffer.Data, i, blockLength);
-                item++;
+                stringBuilder.Append(CreateBlockMd5CheckSumValue(pipelineBuffer.Data, i, blockLength));
             }
-            return String.Join("", blockHashList);
+            return stringBuilder.ToString();
         }
     }
 }

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;


### PR DESCRIPTION
Closes: #303 

This PR includes:
 - Removes the unnecessary/extra allocation of a byte array when creating a hash list of a pipeline buffer.
   - This was the root cause of #303, as it resulted in the significant increase of the LOH size.