### PR TITLE
Report task completions to server

### DIFF
--- a/src/Tes/Models/TesTaskCompletionMessage.cs
+++ b/src/Tes/Models/TesTaskCompletionMessage.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Tes.Models
+{
+    public class TesTaskCompletionMessage
+    {
+        public string Id { get; set; }
+    }
+}

--- a/src/TesApi.Tests/SchedulerTests.cs
+++ b/src/TesApi.Tests/SchedulerTests.cs
@@ -10,6 +10,7 @@ using Moq;
 using Tes.Models;
 using Tes.Repository;
 using TesApi.Web;
+using TesApi.Web.Storage;
 
 namespace TesApi.Tests
 {
@@ -21,6 +22,7 @@ namespace TesApi.Tests
         private Mock<ILogger<Scheduler>> mockLogger;
         private IRetryPolicyProvider retryPolicyProvider;
         private Mock<IHostApplicationLifetime> mockApplicationLifetime;
+        private Mock<IStorageAccessProvider> mockStorageAccessProvider;
         private CancellationTokenSource cts;
         private Scheduler scheduler;
 
@@ -32,8 +34,10 @@ namespace TesApi.Tests
             mockLogger = new Mock<ILogger<Scheduler>>();
             retryPolicyProvider = new RetryPolicyProvider();
             mockApplicationLifetime = new Mock<IHostApplicationLifetime>();
+            mockStorageAccessProvider = new Mock<IStorageAccessProvider>();
+            
             cts = new CancellationTokenSource();
-            scheduler = new Scheduler(mockRepository.Object, mockBatchScheduler.Object, mockLogger.Object, retryPolicyProvider, mockApplicationLifetime.Object);
+            scheduler = new Scheduler(mockRepository.Object, mockBatchScheduler.Object, mockLogger.Object, mockStorageAccessProvider.Object, retryPolicyProvider, mockApplicationLifetime.Object);
         }
 
         [TestMethod]

--- a/src/TesApi.Web/Scheduler.cs
+++ b/src/TesApi.Web/Scheduler.cs
@@ -256,6 +256,7 @@ namespace TesApi.Web
 
                     if (newCompletedTesTaskIds.Except(this.completedTesTaskIds).Any())
                     {
+                        // At least one new task completion was found
                         lastNewTaskCompleteFoundDate = DateTime.UtcNow;
                     }
 

--- a/src/TesApi.Web/Scheduler.cs
+++ b/src/TesApi.Web/Scheduler.cs
@@ -293,7 +293,7 @@ namespace TesApi.Web
                 bool newTaskCompletionsFound = false;
 
                 // Prioritize processing completed tasks, then terminal state tasks, then randomize order within each state to prevent head-of-line blocking
-                foreach (var tesTask in tesTasks.OrderByDescending(t => completedTesTaskIds.Contains(t.Id)).ThenBy(t => t.State).ThenBy(t => random.Next()))
+                foreach (var tesTask in tesTasks.OrderBy(t => completedTesTaskIds.Contains(t.Id)).ThenByDescending(t => t.State).ThenBy(t => random.Next()))
                 {
                     if (areExistingTesTasks && processNewTasksLock.CurrentCount == 0)
                     {
@@ -315,6 +315,7 @@ namespace TesApi.Web
 
                         if (completedTesTaskIds.Contains(tesTask.Id))
                         {
+                            // TODO remove from TesTasks so we don't process again?
                             await DeleteTesTaskCompletionByIdIfExistsAsync(tesTask.Id, stoppingToken);
 
                             // Don't remove it from completedTesTaskIds or else the collection modified exception will get thrown

--- a/src/TesApi.Web/Scheduler.cs
+++ b/src/TesApi.Web/Scheduler.cs
@@ -283,6 +283,8 @@ namespace TesApi.Web
 
             while (!stoppingToken.IsCancellationRequested)
             {
+                bool newTaskCompletionsFound = false;
+
                 // Prioritize processing completed tasks, then terminal state tasks, then randomize order within each state to prevent head-of-line blocking
                 foreach (var tesTask in tesTasks.OrderByDescending(t => completedTesTaskIds.Contains(t.Id)).ThenBy(t => t.State).ThenBy(t => random.Next()))
                 {
@@ -296,6 +298,7 @@ namespace TesApi.Web
                     {
                         // New task completions found, stop processing existing tasks
                         // Force loop to restart so that new task completions are processed
+                        newTaskCompletionsFound = true;
                         break;
                     }
 
@@ -321,6 +324,12 @@ namespace TesApi.Web
                     {
                         pools.Add(tesTask.PoolId);
                     }
+                }
+
+                if (newTaskCompletionsFound)
+                {
+                    // Force loop to restart so that new task completions are processed
+                    continue;
                 }
 
                 // The while loop is only to handle the task completion case

--- a/src/TesApi.Web/Scheduler.cs
+++ b/src/TesApi.Web/Scheduler.cs
@@ -254,6 +254,8 @@ namespace TesApi.Web
                         newCompletedTesTaskIds.Add(tesTaskCompletionMessage.Id);
                     }
 
+                    // TODO - we will get completion messages before the CloudTask is complete; how should we handle ?
+
                     if (newCompletedTesTaskIds.Except(this.completedTesTaskIds).Any())
                     {
                         // At least one new task completion was found

--- a/src/TesApi.Web/Scheduler.cs
+++ b/src/TesApi.Web/Scheduler.cs
@@ -316,6 +316,9 @@ namespace TesApi.Web
                         if (completedTesTaskIds.Contains(tesTask.Id))
                         {
                             await DeleteTesTaskCompletionByIdIfExistsAsync(tesTask.Id, stoppingToken);
+
+                            // Don't remove it from completedTesTaskIds or else the collection modified exception will get thrown
+                            // It will automatically be removed when the next batch of task completions is downloaded
                         }
                     }
                     catch (RepositoryCollisionException exc)


### PR DESCRIPTION
Code running on the node will now use `wget` to `put` a new block blob that represents a TesTask being completed.  The server will loop through all of those items, and prioritize processing them first.  If BatchScheduler is looping through a long list of existing tasks, this code will interrupt that and force it to restart processing, and process the completed ones first.  We can easily add more properties to `TesTaskCompletionMessage` for additional helpful info