### PR TITLE
Fix DRS resolver env var name

### DIFF
--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -1127,7 +1127,7 @@ namespace TesApi.Web
                 {
                     var drsUrl = drsInputFile.Url;
                     var localizedFilePath = drsInputFile.Path;
-                    var drsLocalizationCommand = $"docker run --rm {volumeMountsOption} -e MARTHA_URL=\"{marthaUrl}\" {cromwellDrsLocalizerImageName} {drsUrl} {localizedFilePath} --access-token-strategy azure{(!string.IsNullOrWhiteSpace(marthaKeyVaultName) ? " --vault-name " + marthaKeyVaultName : string.Empty)}{(!string.IsNullOrWhiteSpace(marthaSecretName) ? " --secret-name " + marthaSecretName : string.Empty)} && \\";
+                    var drsLocalizationCommand = $"docker run --rm {volumeMountsOption} -e DRS_RESOLVER_URL=\"{marthaUrl}\" {cromwellDrsLocalizerImageName} {drsUrl} {localizedFilePath} --access-token-strategy azure{(!string.IsNullOrWhiteSpace(marthaKeyVaultName) ? " --vault-name " + marthaKeyVaultName : string.Empty)}{(!string.IsNullOrWhiteSpace(marthaSecretName) ? " --secret-name " + marthaSecretName : string.Empty)} && \\";
                     sb.AppendLinuxLine(drsLocalizationCommand);
                 }
 


### PR DESCRIPTION
Discovered this in testing - our naming of DRS-related stuff has changed since we're replacing Martha, CromwellDRSLocalizer is now expecting this different variable name.

fixes #391