### PR TITLE
[343] Task output file supports TES internal location in Terra

### DIFF
--- a/src/TesApi.Tests/BatchSchedulerTests.cs
+++ b/src/TesApi.Tests/BatchSchedulerTests.cs
@@ -1487,7 +1487,6 @@ namespace TesApi.Tests
         {
             await using var serviceProvider = GetServiceProviderWithMockStorageProvider();
             var batchScheduler = serviceProvider.GetT() as BatchScheduler;
-            // var storageProvider = serviceProvider.GetT() as IStorageAccessProvider;
             serviceProvider.StorageAccessProvider.Setup(p => p.GetInternalTesTaskBlobUrlAsync(It.IsAny<TesTask>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(inputUrl);
 


### PR DESCRIPTION
Fixes: #343 

This PR includes:
 - New logic to handle the TES internal URL when creating the output file destination for clean-up task.
 - Tests that validate correct behavior when the TES internal URL contains additional segments (Terra scenario) and when it does not ( CoA). 