### PR TITLE
Fix TES compliance tests

### DIFF
--- a/src/TesApi.Web/tes-compliance-test/entrypoint.sh
+++ b/src/TesApi.Web/tes-compliance-test/entrypoint.sh
@@ -3,7 +3,7 @@ teshostname=$(jq -r '.TesHostname' TesCredentials.json)
 tesuser=$(jq -r '.TesUsername' TesCredentials.json)
 tespassword=$(jq -r '.TesPassword' TesCredentials.json)
 
-# This file will be used to run tes-compliance-tests as part of the ADO release
-# TES-compliance-suite repo provides a default entry point script, but since TES uses basic auth it needs to be replaced to add approprite credentials
-# https://github.com/elixir-cloud-aai/tes-compliance-suite
+# This file will be used to run tes compliance tests as part of the ADO release
+# openapi-test-runner repo provides a default entry point script, but since TES uses basic auth it needs to be replaced to add approprite credentials
+# https://github.com/elixir-cloud-aai/openapi-test-runner
 openapi-test-runner report --server http://$tesuser:$tespassword@$teshostname/ --tag all --version 1.0.0 --output_path results

--- a/src/TesApi.Web/tes-compliance-test/entrypoint.sh
+++ b/src/TesApi.Web/tes-compliance-test/entrypoint.sh
@@ -6,4 +6,4 @@ tespassword=$(jq -r '.TesPassword' TesCredentials.json)
 # This file will be used to run tes compliance tests as part of the ADO release
 # openapi-test-runner repo provides a default entry point script, but since TES uses basic auth it needs to be replaced to add approprite credentials
 # https://github.com/elixir-cloud-aai/openapi-test-runner
-openapi-test-runner report --server http://$tesuser:$tespassword@$teshostname/ --tag all --version 1.0.0 --output_path results
+openapi-test-runner report --server http://$tesuser:$tespassword@$teshostname/ --version 1.0.0 --output_path results

--- a/src/TesApi.Web/tes-compliance-test/entrypoint.sh
+++ b/src/TesApi.Web/tes-compliance-test/entrypoint.sh
@@ -6,4 +6,4 @@ tespassword=$(jq -r '.TesPassword' TesCredentials.json)
 # This file will be used to run tes-compliance-tests as part of the ADO release
 # TES-compliance-suite repo provides a default entry point script, but since TES uses basic auth it needs to be replaced to add approprite credentials
 # https://github.com/elixir-cloud-aai/tes-compliance-suite
-tes-compliance-suite report --server http://$tesuser:$tespassword@$teshostname/ --tag all --version 1.0.0 --output_path results
+openapi-test-runner report --server http://$tesuser:$tespassword@$teshostname/ --tag all --version 1.0.0 --output_path results


### PR DESCRIPTION
ever since the tes compliance test repo was renamed, the tes tests have not been working due to this change. This PR will fix that. 

issues related to this: 
https://github.com/microsoft/ga4gh-tes/issues/457
https://github.com/microsoft/ga4gh-tes/issues/397
https://github.com/microsoft/ga4gh-tes/issues/393