### PR TITLE
Sort the RegionsAvailable in ascending order for easier reading in BatchSupportedVmSizeInformation.json

### DIFF
--- a/src/GenerateBatchVmSkus/Program.cs
+++ b/src/GenerateBatchVmSkus/Program.cs
@@ -176,7 +176,7 @@ namespace TesUtils
                     VmSize = sizeInfo.Name,
                     VmFamily = sku?.Family,
                     HyperVGenerations = generationList,
-                    RegionsAvailable = new List<string>(regionsForVm[s])
+                    RegionsAvailable = new List<string>(regionsForVm[s].Order())
                 };
             }).Where(x => x is not null).OrderBy(x => x!.VmSize).ToList();
 


### PR DESCRIPTION
Minor readability improvement.  Currently it's unsorted like this:

```
  {
    "VmSize": "Standard_A2_v2",
    "VmFamily": "standardAv2Family",
    "LowPriority": false,
    "PricePerHour": null,
    "MemoryInGiB": 4,
    "VCpusAvailable": 2,
    "ResourceDiskSizeInGiB": 20,
    "MaxDataDiskCount": 4,
    "HyperVGenerations": [
      "V1"
    ],
    "RegionsAvailable": [
      "eastus",
      "eastus2",
      "southcentralus",
      "westus2",
      "westus3",
      "australiaeast",
      "southeastasia",
      "northeurope",
      "swedencentral",
      "uksouth",
      "westeurope",
      "centralus",
      "southafricanorth",
      "centralindia",
      "eastasia",
      "japaneast",
      "koreacentral",
      "canadacentral",
      "francecentral",
      "germanywestcentral",
      "norwayeast",
      "polandcentral",
      "switzerlandnorth",
      "uaenorth",
      "brazilsouth",
      "centraluseuap",
      "qatarcentral",
      "northcentralus",
      "westus",
      "jioindiawest",
      "eastus2euap",
      "westcentralus",
      "australiacentral",
      "australiasoutheast",
      "japanwest",
      "koreasouth",
      "southindia",
      "westindia",
      "canadaeast",
      "ukwest",
      "brazilsoutheast"
    ]
  }
```