### PR TITLE
[364] Volume mappings for node TES task inputs and outputs

### DIFF
--- a/src/CommonUtilities/Models/NodeTask.cs
+++ b/src/CommonUtilities/Models/NodeTask.cs
@@ -21,6 +21,7 @@ namespace Tes.Runner.Models
     public class FileOutput
     {
         public string? Path { get; set; }
+        public string? MountParentDirectory { get; set; }
         public string? TargetUrl { get; set; }
         public SasResolutionStrategy? SasStrategy { get; set; }
         public FileType? FileType { get; set; }
@@ -30,6 +31,7 @@ namespace Tes.Runner.Models
     public class FileInput
     {
         public string? Path { get; set; }
+        public string? MountParentDirectory { get; set; }
         public string? SourceUrl { get; set; }
         public SasResolutionStrategy? SasStrategy { get; set; }
     }

--- a/src/CommonUtilities/Models/NodeTask.cs
+++ b/src/CommonUtilities/Models/NodeTask.cs
@@ -25,7 +25,6 @@ namespace Tes.Runner.Models
         public string? TargetUrl { get; set; }
         public SasResolutionStrategy? SasStrategy { get; set; }
         public FileType? FileType { get; set; }
-        public string? PathPrefix { get; set; }
     }
 
     public class FileInput

