### PR TITLE
[367] Removes path-prefix property from the runner and TES task model 

### DIFF
--- a/src/CommonUtilities/Models/NodeTask.cs
+++ b/src/CommonUtilities/Models/NodeTask.cs
@@ -34,8 +34,6 @@ namespace Tes.Runner.Models
         public string? Path { get; set; }
         public string? SourceUrl { get; set; }
         public SasResolutionStrategy? SasStrategy { get; set; }
-        public string? NodeWorkingDirectory { get; set; }
-
     }
 
     public class RuntimeOptions

--- a/src/CommonUtilities/Models/NodeTask.cs
+++ b/src/CommonUtilities/Models/NodeTask.cs
@@ -25,8 +25,6 @@ namespace Tes.Runner.Models
         public SasResolutionStrategy? SasStrategy { get; set; }
         public FileType? FileType { get; set; }
         public string? PathPrefix { get; set; }
-        public string? NodeWorkingDirectory { get; set; }
-
     }
 
     public class FileInput

--- a/src/CommonUtilities/Models/NodeTask.cs
+++ b/src/CommonUtilities/Models/NodeTask.cs
@@ -25,6 +25,8 @@ namespace Tes.Runner.Models
         public SasResolutionStrategy? SasStrategy { get; set; }
         public FileType? FileType { get; set; }
         public string? PathPrefix { get; set; }
+        public string? NodeWorkingDirectory { get; set; }
+
     }
 
     public class FileInput
@@ -32,6 +34,8 @@ namespace Tes.Runner.Models
         public string? Path { get; set; }
         public string? SourceUrl { get; set; }
         public SasResolutionStrategy? SasStrategy { get; set; }
+        public string? NodeWorkingDirectory { get; set; }
+
     }
 
     public class RuntimeOptions

--- a/src/Tes.Runner.Test/ExecutorTests.cs
+++ b/src/Tes.Runner.Test/ExecutorTests.cs
@@ -32,9 +32,8 @@ namespace Tes.Runner.Test
                     },
                     new FileOutput()
                     {
-                        Path = "*.txt",
+                        Path = "/*.txt",
                         TargetUrl = "https://test.blob.core.windows.net/test/output2.txt",
-                        PathPrefix = "/mnt/data"
                     }
                 }
             };

