### PR TITLE
[347] Container SAS token is generated for internal TES URLs

### DIFF
--- a/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
+++ b/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
+++ b/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -146,10 +147,11 @@ namespace TesApi.Tests
         }
 
         [TestMethod]
-        [DataRow("script/foo.sh")]
-        [DataRow("/script/foo.sh")]
+        [DataRow("script/foo.sh", "/script/foo.sh")]
+        [DataRow("/script/foo.sh", "/script/foo.sh")]
+        [DataRow("", "")]
         public async Task GetInternalTesTaskBlobUrlAsync_BlobPathIsProvided_ReturnsValidURLWithWsmContainerTaskIdAndTesPrefixAppended(
-            string blobName)
+            string blobName, string expectedBlobName)
         {
             SetUpTerraApiClient();
             var task = new TesTask { Name = "taskName", Id = Guid.NewGuid().ToString() };
@@ -157,14 +159,15 @@ namespace TesApi.Tests
 
             Assert.IsNotNull(url);
             var uri = new Uri(url);
-            Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}/{batchSchedulingOptions.Prefix}{StorageAccessProvider.TesExecutionsPathPrefix}/{task.Id}/{blobName.TrimStart('/')}", uri.AbsolutePath);
+            Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}/{batchSchedulingOptions.Prefix}{StorageAccessProvider.TesExecutionsPathPrefix}/{task.Id}{expectedBlobName}", uri.AbsolutePath);
         }
 
         [TestMethod]
-        [DataRow("script/foo.sh")]
-        [DataRow("/script/foo.sh")]
+        [DataRow("script/foo.sh", "/script/foo.sh")]
+        [DataRow("/script/foo.sh", "/script/foo.sh")]
+        [DataRow("", "")]
         public async Task GetInternalTesTaskBlobUrlAsync_BlobPathAndInternalPathPrefixIsProvided_ReturnsValidURLWithWsmContainerTaskIdAndInternalPathPrefixAppended(
-            string blobName)
+            string blobName, string expectedBlobName)
         {
             var internalPathPrefix = "internalPathPrefix";
 
@@ -179,7 +182,7 @@ namespace TesApi.Tests
 
             Assert.IsNotNull(url);
             var uri = new Uri(url);
-            Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}/{internalPathPrefix}/{blobName.TrimStart('/')}", uri.AbsolutePath);
+            Assert.AreEqual($"/{TerraApiStubData.WorkspaceStorageContainerName}/{internalPathPrefix}{expectedBlobName}", uri.AbsolutePath);
         }
     }
 }

--- a/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
@@ -102,18 +102,43 @@ namespace TesApi.Web.Storage
             return await GetMappedSasUrlFromWsmAsync(terraBlobInfo, cancellationToken);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Returns a URL with a SAS token for the provided blobPath.The resulting URL contains the TES internal segments as a prefix to the blobPath.
+        /// If the blobPath is not provided(empty), a container SAS token is generated.
+        /// If the blobPath is provided, a SAS token to the blobPath prefixed with the TES internal segments is generated.
+        /// </summary>
+        /// <param name="blobPath"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
         public override async Task<string> GetInternalTesBlobUrlAsync(string blobPath, CancellationToken cancellationToken)
         {
             var blobInfo = GetTerraBlobInfoForInternalTes(blobPath);
 
+            if (string.IsNullOrEmpty(blobPath))
+            {
+                return await GetMappedSasContainerUrlFromWsmAsync(blobInfo, cancellationToken);
+            }
+
             return await GetMappedSasUrlFromWsmAsync(blobInfo, cancellationToken);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Returns a URL with a SAS token for the provided blobPath.The resulting URL contains the TES task internal segments as a prefix to the blobPath.
+        /// If the blobPath is not provided(empty), a container SAS token is generated.
+        /// If the blobPath is provided, a SAS token to the blobPath prefixed with the TES task internal segments is generated.
+        /// </summary>
+        /// <param name="task"></param>
+        /// <param name="blobPath"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
         public override async Task<string> GetInternalTesTaskBlobUrlAsync(TesTask task, string blobPath, CancellationToken cancellationToken)
         {
             var blobInfo = GetTerraBlobInfoForInternalTesTask(task, blobPath);
+
+            if (string.IsNullOrEmpty(blobPath))
+            {
+                return await GetMappedSasContainerUrlFromWsmAsync(blobInfo, cancellationToken);
+            }
 
             return await GetMappedSasUrlFromWsmAsync(blobInfo, cancellationToken);
         }
@@ -225,14 +250,13 @@ namespace TesApi.Web.Storage
 
         private async Task<string> GetMappedSasContainerUrlFromWsmAsync(TerraBlobInfo blobInfo, CancellationToken cancellationToken)
         {
-            //an empty blob name gets a container Sas token
             var tokenInfo = await GetWorkspaceContainerSasTokenFromWsmAsync(blobInfo, cancellationToken);
 
             var urlBuilder = new UriBuilder(tokenInfo.Url);
 
             if (!string.IsNullOrEmpty(blobInfo.BlobName))
             {
-                urlBuilder.Path += $"/{blobInfo.BlobName}";
+                urlBuilder.Path += $"/{blobInfo.BlobName.TrimStart('/')}";
             }
 
             return urlBuilder.Uri.ToString();


### PR DESCRIPTION
Fixes: #347 

This PR includes:
 - Terra storage provide generates a container token when the blobPath is not set (empty) when generating TES internal URLs.
 