--- a/src/Tes.Runner.Test/Docker/VolumeBindingsGeneratorTests.cs
+++ b/src/Tes.Runner.Test/Docker/VolumeBindingsGeneratorTests.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Moq;
+using Tes.Runner.Docker;
+using Tes.Runner.Models;
+using Tes.Runner.Transfer;
+
+namespace Tes.Runner.Test.Docker
+{
+    [TestClass, TestCategory("Unit")]
+    public class VolumeBindingsGeneratorTests
+    {
+        private VolumeBindingsGenerator volumeBindingsGenerator = null!;
+        private Mock<IFileInfoProvider> mockFileInfoProvider = null!;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            mockFileInfoProvider = new Mock<IFileInfoProvider>();
+            mockFileInfoProvider.Setup(p => p.GetExpandedFileName(It.IsAny<string>())).Returns<string>(p => p);
+            volumeBindingsGenerator = new VolumeBindingsGenerator();
+        }
+
+        [DataTestMethod]
+        [DataRow("/wkd/input/file.bam", "/wkd", "/wkd/input:/input")]
+        [DataRow("/wkd/input/file.bam", "/wkd/", "/wkd/input:/input")]
+        public void GenerateVolumeBindings_SingleInputWithWorkingDir_SingleVolumeBinding(string path, string mountParent, string expected)
+        {
+            var input = new FileInput() { Path = path, MountParentDirectory = mountParent };
+
+            var bindings = volumeBindingsGenerator.GenerateVolumeBindings(new List<FileInput>() { input }, outputs: default);
+
+            Assert.AreEqual(expected, bindings.Single());
+        }
+
+        [DataTestMethod]
+        [DataRow("/wkd/output/file.bam", "/wkd", "/wkd/output:/output")]
+        [DataRow("/wkd/output/file.bam", "/wkd/", "/wkd/output:/output")]
+        public void GenerateVolumeBindings_SingleOutputWithWorkingDir_SingleVolumeBinding(string path, string mountParent, string expected)
+        {
+            var output = new FileOutput() { Path = path, MountParentDirectory = mountParent };
+
+            var bindings = volumeBindingsGenerator.GenerateVolumeBindings(inputs: default, new List<FileOutput>() { output });
+
+            Assert.AreEqual(expected, bindings.Single());
+        }
+
+        [DataTestMethod]
+        [DataRow("/wkd", "/wkd/output:/output", "/wkd/output/file.bam", "/wkd/output/file1.bam")]
+        [DataRow("/wkd", "/wkd/output:/output", "/wkd/output/file.bam", "/wkd/output/dir1/file1.bam")]
+        [DataRow("/wkd", "/wkd/output:/output", "/wkd/output/file.bam", "/wkd/output/dir1/file1.bam", "/wkd/output/dir2/file1.bam")]
+        public void GenerateVolumeBindings_OutputsWithWorkingDir_SingleVolumeBinding(string mountParent, string expected, params string[] paths)
+        {
+            var outputs = paths.Select(p => new FileOutput() { Path = p, MountParentDirectory = mountParent }).ToList();
+
+            var bindings = volumeBindingsGenerator.GenerateVolumeBindings(inputs: default, outputs);
+
+            Assert.AreEqual(expected, bindings.Single());
+        }
+        [DataTestMethod]
+        [DataRow("/wkd", "/wkd/output:/output", "/wkd/out:/out", "/wkd/output/file.bam", "/wkd/out/file1.bam")]
+        [DataRow("/wkd", "/wkd/output:/output", "/wkd/out:/out", "/wkd/output/file.bam", "/wkd/out/dir1/file1.bam")]
+        [DataRow("/wkd", "/wkd/output:/output", "/wkd/out:/out", "/wkd/out/dir1/file1.bam", "/wkd/output/dir2/file1.bam")]
+        public void GenerateVolumeBindings_OutputsWitDifferentParentsAfterWd_TwoVolumeBinding(string mountParent, string expected1, string expected2, params string[] paths)
+        {
+            var outputs = paths.Select(p => new FileOutput() { Path = p, MountParentDirectory = mountParent }).ToList();
+
+            var bindings = volumeBindingsGenerator.GenerateVolumeBindings(inputs: default, outputs);
+
+            Assert.AreEqual(2, bindings.Count);
+            Assert.IsTrue(bindings.Any(p => p.Equals(expected1, StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(bindings.Any(p => p.Equals(expected2, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        [TestMethod]
+        public void GenerateVolumeBindings_MultipleInputsAndOutputsWitDifferentParentsAfterWd_TwoVolumeBinding()
+        {
+            var mountParent = "/wkd";
+            var paths = new string[] { "/wkd/outputs/f.bam", "/wkd/outputs/b.bam" };
+            var outputs = paths.Select(p => new FileOutput() { Path = p, MountParentDirectory = mountParent }).ToList();
+
+            paths = new string[] { "/wkd/inputs/f.bam", "/wkd/inputs/b.bam" };
+            var inputs = paths.Select(p => new FileInput() { Path = p, MountParentDirectory = mountParent }).ToList();
+
+            var bindings = volumeBindingsGenerator.GenerateVolumeBindings(inputs, outputs);
+
+            Assert.AreEqual(2, bindings.Count);
+            Assert.IsTrue(bindings.Any(p => p.Equals("/wkd/inputs:/inputs", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(bindings.Any(p => p.Equals("/wkd/outputs:/outputs", StringComparison.OrdinalIgnoreCase)));
+        }
+    }
+}

--- a/src/Tes.Runner.Test/Docker/VolumeBindingsGeneratorTests.cs
+++ b/src/Tes.Runner.Test/Docker/VolumeBindingsGeneratorTests.cs
@@ -24,6 +24,7 @@ namespace Tes.Runner.Test.Docker
 
         [DataTestMethod]
         [DataRow("/wkd/input/file.bam", "/wkd", "/wkd/input:/input")]
+        [DataRow("/wkd/dir1/input/file.bam", "/wkd/dir1", "/wkd/dir1/input:/input")]
         [DataRow("/wkd/input/file.bam", "/wkd/", "/wkd/input:/input")]
         public void GenerateVolumeBindings_SingleInputWithWorkingDir_SingleVolumeBinding(string path, string mountParent, string expected)
         {

--- a/src/Tes.Runner/Docker/DockerExecutor.cs
+++ b/src/Tes.Runner/Docker/DockerExecutor.cs
@@ -28,7 +28,7 @@ namespace Tes.Runner.Docker
 
             await PullImageAsync(imageName, tag);
 
-            // await ConfigureNetworkAsync();
+            await ConfigureNetworkAsync();
 
             var createResponse = await CreateContainerAsync(imageName, commandsToExecute, volumeBindings);
 

--- a/src/Tes.Runner/Docker/DockerExecutor.cs
+++ b/src/Tes.Runner/Docker/DockerExecutor.cs
@@ -20,7 +20,7 @@ namespace Tes.Runner.Docker
                 .CreateClient();
         }
 
-        public async Task<ContainerExecutionResult> RunOnContainerAsync(string? imageName, string? tag, List<string>? commandsToExecute)
+        public async Task<ContainerExecutionResult> RunOnContainerAsync(string? imageName, string? tag, List<string>? commandsToExecute, List<string>? volumeBindings)
         {
             ArgumentException.ThrowIfNullOrEmpty(imageName);
             ArgumentException.ThrowIfNullOrEmpty(tag);
@@ -30,7 +30,7 @@ namespace Tes.Runner.Docker
 
             await ConfigureNetworkAsync();
 
-            var createResponse = await CreateContainerAsync(imageName, commandsToExecute);
+            var createResponse = await CreateContainerAsync(imageName, commandsToExecute, volumeBindings);
 
             var logs = await StartContainerWithStreamingOutput(createResponse);
 
@@ -61,7 +61,7 @@ namespace Tes.Runner.Docker
                 });
         }
 
-        private async Task<CreateContainerResponse> CreateContainerAsync(string imageName, List<string> commandsToExecute)
+        private async Task<CreateContainerResponse> CreateContainerAsync(string imageName, List<string> commandsToExecute, List<string>? volumeBindings)
         {
             var createResponse = await dockerClient.Containers.CreateContainerAsync(
                 new CreateContainerParameters
@@ -70,7 +70,11 @@ namespace Tes.Runner.Docker
                     Entrypoint = commandsToExecute,
                     AttachStdout = true,
                     AttachStderr = true,
-                    WorkingDir = "/"
+                    WorkingDir = "/",
+                    HostConfig = new HostConfig
+                    {
+                        Binds = volumeBindings
+                    }
                 });
             return createResponse;
         }

--- a/src/Tes.Runner/Docker/DockerExecutor.cs
+++ b/src/Tes.Runner/Docker/DockerExecutor.cs
@@ -28,7 +28,7 @@ namespace Tes.Runner.Docker
 
             await PullImageAsync(imageName, tag);
 
-            await ConfigureNetworkAsync();
+            // await ConfigureNetworkAsync();
 
             var createResponse = await CreateContainerAsync(imageName, commandsToExecute, volumeBindings);
 

--- a/src/Tes.Runner/Docker/VolumeBindingsGenerator.cs
+++ b/src/Tes.Runner/Docker/VolumeBindingsGenerator.cs
@@ -74,9 +74,9 @@ namespace Tes.Runner.Docker
                 return default;
             }
 
-            var targetDir = $"{path.Substring(expandedMountParentDirectory.Length - 1).Split('/')[0].TrimStart('/')}";
+            var targetDir = $"{path.Substring(expandedMountParentDirectory.Length).Split('/', StringSplitOptions.RemoveEmptyEntries)[0].TrimStart('/')}";
 
-            var volBinding = $"{expandedMountParentDirectory}/{targetDir}:/{targetDir}";
+            var volBinding = $"{expandedMountParentDirectory.TrimEnd('/')}/{targetDir}:/{targetDir}";
 
             logger.LogDebug($"Volume binding for {path} is {volBinding}");
 

--- a/src/Tes.Runner/Docker/VolumeBindingsGenerator.cs
+++ b/src/Tes.Runner/Docker/VolumeBindingsGenerator.cs
@@ -1,17 +1,86 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.Logging;
+using Tes.Runner.Models;
+using Tes.Runner.Transfer;
+
 namespace Tes.Runner.Docker
 {
     public class VolumeBindingsGenerator
     {
-        private readonly string mountParentDirectory;
+        private readonly ILogger<VolumeBindingsGenerator> logger = PipelineLoggerFactory.Create<VolumeBindingsGenerator>();
+        private readonly IFileInfoProvider fileInfoProvider;
 
-        public VolumeBindingsGenerator(string mountParentDirectory)
+        public VolumeBindingsGenerator() : this(new DefaultFileInfoProvider())
         {
-            ArgumentException.ThrowIfNullOrEmpty(mountParentDirectory, nameof(mountParentDirectory));
+        }
 
-            this.mountParentDirectory = mountParentDirectory;
+        protected VolumeBindingsGenerator(IFileInfoProvider fileInfoProvider)
+        {
+            ArgumentNullException.ThrowIfNull(fileInfoProvider);
+
+            this.fileInfoProvider = fileInfoProvider;
+        }
+
+        public List<string> GenerateVolumeBindings(List<FileInput>? inputs, List<FileOutput>? outputs)
+        {
+            var volumeBindings = new HashSet<string>();
+
+            if (inputs != null)
+            {
+                foreach (var input in inputs)
+                {
+                    AddVolumeBindingIfRequired(volumeBindings, input.MountParentDirectory, input.Path!);
+                }
+            }
+
+            if (outputs != null)
+            {
+                foreach (var output in outputs)
+                {
+                    AddVolumeBindingIfRequired(volumeBindings, output.MountParentDirectory, output.Path!);
+                }
+            }
+
+            return volumeBindings.ToList();
+        }
+
+        private void AddVolumeBindingIfRequired(HashSet<string> volumeBindings, string? mountParentDirectory, string path)
+        {
+            var mountPath = ToVolumeBinding(mountParentDirectory, path);
+
+            if (!string.IsNullOrEmpty(mountPath))
+            {
+                volumeBindings.Add(mountPath);
+            }
+        }
+
+        private string? ToVolumeBinding(string? mountParentDirectory, string path)
+        {
+            if (string.IsNullOrEmpty(mountParentDirectory))
+            {
+                logger.LogWarning(
+                    $"The file {path} does not have a mount parent directory defined in the task definition. No volume binding will be created for this file in the container.");
+                return default;
+            }
+
+            var expandedMountParentDirectory = fileInfoProvider.GetExpandedFileName(mountParentDirectory);
+
+            if (!path.StartsWith(expandedMountParentDirectory))
+            {
+                logger.LogWarning(
+                    $"The path value {path} does not contain the specified mount parent directory: {expandedMountParentDirectory}. No volume binding will be created for this file in the container.");
+                return default;
+            }
+
+            var targetDir = $"{path.Substring(expandedMountParentDirectory.Length - 1).Split('/')[0].TrimStart('/')}";
+
+            var volBinding = $"{expandedMountParentDirectory}/{targetDir}:/{targetDir}";
+
+            logger.LogDebug($"Volume binding for {path} is {volBinding}");
+
+            return volBinding;
         }
     }
 }

--- a/src/Tes.Runner/Docker/VolumeBindingsGenerator.cs
+++ b/src/Tes.Runner/Docker/VolumeBindingsGenerator.cs
@@ -66,19 +66,20 @@ namespace Tes.Runner.Docker
             }
 
             var expandedMountParentDirectory = fileInfoProvider.GetExpandedFileName(mountParentDirectory);
+            var expandedPath = fileInfoProvider.GetExpandedFileName(path);
 
-            if (!path.StartsWith(expandedMountParentDirectory))
+            if (!expandedPath.StartsWith(expandedMountParentDirectory))
             {
                 logger.LogWarning(
-                    $"The path value {path} does not contain the specified mount parent directory: {expandedMountParentDirectory}. No volume binding will be created for this file in the container.");
+                    $"The expanded path value {expandedPath} does not contain the specified mount parent directory: {expandedMountParentDirectory}. No volume binding will be created for this file in the container.");
                 return default;
             }
 
-            var targetDir = $"{path.Substring(expandedMountParentDirectory.Length).Split('/', StringSplitOptions.RemoveEmptyEntries)[0].TrimStart('/')}";
+            var targetDir = $"{expandedPath.Substring(expandedMountParentDirectory.Length).Split('/', StringSplitOptions.RemoveEmptyEntries)[0].TrimStart('/')}";
 
             var volBinding = $"{expandedMountParentDirectory.TrimEnd('/')}/{targetDir}:/{targetDir}";
 
-            logger.LogDebug($"Volume binding for {path} is {volBinding}");
+            logger.LogInformation($"Volume binding for {expandedPath} is {volBinding}");
 
             return volBinding;
         }

--- a/src/Tes.Runner/Docker/VolumeBindingsGenerator.cs
+++ b/src/Tes.Runner/Docker/VolumeBindingsGenerator.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Tes.Runner.Docker
+{
+    public class VolumeBindingsGenerator
+    {
+        private readonly string mountParentDirectory;
+
+        public VolumeBindingsGenerator(string mountParentDirectory)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(mountParentDirectory, nameof(mountParentDirectory));
+
+            this.mountParentDirectory = mountParentDirectory;
+        }
+    }
+}

--- a/src/Tes.Runner/Executor.cs
+++ b/src/Tes.Runner/Executor.cs
@@ -16,6 +16,7 @@ namespace Tes.Runner
         private readonly ILogger logger = PipelineLoggerFactory.Create<Executor>();
         private readonly NodeTask tesNodeTask;
         private readonly FileOperationResolver operationResolver;
+        private readonly VolumeBindingsGenerator volumeBindingsGenerator = new VolumeBindingsGenerator();
 
         public Executor(NodeTask tesNodeTask) : this(tesNodeTask, new FileOperationResolver(tesNodeTask))
         {
@@ -32,7 +33,9 @@ namespace Tes.Runner
 
         public async Task<NodeTaskResult> ExecuteNodeContainerTaskAsync(DockerExecutor dockerExecutor)
         {
-            var result = await dockerExecutor.RunOnContainerAsync(tesNodeTask.ImageName, tesNodeTask.ImageTag, tesNodeTask.CommandsToExecute);
+            var bindings = volumeBindingsGenerator.GenerateVolumeBindings(tesNodeTask.Inputs, tesNodeTask.Outputs);
+
+            var result = await dockerExecutor.RunOnContainerAsync(tesNodeTask.ImageName, tesNodeTask.ImageTag, tesNodeTask.CommandsToExecute, bindings);
 
             return new NodeTaskResult(result);
         }

--- a/src/Tes.Runner/Transfer/DefaultFileInfoProvider.cs
+++ b/src/Tes.Runner/Transfer/DefaultFileInfoProvider.cs
@@ -24,7 +24,11 @@ public class DefaultFileInfoProvider : IFileInfoProvider
     {
         logger.LogInformation($"Expanding file name: {fileName}");
 
-        return Environment.ExpandEnvironmentVariables(fileName);
+        var expandedValue = Environment.ExpandEnvironmentVariables(fileName);
+
+        logger.LogInformation($"Expanded file name: {expandedValue}");
+
+        return expandedValue;
     }
 
     public bool FileExists(string fileName)

--- a/src/Tes.RunnerCLI/README.md
+++ b/src/Tes.RunnerCLI/README.md
@@ -53,6 +53,7 @@ The operations are defined in a TES task file using ``JSON``
         {
             "path": "<PATH>",
             "sourceUrl": "<SOURCE_URL>",
+            "mountParentDirectory" : "<MOUNT_PARENT_DIRECTORY>",
             "sasStrategy": "None",
         }
     ],
@@ -61,7 +62,7 @@ The operations are defined in a TES task file using ``JSON``
             "path": "<PATH>",
             "targetUrl": "<TARGET_URL>",
             "sasStrategy": "None",
-            "pathPrefix": "<PATH_PREFIX>",
+            "mountParentDirectory" : "<MOUNT_PARENT_DIRECTORY>",
             "fileType": "<FILE_TYPE>"
         }
     ]
