### PR TITLE
Ensure DB schema updated and cache warmed before enabling REST API

### DIFF
--- a/src/Tes/Repository/TesTaskPostgreSqlRepository.cs
+++ b/src/Tes/Repository/TesTaskPostgreSqlRepository.cs
@@ -35,9 +35,10 @@ namespace Tes.Repository
         {
             var connectionString = new ConnectionStringUtility().GetPostgresConnectionString(options);
             CreateDbContext = () => { return new TesDbContext(connectionString); };
-            using var dbContext = CreateDbContext();
+            
             InitializationTask = Task.Run(async () =>
             {
+                using var dbContext = CreateDbContext();
                 await dbContext.Database.MigrateAsync();
                 await WarmCacheAsync(CancellationToken.None);
             });

--- a/src/TesApi.Web/Startup.cs
+++ b/src/TesApi.Web/Startup.cs
@@ -259,8 +259,14 @@ namespace TesApi.Web
         /// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         /// </summary>
         /// <param name="app">An Microsoft.AspNetCore.Builder.IApplicationBuilder for the app to configure.</param>
-        public void Configure(IApplicationBuilder app)
-            => app.UseRouting()
+        /// <param name="serviceProvider">The service provider</param>
+        public async void Configure(IApplicationBuilder app, IServiceProvider serviceProvider)
+        {
+            // Wait for database schema to be updated and cache warmed
+            var tesTaskPostgreSqlRepository = serviceProvider.GetRequiredService<TesTaskPostgreSqlRepository>();
+            await tesTaskPostgreSqlRepository.InitializationTask;
+
+            app.UseRouting()
                 .UseEndpoints(endpoints =>
                 {
                     endpoints.MapControllers();
@@ -290,6 +296,7 @@ namespace TesApi.Web
                         var r = s.UseHsts();
                         logger.LogInformation("Configuring for Production environment");
                     });
+        }
     }
 
     internal static class BooleanMethodSelectorExtensions

--- a/src/TesApi.Web/Startup.cs
+++ b/src/TesApi.Web/Startup.cs
@@ -263,8 +263,8 @@ namespace TesApi.Web
         public async void Configure(IApplicationBuilder app, IServiceProvider serviceProvider)
         {
             // Wait for database schema to be updated and cache warmed
-            var tesTaskPostgreSqlRepository = serviceProvider.GetRequiredService<TesTaskPostgreSqlRepository>();
-            await tesTaskPostgreSqlRepository.InitializationTask;
+            await serviceProvider.GetRequiredService<TesTaskPostgreSqlRepository>().InitializationTask;
+            logger?.LogInformation("Database schema is up to date and the cache is warmed.");
 
             app.UseRouting()
                 .UseEndpoints(endpoints =>


### PR DESCRIPTION
An edge case could occur whereby a large number of existing tasks are running and TES is restarted, resulting in the cache not being warmed before the REST API starting, potentially leading to a race condition and corrupt state.

Resolves #432 