--- a/src/Tes.Runner.Test/Storage/FileOperationResolverTests.cs
+++ b/src/Tes.Runner.Test/Storage/FileOperationResolverTests.cs
@@ -23,24 +23,18 @@ namespace Tes.Runner.Test.Storage
         public void SetUp()
         {
             resolutionPolicyHandler = new ResolutionPolicyHandler(new RuntimeOptions());
-            fileInfoProvider = new Mock<IFileInfoProvider>();
-
-            fileInfoProvider.Setup(x => x.GetExpandedFileName(It.IsAny<string>())).Returns<string>(x => x);
-            fileInfoProvider.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
-            fileInfoProvider.Setup(x => x.GetRootPathPair(It.IsAny<string>()))
-                .Returns(()=> new RootPathPair("/","foo/bar" ));
 
             singleFileInput = new FileInput
             {
                 Path = "/foo/bar",
-                SourceUrl = "https://foo.bar/cont/foo/bar?sig=sasToken",
+                SourceUrl = "https://foo.bar/cont?sig=sasToken",
                 SasStrategy = SasResolutionStrategy.None,
             };
 
             singleFileOutput = new FileOutput
             {
                 Path = "/foo/bar",
-                TargetUrl = "https://foo.bar/cont/foo/bar?sig=sasToken",
+                TargetUrl = "https://foo.bar/cont/outputs?sig=sasToken",
                 SasStrategy = SasResolutionStrategy.None,
                 FileType = FileType.File
             };
@@ -55,33 +49,47 @@ namespace Tes.Runner.Test.Storage
 
             patternFileOutput = new FileOutput
             {
-                Path = "/data/*.foo",
+                Path = "/data/*",
                 TargetUrl = "https://foo.bar/cont?sig=sasToken",
                 SasStrategy = SasResolutionStrategy.None,
                 FileType = FileType.File
             };
+
+            fileInfoProvider = new Mock<IFileInfoProvider>();
+
+            fileInfoProvider.Setup(x => x.GetExpandedFileName(It.IsAny<string>())).Returns<string>(f => f);
+            fileInfoProvider.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+            fileInfoProvider.Setup(x => x.GetRootPathPair("/foo/bar"))
+                .Returns(() => new RootPathPair("/", "foo/bar"));
+            fileInfoProvider.Setup(x => x.GetRootPathPair("/data/*"))
+                .Returns(() => new RootPathPair("/", "data/*"));
+
         }
 
         [TestMethod]
         public async Task ResolveOutputsAsync_FileOutputProvided_FileOperationIsResolved()
         {
-            var nodeTask = new NodeTask()
-            {
-                Outputs = new List<FileOutput>
-                {
-                    singleFileOutput
-                }
-            };
+            var nodeTask = new NodeTask() { Outputs = new List<FileOutput> { singleFileOutput } };
 
-            fileInfoProvider.Setup(x => x.GetFilesBySearchPattern(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(new List<string> { singleFileOutput.Path! }.ToArray);
+            //the path in the setup is /foo/bar, and the target URL is https://foo.bar/cont/outputs?sig=sasToken
+            //therefore the expected output URL is:
+            var expectedSingleFileOutputUrl = "https://foo.bar/cont/outputs/bar?sig=sasToken";
 
-            var fileOperationInfoResolver = new FileOperationResolver(nodeTask, resolutionPolicyHandler, fileInfoProvider.Object);
+
+            fileInfoProvider.Setup(p =>
+                    p.GetFilesBySearchPattern(It.IsAny<string>(), It.IsAny<string>()))
+                     .Returns(new List<FileResult> { new FileResult(singleFileOutput.Path!, "bar", "/") });
+
+            var fileOperationInfoResolver =
+                new FileOperationResolver(nodeTask, resolutionPolicyHandler, fileInfoProvider.Object);
             var resolvedOutputs = await fileOperationInfoResolver.ResolveOutputsAsync();
 
             Assert.AreEqual(1, resolvedOutputs?.Count);
-            Assert.IsTrue(resolvedOutputs?.Any(r => r.FullFilePath.Equals(singleFileOutput.Path, StringComparison.InvariantCultureIgnoreCase)));
-            Assert.IsTrue(resolvedOutputs?.Any(r => r.TargetUri.ToString().Equals(singleFileOutput.TargetUrl, StringComparison.InvariantCultureIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs?.Any(r =>
+                r.FullFilePath.Equals(singleFileOutput.Path, StringComparison.InvariantCultureIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs?.Any(r =>
+                r.TargetUri.ToString()
+                    .Equals(expectedSingleFileOutputUrl, StringComparison.InvariantCultureIgnoreCase)));
         }
 
         [TestMethod]
@@ -91,39 +99,47 @@ namespace Tes.Runner.Test.Storage
             {
                 Outputs = new List<FileOutput>
                 {
-                    patternFileOutput
+                    patternFileOutput // path: /data/*, target URL: https://foo.bar/cont/data?sig=sasToken
                 }
             };
 
-            fileInfoProvider.Setup(x => x.GetFilesBySearchPattern(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(new List<string> { "/prefix/data/foo.foo", "/prefix/data/bar.foo" }.ToArray);
+            fileInfoProvider.Setup(x => x.GetFilesBySearchPattern("/", "data/*"))
+                .Returns(new List<FileResult> {
+                    new FileResult("/data/foo.foo", "foo.foo", "/"),  //result of pattern file output
+                    new FileResult("/data/dir1/bar.foo", "dir1/bar.foo", "/")
+                });
 
-            var fileOperationInfoResolver = new FileOperationResolver(nodeTask, resolutionPolicyHandler, fileInfoProvider.Object);
+            var fileOperationInfoResolver =
+                new FileOperationResolver(nodeTask, resolutionPolicyHandler, fileInfoProvider.Object);
             var resolvedOutputs = await fileOperationInfoResolver.ResolveOutputsAsync();
 
             Assert.AreEqual(2, resolvedOutputs?.Count);
-            Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/prefix/data/foo.foo", StringComparison.OrdinalIgnoreCase)));
-            Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/prefix/data/bar.foo", StringComparison.OrdinalIgnoreCase)));
-            Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/data/foo.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
-            Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/data/bar.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r =>
+                r.FullFilePath.Equals("/data/foo.foo", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r =>
+                r.FullFilePath.Equals("/data/dir1/bar.foo", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r =>
+                r.TargetUri.ToString().Equals(@"https://foo.bar/cont/foo.foo?sig=sasToken",
+                    StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r =>
+                r.TargetUri.ToString().Equals(@"https://foo.bar/cont/dir1/bar.foo?sig=sasToken",
+                    StringComparison.OrdinalIgnoreCase)));
         }
 
         [TestMethod]
         public async Task ResolveOutputsAsync_DirectoryOutputProvided_TargetUrlDoesNotContainRootDirInPathProperty()
         {
-            var nodeTask = new NodeTask()
-            {
-                Outputs = new List<FileOutput>
-                {
-                    directoryFileOutput
-                }
-            };
+            var nodeTask = new NodeTask() { Outputs = new List<FileOutput> { directoryFileOutput } };
             var rootDir = directoryFileOutput.Path;
             var file1 = "/dir1/file1.tmp";
             var file2 = "/dir1/dir2/file2.tmp";
 
             fileInfoProvider.Setup(x => x.GetAllFilesInDirectory(It.IsAny<string>()))
-                .Returns(new List<string> { $"{rootDir}{file1}", $"{rootDir}{file2}" }.ToArray);
+                .Returns(new List<FileResult>
+                {
+                    new FileResult($"{rootDir}{file1}", $"{file1.TrimStart('/')}", $"{rootDir}"),
+                    new FileResult($"{rootDir}{file2}", $"{file2.TrimStart('/')}", $"{rootDir}")
+                });
 
             var fileOperationInfoResolver = new FileOperationResolver(nodeTask, resolutionPolicyHandler, fileInfoProvider.Object);
             var resolvedOutputs = await fileOperationInfoResolver.ResolveOutputsAsync();
@@ -143,25 +159,31 @@ namespace Tes.Runner.Test.Storage
             {
                 Outputs = new List<FileOutput>
                 {
-                    patternFileOutput,
-                    singleFileOutput
+                    patternFileOutput,  // path: /data/*, target URL: https://foo.bar/cont/data?sig=sasToken
+                    singleFileOutput    // path: /foo/bar, target URL: https://foo.bar/cont/outputs?sig=sasToken
                 }
             };
 
-            fileInfoProvider.Setup(x => x.GetFilesBySearchPattern(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(new List<string> { "/prefix/data/foo.foo", "/prefix/data/bar.foo" }.ToArray);
+            fileInfoProvider.Setup(x => x.GetFilesBySearchPattern("/", "data/*"))
+                .Returns(new List<FileResult> {
+                    new FileResult("/data/foo.foo", "foo.foo", "/"),  //result of pattern file output
+                    new FileResult("/data/dir1/bar.foo", "dir1/bar.foo", "/")
+                });
+            fileInfoProvider.Setup(x => x.GetFilesBySearchPattern("/", "foo/bar"))
+                .Returns(new List<FileResult> {
+                    new FileResult("/foo/bar", "bar", "/") // result of the single file output
+                });
 
             var fileOperationInfoResolver = new FileOperationResolver(nodeTask, resolutionPolicyHandler, fileInfoProvider.Object);
             var resolvedOutputs = await fileOperationInfoResolver.ResolveOutputsAsync();
 
             Assert.AreEqual(3, resolvedOutputs?.Count);
-            Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/prefix/data/foo.foo", StringComparison.OrdinalIgnoreCase)));
-            Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/prefix/data/bar.foo", StringComparison.OrdinalIgnoreCase)));
-            Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/prefix/data/bar.foo", StringComparison.OrdinalIgnoreCase)));
-            Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/data/foo.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
-            Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/data/bar.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
-            Assert.IsTrue(resolvedOutputs?.Any(r => r.FullFilePath.Equals(singleFileOutput.Path, StringComparison.InvariantCultureIgnoreCase)));
-            Assert.IsTrue(resolvedOutputs?.Any(r => r.TargetUri.ToString().Equals(singleFileOutput.TargetUrl, StringComparison.InvariantCultureIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/data/foo.foo", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/data/dir1/bar.foo", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.FullFilePath.Equals("/foo/bar", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/foo.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/dir1/bar.foo?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(resolvedOutputs!.Any(r => r.TargetUri.ToString().Equals(@"https://foo.bar/cont/outputs/bar?sig=sasToken", StringComparison.OrdinalIgnoreCase)));
         }
 
         [TestMethod]

--- a/src/Tes.Runner.Test/Storage/FileOperationResolverTests.cs
+++ b/src/Tes.Runner.Test/Storage/FileOperationResolverTests.cs
@@ -17,7 +17,6 @@ namespace Tes.Runner.Test.Storage
         private FileOutput singleFileOutput = null!;
         private FileOutput directoryFileOutput = null!;
         private FileOutput patternFileOutput = null!;
-
         private FileInput singleFileInput = null!;
 
         [TestInitialize]
@@ -28,6 +27,8 @@ namespace Tes.Runner.Test.Storage
 
             fileInfoProvider.Setup(x => x.GetExpandedFileName(It.IsAny<string>())).Returns<string>(x => x);
             fileInfoProvider.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+            fileInfoProvider.Setup(x => x.GetRootPathPair(It.IsAny<string>()))
+                .Returns(()=> new RootPathPair("/","foo/bar" ));
 
             singleFileInput = new FileInput
             {
@@ -46,7 +47,7 @@ namespace Tes.Runner.Test.Storage
 
             directoryFileOutput = new FileOutput
             {
-                Path = "/root",
+                Path = "/foo/",
                 TargetUrl = "https://foo.bar/cont?sig=sasToken",
                 SasStrategy = SasResolutionStrategy.None,
                 FileType = FileType.Directory
@@ -57,7 +58,6 @@ namespace Tes.Runner.Test.Storage
                 Path = "/data/*.foo",
                 TargetUrl = "https://foo.bar/cont?sig=sasToken",
                 SasStrategy = SasResolutionStrategy.None,
-                PathPrefix = "/prefix",
                 FileType = FileType.File
             };
         }
@@ -72,6 +72,9 @@ namespace Tes.Runner.Test.Storage
                     singleFileOutput
                 }
             };
+
+            fileInfoProvider.Setup(x => x.GetFilesBySearchPattern(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(new List<string> { singleFileOutput.Path! }.ToArray);
 
             var fileOperationInfoResolver = new FileOperationResolver(nodeTask, resolutionPolicyHandler, fileInfoProvider.Object);
             var resolvedOutputs = await fileOperationInfoResolver.ResolveOutputsAsync();

--- a/src/Tes.Runner.Test/Transfer/DefaultFileInfoProviderTests.cs
+++ b/src/Tes.Runner.Test/Transfer/DefaultFileInfoProviderTests.cs
@@ -69,6 +69,31 @@ namespace Tes.Runner.Test.Transfer
             AssertAllTempFilesAreReturned(files);
         }
 
+
+        [TestMethod]
+        public void GetFilesBySearchPattern_SingleFileUseRootAsPathAndRemainingAsSearchPattern_ReturnsFile()
+        {
+            var targetFile = directoryInfo.GetFiles().First();
+            var rootFullName = targetFile.Directory!.Root.FullName;
+            var searchPattern = targetFile.FullName.Substring(rootFullName.Length);
+
+            var files = fileInfoProvider.GetFilesBySearchPattern(rootFullName, searchPattern);
+
+            Assert.AreEqual(1, files.Length);
+            Assert.AreEqual(targetFile.FullName, files[0]);
+        }
+
+        [TestMethod]
+        public void GetRootPathPair_SingleFile_RootAndRelativePathIsReturned()
+        {
+            var targetFile = directoryInfo.GetFiles().First();
+        
+            var rootPathPair = fileInfoProvider.GetRootPathPair(targetFile.FullName);
+
+            Assert.AreEqual(targetFile.Directory!.Root.Name, rootPathPair.Root);
+            Assert.AreEqual(targetFile.FullName.Substring(targetFile.Directory.Root.Name.Length), rootPathPair.RelativePath);
+        }
+        
         private static void AssertAllTempFilesAreReturned(string[] files)
         {
             //the setup creates 4 files with the same prefix

--- a/src/Tes.Runner.Test/Transfer/DefaultFileInfoProviderTests.cs
+++ b/src/Tes.Runner.Test/Transfer/DefaultFileInfoProviderTests.cs
@@ -66,7 +66,7 @@ namespace Tes.Runner.Test.Transfer
         {
             var files = fileInfoProvider.GetFilesBySearchPattern(directoryInfo.FullName, pattern);
 
-            AssertAllTempFilesAreReturned(files);
+            AssertCountOfFilesReturned(files);
         }
 
 
@@ -79,25 +79,25 @@ namespace Tes.Runner.Test.Transfer
 
             var files = fileInfoProvider.GetFilesBySearchPattern(rootFullName, searchPattern);
 
-            Assert.AreEqual(1, files.Length);
-            Assert.AreEqual(targetFile.FullName, files[0]);
+            Assert.AreEqual(1, files.Count);
+            Assert.AreEqual(targetFile.FullName, files[0].AbsolutePath);
         }
 
         [TestMethod]
         public void GetRootPathPair_SingleFile_RootAndRelativePathIsReturned()
         {
             var targetFile = directoryInfo.GetFiles().First();
-        
+
             var rootPathPair = fileInfoProvider.GetRootPathPair(targetFile.FullName);
 
             Assert.AreEqual(targetFile.Directory!.Root.Name, rootPathPair.Root);
             Assert.AreEqual(targetFile.FullName.Substring(targetFile.Directory.Root.Name.Length), rootPathPair.RelativePath);
         }
-        
-        private static void AssertAllTempFilesAreReturned(string[] files)
+
+        private static void AssertCountOfFilesReturned(IEnumerable<Object> files)
         {
             //the setup creates 4 files with the same prefix
-            Assert.AreEqual(4, files.Length);
+            Assert.AreEqual(4, files.Count());
         }
 
         [TestMethod]
@@ -105,7 +105,7 @@ namespace Tes.Runner.Test.Transfer
         {
             var files = fileInfoProvider.GetAllFilesInDirectory(directoryInfo.FullName);
 
-            AssertAllTempFilesAreReturned(files);
+            AssertCountOfFilesReturned(files.AsEnumerable());
         }
     }
 }

--- a/src/Tes.Runner/Storage/FileOperationResolver.cs
+++ b/src/Tes.Runner/Storage/FileOperationResolver.cs
@@ -170,17 +170,6 @@ namespace Tes.Runner.Storage
             }
         }
 
-        public string ExpandAndAppendNodeWorkingDirectoryIfSet(string? nodeWorkingDirectory, string filePath)
-        {
-            if (!string.IsNullOrWhiteSpace(nodeWorkingDirectory))
-            {
-                //the path is assumed to be absolute
-                return fileInfoProvider.GetExpandedFileName($"{nodeWorkingDirectory.TrimEnd('/')}{filePath}");
-            }
-
-            return fileInfoProvider.GetExpandedFileName(filePath);
-        }
-
         private static FileOutput CreateExpandedFileOutputWithCombinedTargetUrl(FileOutput output, string absoluteFilePath, string relativePathToSearchPath)
         {
             return new FileOutput()

--- a/src/Tes.Runner/Storage/FileOperationResolver.cs
+++ b/src/Tes.Runner/Storage/FileOperationResolver.cs
@@ -164,7 +164,7 @@ namespace Tes.Runner.Storage
 
             foreach (var file in fileInfoProvider.GetFilesBySearchPattern(rootPathPair.Root, rootPathPair.RelativePath))
             {
-                logger.LogInformation($"Adding file {file.RelativePathToSearchPath} to the output list");
+                logger.LogInformation($"Adding file: {file.RelativePathToSearchPath} with absolute path: {file.AbsolutePath} to the output list");
 
                 yield return CreateExpandedFileOutputWithCombinedTargetUrl(output, absoluteFilePath: file.AbsolutePath, relativePathToSearchPath: file.RelativePathToSearchPath);
             }

--- a/src/Tes.Runner/Transfer/DefaultFileInfoProvider.cs
+++ b/src/Tes.Runner/Transfer/DefaultFileInfoProvider.cs
@@ -51,6 +51,22 @@ public class DefaultFileInfoProvider : IFileInfoProvider
         return Directory.GetFiles(Environment.ExpandEnvironmentVariables(path), "*", SearchOption.AllDirectories);
     }
 
+    public RootPathPair GetRootPathPair(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        var root = Path.GetPathRoot(path);
+
+        if (string.IsNullOrEmpty(root))
+        {
+            throw new ArgumentException($"Path {path} does not have a root");
+        }
+
+        var relativePath = path.Substring(root.Length);
+
+        return new RootPathPair(root, relativePath);
+    }
+
     private FileInfo GetFileInfoOrThrowIfFileDoesNotExist(string fileName)
     {
         var expandedFilename = Environment.ExpandEnvironmentVariables(fileName);

--- a/src/Tes.Runner/Transfer/DefaultFileInfoProvider.cs
+++ b/src/Tes.Runner/Transfer/DefaultFileInfoProvider.cs
@@ -56,7 +56,7 @@ public class DefaultFileInfoProvider : IFileInfoProvider
         }
         var prefixToRemove = Path.GetDirectoryName($"{searchPath}{delimiter}{searchPattern.TrimStart('/')}");
 
-        if (prefixToRemove != null && absolutePath.StartsWith(prefixToRemove))
+        if (!string.IsNullOrWhiteSpace(prefixToRemove) && absolutePath.StartsWith(prefixToRemove))
         {
             logger.LogInformation($"Removing prefix: {prefixToRemove} from absolute path: {absolutePath}");
 
@@ -72,7 +72,7 @@ public class DefaultFileInfoProvider : IFileInfoProvider
 
         if (!Directory.Exists(path))
         {
-            logger.LogWarning($"The directory provided does not exists: {path}. The output will be ignored.");
+            logger.LogWarning($"The directory provided does not exist: {path}. The output will be ignored.");
 
             return new List<FileResult>();
         }

--- a/src/Tes.Runner/Transfer/IFileInfoProvider.cs
+++ b/src/Tes.Runner/Transfer/IFileInfoProvider.cs
@@ -3,7 +3,7 @@
 
 namespace Tes.Runner.Transfer;
 
-// A simple abstraction to the file stats information.
+// A simple abstraction for file searching and stats.
 // The main purpose of this is to facilitate testing and provide a light abstraction on top of the file system
 // and enable future extensibility to support full glob POSIX semantics.
 
@@ -15,13 +15,13 @@ public interface IFileInfoProvider
 
     bool FileExists(string fileName);
 
-    string[] GetFilesBySearchPattern(string path, string searchPattern);
+    List<FileResult> GetFilesBySearchPattern(string searchPath, string searchPattern);
 
-    string[] GetAllFilesInDirectory(string path);
+    List<FileResult> GetAllFilesInDirectory(string path);
 
     RootPathPair GetRootPathPair(string path);
 }
 
-public record RootPathPair(string Root, string RelativePath)
-{
-}
+public record RootPathPair(string Root, string RelativePath);
+
+public record FileResult(string AbsolutePath, string RelativePathToSearchPath, string SearchPath);

--- a/src/Tes.Runner/Transfer/IFileInfoProvider.cs
+++ b/src/Tes.Runner/Transfer/IFileInfoProvider.cs
@@ -18,4 +18,10 @@ public interface IFileInfoProvider
     string[] GetFilesBySearchPattern(string path, string searchPattern);
 
     string[] GetAllFilesInDirectory(string path);
+
+    RootPathPair GetRootPathPair(string path);
+}
+
+public record RootPathPair(string Root, string RelativePath)
+{
 }

--- a/src/Tes/Models/TesOutput.cs
+++ b/src/Tes/Models/TesOutput.cs
@@ -61,12 +61,6 @@ namespace Tes.Models
         public TesFileType Type { get; set; }
 
         /// <summary>
-        /// Gets or Sets Path Prefix
-        /// </summary>
-        [DataMember(Name = "pathPrefix")]
-        public string PathPrefix { get; set; }
-
-        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -78,7 +72,6 @@ namespace Tes.Models
                 .Append("  Url: ").Append(Url).Append('\n')
                 .Append("  Path: ").Append(Path).Append('\n')
                 .Append("  Type: ").Append(Type).Append('\n')
-                .Append("  PathPrefix: ").Append(PathPrefix).Append('\n')
                 .Append("}\n")
                 .ToString();
 
@@ -136,11 +129,7 @@ namespace Tes.Models
                 (
                     Type == other.Type ||
                     Type.Equals(other.Type)
-                ) &&
-                (
-                    PathPrefix == other.PathPrefix ||
-                    PathPrefix.Equals(other.PathPrefix)
-                    ),
+                ),
             };
 
         /// <summary>
@@ -171,11 +160,6 @@ namespace Tes.Models
                 if (Path is not null)
                 {
                     hashCode = hashCode * 59 + Path.GetHashCode();
-                }
-
-                if (PathPrefix is not null)
-                {
-                    hashCode = hashCode * 59 + PathPrefix.GetHashCode();
                 }
 
                 hashCode = hashCode * 59 + Type.GetHashCode();

--- a/src/TesApi.Tests/expectedBasicJsonResult.json
+++ b/src/TesApi.Tests/expectedBasicJsonResult.json
@@ -19,8 +19,7 @@
       "description": "string",
       "url": "string",
       "path": "string",
-      "type": "FILE",
-      "pathPrefix": "string"
+      "type": "FILE"
     }
   ],
   "resources": {

--- a/src/TesApi.Tests/expectedFullJsonResult.json
+++ b/src/TesApi.Tests/expectedFullJsonResult.json
@@ -20,8 +20,7 @@
       "description": "string",
       "url": "string",
       "path": "string",
-      "type": "FILE",
-      "pathPrefix": "string"
+      "type": "FILE"
     }
   ],
   "resources": {

--- a/src/TesApi.Tests/tesTaskExample.json
+++ b/src/TesApi.Tests/tesTaskExample.json
@@ -19,8 +19,7 @@
       "description": "string",
       "url": "string",
       "path": "string",
-      "type": "FILE",
-      "pathPrefix": "string"
+      "type": "FILE"
     }
   ],
   "resources": {

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -1032,8 +1032,7 @@ namespace TesApi.Web
                     new()
                     {
                         TargetUrl = AppendPathToUrl(await storageAccessProvider.GetInternalTesTaskBlobUrlAsync(task, string.Empty, cancellationToken), "start-task"),
-                        Path = @"std*.txt",
-                        PathPrefix = "%AZ_BATCH_NODE_STARTUP_DIR%/",
+                        Path = "%AZ_BATCH_NODE_STARTUP_DIR%/std*.txt",
                         SasStrategy = SasResolutionStrategy.None,
                         FileType = FileType.File
                     }
@@ -1073,7 +1072,7 @@ namespace TesApi.Web
                 // Ignore any other missing files and directories. WDL tasks can have optional output files.
                 // Implementation: do not set Required to True (it defaults to False)
                 OutputsMetricsFormat = "FileUploadSizeInBytes={Size}",
-                Outputs = filesToUpload.Select(f => new FileOutput { TargetUrl = f.Url, Path = LocalizeLocalPath(f.Path), FileType = ConvertFileType(f.Type), SasStrategy = SasResolutionStrategy.None, PathPrefix = f.PathPrefix }).ToList()
+                Outputs = filesToUpload.Select(f => new FileOutput { TargetUrl = f.Url, Path = LocalizeLocalPath(f.Path), FileType = ConvertFileType(f.Type), SasStrategy = SasResolutionStrategy.None }).ToList()
             };
 
             var executor = task.Executors.First();


### PR DESCRIPTION
Closes: #367 

In this PR:
 - The path-prefix property in the runner and the TES task model was removed.
 - Output paths are treated as search pattern when the type is FILE.