@@ -92,9 +93,10 @@ The inputs are defined as a list of objects with the following fields:
 
 | Field | Description | Required |
 | --- | --- | --- |
-| `path` | The local path of the input file.  | Yes |
+| `path` | The local absolute path of the input file.  | Yes |
 | `sourceUrl` | The URL of the input file | Yes |
 | `sasStrategy` | The strategy to resolve the SAS token | Yes |
+| `mountParentDirectory` | The directory from which the children directories must be mapped as a volume in the Docker container | No |
 
 ### Outputs
 
@@ -102,11 +104,11 @@ The outputs are defined as a list of objects with the following fields:
 
 | Field | Description | Required |
 | --- | --- | --- |
-| `path` | The local path of the output file, directory or the search pattern if the `pathPrefix` is provided  | Yes |
+| `path` | The local absolute path of the output file, directory or the search pattern | Yes |
 | `targetUrl` | The URL of the output file | Yes |
 | `sasStrategy` | The strategy to resolve the SAS token | Yes |
-| `pathPrefix` | The prefix of the output file. If provided, the `path` is used as a search pattern. This value is not included in the target URL of the files. Ignored if the `fileType` is `Directory` | No |
 | `fileType` | `File` or `Directory`. If the value is `Directory` value in the `path` property must be a directory. All files in the directory structure are uploaded. | Yes |
+| `mountParentDirectory` | The directory from which the children directories must be mapped as a volume in the Docker container | No |
 
 ## Download and Upload
 


### PR DESCRIPTION
Closes: #364 

In this PR:
 - Inputs and outputs have a new property: `MountParentDirectory`
 - If the property is set, the runner creates a docker container volume mapping to the first directory after the value in `MountParentDirectory`
 - If not set, the runner won't create any volume mapping for the given input or output. 