### PR TITLE
[356] Executor handles empty output list after resolution

### DIFF
--- a/src/Tes.Runner.Test/ExecutorTests.cs
+++ b/src/Tes.Runner.Test/ExecutorTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Moq;
+using Tes.Runner.Models;
+using Tes.Runner.Storage;
+using Tes.Runner.Transfer;
+
+namespace Tes.Runner.Test
+{
+    [TestClass, TestCategory("Unit")]
+    public class ExecutorTests
+    {
+        private Executor executor = null!;
+        private Mock<FileOperationResolver> fileOperationResolverMock = null!;
+        private NodeTask nodeTask = null!;
+        private BlobPipelineOptions blobPipelineOptions = null!;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            fileOperationResolverMock = new Mock<FileOperationResolver>();
+            blobPipelineOptions = new BlobPipelineOptions();
+            nodeTask = new NodeTask()
+            {
+                Outputs = new List<FileOutput>
+                {
+                    new FileOutput()
+                    {
+                        Path = "/mnt/data/output1.txt",
+                        TargetUrl = "https://test.blob.core.windows.net/test/output1.txt"
+                    },
+                    new FileOutput()
+                    {
+                        Path = "*.txt",
+                        TargetUrl = "https://test.blob.core.windows.net/test/output2.txt",
+                        PathPrefix = "/mnt/data"
+                    }
+                }
+            };
+            executor = new Executor(nodeTask, fileOperationResolverMock.Object);
+        }
+
+        [TestMethod]
+        public async Task UploadOutputsAsyncTest_ResolverReturnsEmptyList_SucceedsAndReturnsZeroBytes()
+        {
+            fileOperationResolverMock.Setup(r => r.ResolveOutputsAsync()).ReturnsAsync(new List<UploadInfo>());
+
+            var result = await executor.UploadOutputsAsync(blobPipelineOptions);
+
+            Assert.AreEqual(Executor.ZeroBytesTransferred, result);
+        }
+    }
+}

--- a/src/Tes.Runner/Executor.cs
+++ b/src/Tes.Runner/Executor.cs
@@ -12,17 +12,22 @@ namespace Tes.Runner
 {
     public class Executor
     {
+        public const long ZeroBytesTransferred = 0;
         private readonly ILogger logger = PipelineLoggerFactory.Create<Executor>();
         private readonly NodeTask tesNodeTask;
         private readonly FileOperationResolver operationResolver;
 
-        public Executor(NodeTask tesNodeTask)
+        public Executor(NodeTask tesNodeTask) : this(tesNodeTask, new FileOperationResolver(tesNodeTask))
+        {
+        }
+
+        public Executor(NodeTask tesNodeTask, FileOperationResolver operationResolver)
         {
             ArgumentNullException.ThrowIfNull(tesNodeTask);
+            ArgumentNullException.ThrowIfNull(operationResolver);
 
             this.tesNodeTask = tesNodeTask;
-
-            operationResolver = new FileOperationResolver(tesNodeTask);
+            this.operationResolver = operationResolver;
         }
 
         public async Task<NodeTaskResult> ExecuteNodeContainerTaskAsync(DockerExecutor dockerExecutor)
@@ -48,7 +53,13 @@ namespace Tes.Runner
 
             if (outputs is null)
             {
-                return 0;
+                return ZeroBytesTransferred;
+            }
+
+            if (outputs.Count == 0)
+            {
+                logger.LogWarning("No output files were found.");
+                return ZeroBytesTransferred;
             }
 
             var optimizedOptions = OptimizeBlobPipelineOptionsForUpload(blobPipelineOptions, outputs);

--- a/src/Tes.Runner/Storage/FileOperationResolver.cs
+++ b/src/Tes.Runner/Storage/FileOperationResolver.cs
@@ -12,14 +12,19 @@ namespace Tes.Runner.Storage
     /// </summary>
     public class FileOperationResolver
     {
-        private readonly NodeTask nodeTask;
-        private readonly ResolutionPolicyHandler resolutionPolicyHandler;
-        private readonly IFileInfoProvider fileInfoProvider;
+        private readonly NodeTask nodeTask = null!;
+        private readonly ResolutionPolicyHandler resolutionPolicyHandler = null!;
+        private readonly IFileInfoProvider fileInfoProvider = null!;
         private readonly ILogger logger = PipelineLoggerFactory.Create<FileOperationResolver>();
 
         public FileOperationResolver(NodeTask nodeTask) : this(nodeTask, new ResolutionPolicyHandler(), new DefaultFileInfoProvider())
         {
         }
+
+        /// <summary>
+        /// Parameter-less constructor for mocking
+        /// </summary>
+        protected FileOperationResolver() { }
 
         public FileOperationResolver(NodeTask nodeTask, ResolutionPolicyHandler resolutionPolicyHandler,
             IFileInfoProvider fileInfoProvider)
@@ -33,14 +38,14 @@ namespace Tes.Runner.Storage
             this.fileInfoProvider = fileInfoProvider;
         }
 
-        public async Task<List<DownloadInfo>?> ResolveInputsAsync()
+        public virtual async Task<List<DownloadInfo>?> ResolveInputsAsync()
         {
             var expandedInputs = ExpandInputs();
 
             return await resolutionPolicyHandler.ApplyResolutionPolicyAsync(expandedInputs);
         }
 
-        public async Task<List<UploadInfo>?> ResolveOutputsAsync()
+        public virtual async Task<List<UploadInfo>?> ResolveOutputsAsync()
         {
             var expandedOutputs = ExpandOutputs();
 


### PR DESCRIPTION
Fixes: #356 

This PR includes:
 - The executor handles an empty list of outputs after resolution without failing and logging a warning.
 - Test that validates the functionality. 