### PR TITLE
Fix pricing data bugs

### DIFF
--- a/src/TesApi.Web/Management/PriceApiBatchSkuInformationProvider.cs
+++ b/src/TesApi.Web/Management/PriceApiBatchSkuInformationProvider.cs
@@ -84,9 +84,9 @@ namespace TesApi.Web.Management
 
                     var instancePricingInfo = pricingItems.Where(p => p.armSkuName == vm.VmSize && p.effectiveStartDate < DateTime.UtcNow).ToList();
                     var normalPriorityInfo = instancePricingInfo.Where(s =>
-                        s.skuName.Contains(" Low Priority", StringComparison.OrdinalIgnoreCase)).MaxBy(p => p.effectiveStartDate);
-                    var lowPriorityInfo = instancePricingInfo.Where(s =>
                         !s.skuName.Contains(" Low Priority", StringComparison.OrdinalIgnoreCase)).MaxBy(p => p.effectiveStartDate);
+                    var lowPriorityInfo = instancePricingInfo.Where(s =>
+                        s.skuName.Contains(" Low Priority", StringComparison.OrdinalIgnoreCase)).MaxBy(p => p.effectiveStartDate);
 
                     if (lowPriorityInfo is not null)
                     {

--- a/src/TesApi.Web/Management/PriceApiBatchSkuInformationProvider.cs
+++ b/src/TesApi.Web/Management/PriceApiBatchSkuInformationProvider.cs
@@ -82,11 +82,11 @@ namespace TesApi.Web.Management
                 foreach (var vm in localVmSizeInfoForBatchSupportedSkus.Where(v => !v.LowPriority))
                 {
 
-                    var instancePricingInfo = pricingItems.Where(p => p.armSkuName == vm.VmSize).ToList();
-                    var normalPriorityInfo = instancePricingInfo.FirstOrDefault(s =>
-                        s.skuName.Contains(" Low Priority", StringComparison.OrdinalIgnoreCase));
-                    var lowPriorityInfo = instancePricingInfo.FirstOrDefault(s =>
-                        !s.skuName.Contains(" Low Priority", StringComparison.OrdinalIgnoreCase));
+                    var instancePricingInfo = pricingItems.Where(p => p.armSkuName == vm.VmSize && p.effectiveStartDate < DateTime.UtcNow).ToList();
+                    var normalPriorityInfo = instancePricingInfo.Where(s =>
+                        s.skuName.Contains(" Low Priority", StringComparison.OrdinalIgnoreCase)).MaxBy(p => p.effectiveStartDate);
+                    var lowPriorityInfo = instancePricingInfo.Where(s =>
+                        !s.skuName.Contains(" Low Priority", StringComparison.OrdinalIgnoreCase)).MaxBy(p => p.effectiveStartDate);
 
                     if (lowPriorityInfo is not null)
                     {


### PR DESCRIPTION
1. Normal and low priority prices were swapped. 
2. Pick the most recent price and exclude prices that aren't yet effective. 