### PR TITLE
Ensure database migration and cache warming complete before enabling API

### DIFF
--- a/src/TesApi.Web/Startup.cs
+++ b/src/TesApi.Web/Startup.cs
@@ -75,7 +75,7 @@ namespace TesApi.Web
 
                     .AddMemoryCache(o => o.ExpirationScanFrequency = TimeSpan.FromHours(12))
                     .AddSingleton<ICache<TesTaskDatabaseItem>, TesRepositoryCache<TesTaskDatabaseItem>>()
-                    .AddSingleton<TesTaskPostgreSqlRepository>()
+                    .AddSingleton(sp => ActivatorUtilities.CreateInstance<TesTaskPostgreSqlRepository>(sp))
                     .AddSingleton<AzureProxy>()
                     .AddTransient<BatchPool>()
                     .AddSingleton<IBatchPoolFactory, BatchPoolFactory>()
@@ -89,7 +89,6 @@ namespace TesApi.Web
                         })
                     .Services
 
-                    .AddSingleton<IBatchScheduler, BatchScheduler>()
                     .AddSingleton(CreateStorageAccessProviderFromConfiguration)
                     .AddSingleton<IAzureProxy>(sp => ActivatorUtilities.CreateInstance<CachingWithRetriesAzureProxy>(sp, (IAzureProxy)sp.GetRequiredService(typeof(AzureProxy))))
                     .AddSingleton<IRepository<TesTask>>(sp => ActivatorUtilities.CreateInstance<RepositoryRetryHandler<TesTask>>(sp, (IRepository<TesTask>)sp.GetRequiredService(typeof(TesTaskPostgreSqlRepository))))


### PR DESCRIPTION
- Fixes potential edge case.  Ensures DB schema is updated and cache warmed before enabling REST API (#432)
- Remove double instantiation of Batch Scheduler

Note: `ActivatorUtilities.CreateInstance<TesTaskPostgreSqlRepository>(sp)` forces the completion of the constructor for `TesTaskPostgreSqlRepository` and also the injection of its constructor dependencies.  This ensures that the following completes:
```csharp
dbContext.Database.MigrateAsync().Wait();
WarmCacheAsync(CancellationToken.None).Wait();
```