### PR TITLE
Add Conflict Response for Repository Collisions in Task Cancellation

### DIFF
--- a/src/Tes/Models/TesTask.cs
+++ b/src/Tes/Models/TesTask.cs
@@ -111,6 +111,27 @@ namespace Tes.Models
         public DateTimeOffset? CreationTime { get; set; }
 
         /// <summary>
+        /// Creates a valid TES Task ID
+        /// </summary>
+        /// <returns>Valid TES task ID</returns>
+        public string CreateId()
+        {
+            var tesTaskIdPrefix = WorkflowId is not null && Guid.TryParse(WorkflowId, out _) ? $"{WorkflowId.Substring(0, 8)}_" : string.Empty;
+            return $"{tesTaskIdPrefix}{Guid.NewGuid():N}";
+        }
+
+        /// <summary>
+        /// Checks to ensure an ID contains valid characters and length
+        /// </summary>
+        /// <param name="id">TesTask ID</param>
+        /// <returns>True if valid, false if not</returns>
+        public static bool IsValidId(string id)
+        {
+            return (!id.Any(c => !(char.IsLetterOrDigit(c) || c == '_'))) 
+                && (id.Length == 32 || id.Length == 41);
+        }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>

--- a/src/Tes/Models/TesTask.cs
+++ b/src/Tes/Models/TesTask.cs
@@ -127,8 +127,7 @@ namespace Tes.Models
         /// <returns>True if valid, false if not</returns>
         public static bool IsValidId(string id)
         {
-            return (!id.Any(c => !(char.IsLetterOrDigit(c) || c == '_'))) 
-                && (id.Length == 32 || id.Length == 41);
+            return (id.Length == 32 || id.Length == 41) && !id.Any(c => !(char.IsLetterOrDigit(c) || c == '_'));
         }
 
         /// <summary>

--- a/src/Tes/Models/TesTask.cs
+++ b/src/Tes/Models/TesTask.cs
@@ -125,9 +125,10 @@ namespace Tes.Models
         /// </summary>
         /// <param name="id">TesTask ID</param>
         /// <returns>True if valid, false if not</returns>
+        /// <remarks>Letter, digit, _, -, length 32, 36, 41.  Supports GUID for backwards compatibility.</remarks>
         public static bool IsValidId(string id)
         {
-            return (id.Length == 32 || id.Length == 41) && !id.Any(c => !(char.IsLetterOrDigit(c) || c == '_'));
+            return (id.Length == 32 || id.Length == 36 || id.Length == 41) && !id.Any(c => !(char.IsLetterOrDigit(c) || c == '_' || c == '-'));
         }
 
         /// <summary>

--- a/src/TesApi.Tests/TesTaskTests.cs
+++ b/src/TesApi.Tests/TesTaskTests.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Tes.Models;
+
+namespace TesApi.Tests
+{
+    [TestClass]
+    public class TesTaskTests
+    {
+        [TestMethod]
+        public void CreateId_Generates_Valid_Id()
+        {
+            var tesTask = new TesTask
+            {
+                WorkflowId = Guid.NewGuid().ToString()
+            };
+
+            string id = tesTask.CreateId();
+
+            // Check that the ID is valid according to the IsValidId method
+            Assert.IsTrue(TesTask.IsValidId(id));
+
+            // Check that the ID starts with the first 8 characters of WorkflowId
+            Assert.IsTrue(id.StartsWith(tesTask.WorkflowId.Substring(0, 8)));
+        }
+
+        [TestMethod]
+        public void CreateId_Generates_Valid_Id_Without_WorkflowId()
+        {
+            var tesTask = new TesTask();
+            string id = tesTask.CreateId();
+
+            // Check that the ID is valid according to the IsValidId method
+            Assert.IsTrue(TesTask.IsValidId(id));
+        }
+
+        [TestMethod]
+        public void IsValidId_Returns_False_For_InvalidIds()
+        {
+            string[] invalidIds = { "invalid-id", "123", "ABC!", "" };
+
+            foreach (string id in invalidIds)
+            {
+                Assert.IsFalse(TesTask.IsValidId(id));
+            }
+        }
+
+        [TestMethod]
+        public void IsValidId_Returns_True_For_ValidIds()
+        {
+            string[] validIds = {
+                "12345678123456781234567812345678", // 32 characters
+                "12345678_12345678123456781234567812345678" // 41 characters
+            };
+
+            foreach (string id in validIds)
+            {
+                Assert.IsTrue(TesTask.IsValidId(id));
+            }
+        }
+    }
+}

