### PR TITLE
[369] Remove starting slash from the blobname when internal path prefix is used

### DIFF
--- a/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
+++ b/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
@@ -43,7 +43,7 @@ namespace TesApi.Tests
             wsmApiClientMock = new Mock<TerraWsmApiClient>();
             optionsMock = new Mock<IOptions<TerraOptions>>();
             terraOptions = terraApiStubData.GetTerraOptions();
-            batchSchedulingOptions = new BatchSchedulingOptions() { Prefix = @"workspace-services/cbas/terra-app-9580351d-61e7-4fb8-a05d-0ced9eaee117/fetch_sra_to_bam/1d137885-01df-4375-b034-d42b26037e99/call-Fetch_SRA_to_BAM/tes_task" };
+            batchSchedulingOptions = new BatchSchedulingOptions() { Prefix = Guid.NewGuid().ToString() };
             optionsMock.Setup(o => o.Value).Returns(terraOptions);
             azureProxyMock = new Mock<IAzureProxy>();
             terraStorageAccessProvider = new TerraStorageAccessProvider(wsmApiClientMock.Object, azureProxyMock.Object, optionsMock.Object, Options.Create(batchSchedulingOptions), NullLogger<TerraStorageAccessProvider>.Instance);
@@ -209,7 +209,7 @@ namespace TesApi.Tests
             var url = await terraStorageAccessProvider.GetInternalTesTaskBlobUrlAsync(task, blobName, CancellationToken.None);
 
             Assert.IsNotNull(url);
-            Assert.AreNotEqual(capturedTokenApiParameters.SasBlobName[0], '/');
+            Assert.AreNotEqual('/', capturedTokenApiParameters.SasBlobName[0]);
         }
     }
 }

--- a/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
+++ b/src/TesApi.Tests/TerraStorageAccessProviderTests.cs
@@ -195,8 +195,8 @@ namespace TesApi.Tests
         [DataRow("script/foo.sh", "/prefix")]
         [DataRow("/script/foo.sh", "prefix")]
         [DataRow("script/foo.sh", "prefix")]
-        public async Task GetInternalTesTaskBlobUrlAsync_BlobPathAndInternalPathPrefixIsProvided_BlobNameDoesNotStartWithSlashWhenCallingWSM(
-            string blobName, string internalPrefix)
+        public async Task GetInternalTesTaskBlobUrlAsync_BlobPathAndInternalPathPrefixAreProvided_BlobNameDoesNotStartWithSlashWhenCallingWSM(
+            string blobPath, string internalPrefix)
         {
 
             SetUpTerraApiClient();
@@ -206,7 +206,7 @@ namespace TesApi.Tests
             {
                 { TesResources.SupportedBackendParameters.internal_path_prefix.ToString(), internalPrefix }
             };
-            var url = await terraStorageAccessProvider.GetInternalTesTaskBlobUrlAsync(task, blobName, CancellationToken.None);
+            var url = await terraStorageAccessProvider.GetInternalTesTaskBlobUrlAsync(task, blobPath, CancellationToken.None);
 
             Assert.IsNotNull(url);
             Assert.AreNotEqual('/', capturedTokenApiParameters.SasBlobName[0]);

--- a/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/TerraStorageAccessProvider.cs
@@ -166,7 +166,7 @@ namespace TesApi.Web.Storage
 
             if (task.Resources != null && task.Resources.ContainsBackendParameterValue(TesResources.SupportedBackendParameters.internal_path_prefix))
             {
-                internalPath = $"/{task.Resources.GetBackendParameterValue(TesResources.SupportedBackendParameters.internal_path_prefix).Trim('/')}";
+                internalPath = $"{task.Resources.GetBackendParameterValue(TesResources.SupportedBackendParameters.internal_path_prefix).Trim('/')}";
             }
 
             if (!string.IsNullOrEmpty(blobPath))


### PR DESCRIPTION
Fixes: #369 

This PR includes:
 - The blobname used to generate the SAS token using WSM no longer begins with a slash when the internal path prefix is used.
 - Tests cases that replicate the scenario and confirm the issue's resolution. 