### PR TITLE
Make WriterWorkerProc a simple async Task and only delay 50ms

### DIFF
--- a/src/Tes/Repository/PostgreSqlCachingRepository.cs
+++ b/src/Tes/Repository/PostgreSqlCachingRepository.cs
@@ -164,7 +164,7 @@ namespace Tes.Repository
                 {
                     if (_writerWorkerCancellationTokenSource.IsCancellationRequested)
                     {
-                        // Cancellation has been requested pending and all items have been written
+                        // This class is being disposed and all items have been written
                         return;
                     }
 

--- a/src/Tes/Repository/PostgreSqlCachingRepository.cs
+++ b/src/Tes/Repository/PostgreSqlCachingRepository.cs
@@ -148,22 +148,17 @@ namespace Tes.Repository
         {
             while (!_writerWorker.CancellationPending)
             {
-                List<(T, WriteAction, TaskCompletionSource<T>)> list = null;
+                var list = new List<(T, WriteAction, TaskCompletionSource<T>)>();
 
                 while (!_writerWorker.CancellationPending)
                 {
                     if (_itemsToWrite.TryDequeue(out var itemToWrite))
                     {
-                        if (list == null)
-                        {
-                            list = new List<(T, WriteAction, TaskCompletionSource<T>)>();
-                        }
-
                         list.Add(itemToWrite);
                         continue;
                     }
 
-                    while (list?.Count > 0)
+                    while (list.Count > 0)
                     {
                         try
                         {
@@ -174,9 +169,7 @@ namespace Tes.Repository
                         catch (Exception ex)
                         {
                             _logger?.LogError(ex, "Repository writer worker: WriteItemsAsync failed: {Message}.", ex.Message);
-                        }
-
-                        list = null;
+                        }            
                     }
 
                     if (_writerWorker.CancellationPending)

--- a/src/Tes/Repository/PostgreSqlCachingRepository.cs
+++ b/src/Tes/Repository/PostgreSqlCachingRepository.cs
@@ -159,7 +159,7 @@ namespace Tes.Repository
                         return;
                     }
 
-                    // Only delay if the queue is empty
+                    // Wait, because the queue is empty
                     await Task.Delay(_writerWaitTime);
                     continue;
                 }

--- a/src/Tes/Repository/PostgreSqlCachingRepository.cs
+++ b/src/Tes/Repository/PostgreSqlCachingRepository.cs
@@ -161,7 +161,7 @@ namespace Tes.Repository
                     try
                     {
                         var work = list.Take(_batchSize).ToList();
-                        list = list.Except(work).ToList();
+                        list.RemoveAll(work.Contains);
                         await WriteItemsAsync(work);
                     }
                     catch (Exception ex)

--- a/src/Tes/Repository/PostgreSqlCachingRepository.cs
+++ b/src/Tes/Repository/PostgreSqlCachingRepository.cs
@@ -213,22 +213,12 @@ namespace Tes.Repository
                     _writerWorkerTask.Wait();
                 }
 
-                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
-                // TODO: set large fields to null
                 _disposedValue = true;
             }
         }
 
-        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
-        // ~PostgreSqlCachingRepository()
-        // {
-        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-        //     Dispose(disposing: false);
-        // }
-
         public void Dispose()
         {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
         }

--- a/src/Tes/Repository/PostgreSqlCachingRepository.cs
+++ b/src/Tes/Repository/PostgreSqlCachingRepository.cs
@@ -146,11 +146,11 @@ namespace Tes.Repository
 
         private async void WriterWorkerProcAsync(object _1, DoWorkEventArgs _2)
         {
+            var list = new List<(T, WriteAction, TaskCompletionSource<T>)>();
+
             while (!_writerWorker.CancellationPending)
             {
-                var list = new List<(T, WriteAction, TaskCompletionSource<T>)>();
-
-                while (!_writerWorker.CancellationPending)
+                while (true)
                 {
                     if (_itemsToWrite.TryDequeue(out var itemToWrite))
                     {
@@ -172,12 +172,15 @@ namespace Tes.Repository
                         }            
                     }
 
-                    if (_writerWorker.CancellationPending)
+                    if (_writerWorker.CancellationPending && _itemsToWrite.Count == 0)
                     {
                         return;
                     }
 
-                    await Task.Delay(_writerWaitTime);
+                    if (_itemsToWrite.Count == 0)
+                    {
+                        await Task.Delay(_writerWaitTime);
+                    }
                 }
             }
         }

--- a/src/Tes/Repository/PostgreSqlCachingRepository.cs
+++ b/src/Tes/Repository/PostgreSqlCachingRepository.cs
@@ -139,7 +139,7 @@ namespace Tes.Repository
         {
             var list = new List<(T, WriteAction, TaskCompletionSource<T>)>();
 
-            while (true)
+            while (!cancellationToken.IsCancellationRequested)
             {
                 if (_itemsToWrite.TryDequeue(out var itemToWrite))
                 {

--- a/src/Tes/Repository/PostgreSqlCachingRepository.cs
+++ b/src/Tes/Repository/PostgreSqlCachingRepository.cs
@@ -150,20 +150,18 @@ namespace Tes.Repository
                         continue;
                     }
                 }
-                else
+
+                if (list.Count == 0)
                 {
-                    if (list.Count == 0)
+                    if (_writerWorkerCancellationTokenSource.IsCancellationRequested)
                     {
-                        if (_writerWorkerCancellationTokenSource.IsCancellationRequested)
-                        {
-                            // This class is being disposed and all items have been written
-                            return;
-                        }
-
-
-                        // Only delay if the queue is empty
-                        await Task.Delay(_writerWaitTime);
+                        // This class is being disposed and all items have been written
+                        return;
                     }
+
+                    // Only delay if the queue is empty
+                    await Task.Delay(_writerWaitTime);
+                    continue;
                 }
 
                 try

--- a/src/Tes/Repository/PostgreSqlCachingRepository.cs
+++ b/src/Tes/Repository/PostgreSqlCachingRepository.cs
@@ -178,7 +178,7 @@ namespace Tes.Repository
                         return;
                     }
 
-                    // Only wait if the queue is empty
+                    // Only delay if the queue is empty
                     await Task.Delay(_writerWaitTime);
                 }
             }

--- a/src/TesApi.Tests/Repository/TesTaskPostgreSqlRepositoryIntegrationTests.cs
+++ b/src/TesApi.Tests/Repository/TesTaskPostgreSqlRepositoryIntegrationTests.cs
@@ -34,6 +34,7 @@ namespace Tes.Repository.Tests
     /// </summary>
     [Ignore]
     [TestClass]
+    [TestCategory("Integration")]
     public class TesTaskPostgreSqlRepositoryIntegrationTests
     {
         private static TesTaskPostgreSqlRepository repository;


### PR DESCRIPTION
Currently, posting a TES task takes on average 500ms due to the WriterWorkerProc wait time.  This PR reduces the wait to 50ms (which should result in an average of 25ms), and also rewrites it to be async and removes BackgroundWorker.

Resolves #405 