--- a/src/TesApi.Web/Controllers/TaskServiceApi.cs
+++ b/src/TesApi.Web/Controllers/TaskServiceApi.cs
@@ -73,6 +73,11 @@ namespace TesApi.Controllers
         [SwaggerResponse(statusCode: 200, type: typeof(object), description: "")]
         public virtual async Task<IActionResult> CancelTask([FromRoute][Required] string id, CancellationToken cancellationToken)
         {
+            if (!TesTask.IsValidId(id))
+            {
+                return BadRequest("Invalid ID");
+            }
+
             TesTask tesTask = null;
 
             if (await repository.TryGetItemAsync(id, cancellationToken, item => tesTask = item))
@@ -95,7 +100,7 @@ namespace TesApi.Controllers
                     }
                     catch (RepositoryCollisionException exc)
                     {
-                        logger.LogError(exc, $"RepositoryCollisionException in CancelTask for {(Guid.TryParse(id, out var result) ? $"{id}" : "REMOVED")}");
+                        logger.LogError(exc, $"RepositoryCollisionException in CancelTask for {id}");
                         return Conflict(new { message = "The task could not be updated due to a conflict with the current state; please retry." });
                     }
                 }
@@ -161,8 +166,7 @@ namespace TesApi.Controllers
                 ?.FirstOrDefault();
 
             // Prefix the TES task id with first eight characters of root Cromwell job id to facilitate easier debugging
-            var tesTaskIdPrefix = tesTask.WorkflowId is not null && Guid.TryParse(tesTask.WorkflowId, out _) ? $"{tesTask.WorkflowId.Substring(0, 8)}_" : string.Empty;
-            tesTask.Id = $"{tesTaskIdPrefix}{Guid.NewGuid():N}";
+            tesTask.Id = tesTask.CreateId();
 
             // For CWL workflows, if disk size is not specified in TES object (always), try to retrieve it from the corresponding workflow stored by Cromwell in /cromwell-tmp directory
             // Also allow for TES-style "memory" and "cpu" hints in CWL.
@@ -262,6 +266,11 @@ namespace TesApi.Controllers
         [SwaggerResponse(statusCode: 200, type: typeof(TesTask), description: "")]
         public virtual async Task<IActionResult> GetTaskAsync([FromRoute][Required] string id, [FromQuery] string view, CancellationToken cancellationToken)
         {
+            if (!TesTask.IsValidId(id))
+            {
+                return BadRequest("Invalid ID");
+            }
+
             TesTask tesTask = null;
             var itemFound = await repository.TryGetItemAsync(id, cancellationToken, item => tesTask = item);
 

--- a/src/TesApi.Web/Controllers/TaskServiceApi.cs
+++ b/src/TesApi.Web/Controllers/TaskServiceApi.cs
@@ -95,7 +95,7 @@ namespace TesApi.Controllers
                     }
                     catch (RepositoryCollisionException exc)
                     {
-                        logger.LogError(exc, $"RepositoryCollisionException in CancelTask for {id}");
+                        logger.LogError(exc, $"RepositoryCollisionException in CancelTask for {(Guid.TryParse(id, out var result) ? $"{id}" : "REMOVED")}");
                         return Conflict(new { message = "The task could not be updated due to a conflict with the current state; please retry." });
                     }
                 }

--- a/src/TesApi.Web/Controllers/TaskServiceApi.cs
+++ b/src/TesApi.Web/Controllers/TaskServiceApi.cs
@@ -95,7 +95,8 @@ namespace TesApi.Controllers
                     }
                     catch (RepositoryCollisionException exc)
                     {
-                        // TODO
+                        logger.LogError(exc, $"RepositoryCollisionException in CancelTask for {id}");
+                        return Conflict(new { message = "The task could not be updated due to a conflict with the current state; please retry." });
                     }
                 }
             }

--- a/src/TesApi.Web/Scheduler.cs
+++ b/src/TesApi.Web/Scheduler.cs
@@ -203,7 +203,7 @@ namespace TesApi.Web
                 }
                 catch (RepositoryCollisionException exc)
                 {
-                    // TODO
+                    logger.LogError(exc, $"RepositoryCollisionException in OrchestrateTesTasksOnBatch");
                 }
                 // TODO catch EF / postgres exception?
                 //catch (Microsoft.Azure.Cosmos.CosmosException exc)


### PR DESCRIPTION
RepositoryCollisionException is being handled silently, potentially leaving the caller thinking the task was cancelled.  Also, the ID was not being sanitized.

fixes #395 

Future TODO: https://github.com/microsoft/ga4gh-tes/issues/396