### PR TITLE
[316] Use IOptions<BatchSchedulingOptions> wrapper instead BatchSchedulingOptions in the Terra Storage provider

### DIFF
--- a/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
+++ b/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
@@ -45,7 +45,7 @@ namespace TesApi.Tests
             optionsMock.Setup(o => o.Value).Returns(terraOptions);
             azureProxyMock = new Mock<IAzureProxy>();
             terraStorageAccessProvider = new TerraStorageAccessProvider(NullLogger<TerraStorageAccessProvider>.Instance,
-                optionsMock.Object, azureProxyMock.Object, wsmApiClientMock.Object, batchSchedulingOptions);
+                optionsMock.Object, azureProxyMock.Object, wsmApiClientMock.Object, Options.Create(batchSchedulingOptions));
         }
 
         [TestMethod]

--- a/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
@@ -40,15 +40,15 @@ namespace TesApi.Web.Storage
         /// <param name="terraWsmApiClient"><see cref="TerraWsmApiClient"/></param>
         /// <param name="batchSchedulingOptions"><see cref="BatchSchedulingOptions"/>></param>
         public TerraStorageAccessProvider(ILogger<TerraStorageAccessProvider> logger,
-            IOptions<TerraOptions> terraOptions, IAzureProxy azureProxy, TerraWsmApiClient terraWsmApiClient, BatchSchedulingOptions batchSchedulingOptions) : base(
+            IOptions<TerraOptions> terraOptions, IAzureProxy azureProxy, TerraWsmApiClient terraWsmApiClient, IOptions<BatchSchedulingOptions> batchSchedulingOptions) : base(
             logger, azureProxy)
         {
             ArgumentNullException.ThrowIfNull(terraOptions);
             ArgumentNullException.ThrowIfNull(batchSchedulingOptions);
-            ArgumentNullException.ThrowIfNull(batchSchedulingOptions.Prefix, nameof(batchSchedulingOptions.Prefix));
+            ArgumentNullException.ThrowIfNull(batchSchedulingOptions.Value.Prefix, nameof(batchSchedulingOptions.Value.Prefix));
 
             this.terraWsmApiClient = terraWsmApiClient;
-            this.batchSchedulingOptions = batchSchedulingOptions;
+            this.batchSchedulingOptions = batchSchedulingOptions.Value;
             this.terraOptions = terraOptions.Value;
         }
 


### PR DESCRIPTION
Closes: #316 

This PR includes:
 - The `TerraStorageAccessProvider` was changed to expect `IOptions<BatchSchedulingOptions>` as construction argument instead `BatchSchedulingOptions`.
