### PR TITLE
Remove hard-coded length from failing price API tests

### DIFF
--- a/src/Tes.ApiClients.Tests/PriceApiClientTests.cs
+++ b/src/Tes.ApiClients.Tests/PriceApiClientTests.cs
@@ -40,7 +40,7 @@ namespace Tes.ApiClients.Tests
             var page = await pricingApiClient.GetPricingInformationPageAsync(0, "westus2", CancellationToken.None);
 
             Assert.IsNotNull(page);
-            Assert.IsTrue(page.Items.Length == 100);
+            Assert.IsTrue(page.Items.Length > 0);
         }
 
         [TestMethod]
@@ -50,9 +50,9 @@ namespace Tes.ApiClients.Tests
             var cacheKey = await pricingApiClient.ToCacheKeyAsync(new Uri(page.RequestLink), false, CancellationToken.None);
             var cachedPage = JsonSerializer.Deserialize<RetailPricingData>(appCache.Get<string>(cacheKey)!);
             Assert.IsNotNull(page);
-            Assert.IsTrue(page.Items.Length == 100);
+            Assert.IsTrue(page.Items.Length > 0);
             Assert.IsNotNull(cachedPage);
-            Assert.IsTrue(cachedPage.Items.Length == 100);
+            Assert.IsTrue(page.Items.Length == cachedPage.Items.Length);
         }
 
         [TestMethod]


### PR DESCRIPTION
The pricing page appears to now return 1000 items; this PR fixes it by removing a dependency on an actual number so that it's future proof

Fixes #389