### PR TITLE
Use Channel to reduce write times

### DIFF
--- a/src/Tes/Repository/PostgreSqlCachingRepository.cs
+++ b/src/Tes/Repository/PostgreSqlCachingRepository.cs
@@ -117,7 +117,7 @@ namespace Tes.Repository
         /// <param name="item"></param>
         /// <param name="action"></param>
         /// <returns></returns>
-        protected Task<T> AddUpdateOrRemoveItemInDbAsync(T item, WriteAction action, CancellationToken cancellationToken)
+        protected async Task<T> AddUpdateOrRemoveItemInDbAsync(T item, WriteAction action, CancellationToken cancellationToken)
         {
             var source = new TaskCompletionSource<T>();
             var result = source.Task;
@@ -134,8 +134,8 @@ namespace Tes.Repository
                 }
             }
 
-            _itemsToWrite.Writer.TryWrite((item, action, source));
-            return result;
+            await _itemsToWrite.Writer.WriteAsync((item, action, source));
+            return item;
 
             Task<T> RemoveUpdatingItem(Task<T> task)
             {

--- a/src/Tes/Repository/PostgreSqlCachingRepository.cs
+++ b/src/Tes/Repository/PostgreSqlCachingRepository.cs
@@ -172,15 +172,6 @@ namespace Tes.Repository
             }
 
             // If cancellation is requested, do not write any more items
-            //while (_itemsToWrite.TryTake(out var remainingItem))
-            //{
-            //    list.Add(remainingItem);
-            //}
-
-            //if (list.Any())
-            //{
-            //    await WriteItemsAsync(list, cancellationToken);
-            //}
         }
 
         private async ValueTask WriteItemsAsync(IList<(T DbItem, WriteAction Action, TaskCompletionSource<T> TaskSource)> dbItems, CancellationToken cancellationToken)


### PR DESCRIPTION
Uses `async`/`await` semantics with a `Channel` and eliminates the need for a polling loop that uses `Task.Delay`

Resolves #456 