### PR TITLE
[485] Added support for workflow_identity to provide a Managed Identity (MI) resource ID or MI name when running on Terra

### DIFF
--- a/src/TesApi.Tests/Runner/NodeTaskBuilderTests.cs
+++ b/src/TesApi.Tests/Runner/NodeTaskBuilderTests.cs
@@ -139,11 +139,20 @@ namespace TesApi.Tests.Runner
         }
 
         [TestMethod]
-        public void WithResourceIdManagedIdentity_Called_ResourceIdIsSet()
+        public void WithResourceIdManagedIdentity_ValidResourceIdProvided_ResourceIdIsSet()
         {
-            nodeTaskBuilder.WithResourceIdManagedIdentity("resourceId");
+            var resourceId = "/subscriptions/aaaaa450-5f22-4b20-9326-b5852bb89d90/resourcegroups/foo/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar-identity";
+
+            nodeTaskBuilder.WithResourceIdManagedIdentity(resourceId);
             var nodeTask = nodeTaskBuilder.Build();
-            Assert.AreEqual("resourceId", nodeTask.RuntimeOptions.NodeManagedIdentityResourceId);
+            Assert.AreEqual(resourceId, nodeTask.RuntimeOptions.NodeManagedIdentityResourceId);
+        }
+
+        [TestMethod]
+        public void WithResourceIdManagedIdentity_InvalidResourceIdProvided_ExceptionIsThrown()
+        {
+            var resourceId = "invalid-resource-id";
+            Assert.ThrowsException<ArgumentException>(() => nodeTaskBuilder.WithResourceIdManagedIdentity(resourceId));
         }
 
         [TestMethod]

--- a/src/TesApi.Tests/Runner/NodeTaskBuilderTests.cs
+++ b/src/TesApi.Tests/Runner/NodeTaskBuilderTests.cs
@@ -138,14 +138,15 @@ namespace TesApi.Tests.Runner
             Assert.AreEqual("metrics.txt", metricsFile);
         }
 
-        [TestMethod]
-        public void WithResourceIdManagedIdentity_ValidResourceIdProvided_ResourceIdIsSet()
+        [DataTestMethod]
+        [DataRow(@"/subscriptions/aaaaa450-5f22-4b20-9326-b5852bb89d90/resourcegroups/foo/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar-identity", @"/subscriptions/aaaaa450-5f22-4b20-9326-b5852bb89d90/resourcegroups/foo/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar-identity")]
+        [DataRow(null, null)]
+        [DataRow("", null)]
+        public void WithResourceIdManagedIdentity_dResourceIdProvided_ResourceIdIsSet(string resourceId, string expectedResourceId)
         {
-            var resourceId = "/subscriptions/aaaaa450-5f22-4b20-9326-b5852bb89d90/resourcegroups/foo/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar-identity";
-
             nodeTaskBuilder.WithResourceIdManagedIdentity(resourceId);
             var nodeTask = nodeTaskBuilder.Build();
-            Assert.AreEqual(resourceId, nodeTask.RuntimeOptions.NodeManagedIdentityResourceId);
+            Assert.AreEqual(expectedResourceId, nodeTask.RuntimeOptions?.NodeManagedIdentityResourceId);
         }
 
         [TestMethod]

--- a/src/TesApi.Tests/TerraBatchPoolManagerTests.cs
+++ b/src/TesApi.Tests/TerraBatchPoolManagerTests.cs
@@ -117,23 +117,50 @@ namespace TesApi.Tests
                 },
             };
 
-            var pool = await terraBatchPoolManager.CreateBatchPoolAsync(poolInfo, false, System.Threading.CancellationToken.None);
+            await terraBatchPoolManager.CreateBatchPoolAsync(poolInfo, false, System.Threading.CancellationToken.None);
 
             var name = capturedApiCreateBatchPoolRequest.Common.Name;
             var resourceId = capturedApiCreateBatchPoolRequest.Common.ResourceId;
 
-            pool = await terraBatchPoolManager.CreateBatchPoolAsync(poolInfo, false, System.Threading.CancellationToken.None);
+            await terraBatchPoolManager.CreateBatchPoolAsync(poolInfo, false, System.Threading.CancellationToken.None);
 
             Assert.AreNotEqual(name, capturedApiCreateBatchPoolRequest.Common.Name);
             Assert.AreNotEqual(resourceId, capturedApiCreateBatchPoolRequest.Common.ResourceId);
         }
 
         [TestMethod]
-        public async Task CreateBatchPoolAsync_UserIdentityMapsCorrectly()
+        public async Task CreateBatchPoolAsync_ValidUserIdentityResourceIdProvided_UserIdentityNameIsMapped()
         {
             var identities = new Dictionary<string, UserAssignedIdentities>();
 
-            var identityName = "MyTestIdentity";
+            var identityName = @"bar-identity";
+            var identityResourceId = $@"/subscriptions/aaaaa450-5f22-4b20-9326-b5852bb89d90/resourcegroups/foo/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}";
+
+
+            identities.Add(identityResourceId, new UserAssignedIdentities());
+
+            var poolInfo = new Pool()
+            {
+                DeploymentConfiguration = new DeploymentConfiguration()
+                {
+                    CloudServiceConfiguration = new CloudServiceConfiguration("osfamily", "osversion"),
+                    VirtualMachineConfiguration = new VirtualMachineConfiguration()
+                },
+                Identity = new BatchPoolIdentity(PoolIdentityType.UserAssigned, identities)
+            };
+
+            await terraBatchPoolManager.CreateBatchPoolAsync(poolInfo, false, System.Threading.CancellationToken.None);
+
+            Assert.AreEqual(identityName, capturedApiCreateBatchPoolRequest.AzureBatchPool.UserAssignedIdentities.SingleOrDefault()!.Name);
+        }
+
+        [DataTestMethod]
+        [DataRow("/subscription/foo/bar-identity")]
+        [DataRow("bar-identity")]
+        [DataRow("")]
+        public async Task CreateBatchPoolAsync_InvalidUserIdentityResourceIdProvided_ReturnsValueProvided(string identityName)
+        {
+            var identities = new Dictionary<string, UserAssignedIdentities>();
 
             identities.Add(identityName, new UserAssignedIdentities());
 
@@ -147,14 +174,27 @@ namespace TesApi.Tests
                 Identity = new BatchPoolIdentity(PoolIdentityType.UserAssigned, identities)
             };
 
-            var pool = await terraBatchPoolManager.CreateBatchPoolAsync(poolInfo, false, System.Threading.CancellationToken.None);
+            await terraBatchPoolManager.CreateBatchPoolAsync(poolInfo, false, System.Threading.CancellationToken.None);
 
-            var name = capturedApiCreateBatchPoolRequest.Common.Name;
-            var resourceId = capturedApiCreateBatchPoolRequest.Common.ResourceId;
+            Assert.AreEqual(identityName, capturedApiCreateBatchPoolRequest.AzureBatchPool.UserAssignedIdentities.SingleOrDefault()!.Name);
+        }
+        [TestMethod]
+        public async Task CreateBatchPoolAsync_NoUserIdentityResourceIdProvided_NoIdentitiesMapped()
+        {
+            var identities = new Dictionary<string, UserAssignedIdentities>();
 
-            pool = await terraBatchPoolManager.CreateBatchPoolAsync(poolInfo, false, System.Threading.CancellationToken.None);
+            var poolInfo = new Pool()
+            {
+                DeploymentConfiguration = new DeploymentConfiguration()
+                {
+                    CloudServiceConfiguration = new CloudServiceConfiguration("osfamily", "osversion"),
+                    VirtualMachineConfiguration = new VirtualMachineConfiguration()
+                },
+            };
 
-            Assert.AreEqual(identityName, capturedApiCreateBatchPoolRequest.AzureBatchPool.UserAssignedIdentities.SingleOrDefault().Name);
+            await terraBatchPoolManager.CreateBatchPoolAsync(poolInfo, false, System.Threading.CancellationToken.None);
+
+            Assert.IsFalse(capturedApiCreateBatchPoolRequest.AzureBatchPool.UserAssignedIdentities.Any());
         }
 
         [TestMethod]
@@ -170,7 +210,7 @@ namespace TesApi.Tests
                 }
             };
 
-            var pool = await terraBatchPoolManager.CreateBatchPoolAsync(poolInfo, false, System.Threading.CancellationToken.None);
+            await terraBatchPoolManager.CreateBatchPoolAsync(poolInfo, false, System.Threading.CancellationToken.None);
 
             var captureUserIdentity = capturedApiCreateBatchPoolRequest.AzureBatchPool.StartTask.UserIdentity;
 

--- a/src/TesApi.Web/BatchPool.cs
+++ b/src/TesApi.Web/BatchPool.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -311,7 +311,7 @@ namespace TesApi.Web
         {
             // This method implememts a state machine to disable/enable autoscaling as needed to clear certain conditions that can be observed
             // Inputs are _resetAutoScalingRequired, compute nodes in ejectable states, and the current _scalingMode, along with the pool's
-	    // allocation state and autoscale enablement.
+            // allocation state and autoscale enablement.
             // This method must noop whenthe  allocation state is not Steady
 
             var (allocationState, _, autoScaleEnabled, _, _, _, _) = await _azureProxy.GetFullAllocationStateAsync(Pool.PoolId, cancellationToken);

--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -980,23 +980,9 @@ namespace TesApi.Web
             var nodeTaskCreationOptions = new NodeTaskConversionOptions(
                 DefaultStorageAccountName: defaultStorageAccountName,
                 AdditionalInputs: await GetAdditionalCromwellInputsAsync(task, cancellationToken),
-                NodeManagedIdentityResourceId: GetNodeManagedIdentityResourceId(task)
+                GlobalManagedIdentity: globalManagedIdentity
             );
             return nodeTaskCreationOptions;
-        }
-
-        private string GetNodeManagedIdentityResourceId(TesTask task)
-        {
-            var resourceId =
-                task.Resources?.GetBackendParameterValue(TesResources.SupportedBackendParameters
-                    .workflow_execution_identity);
-
-            if (!string.IsNullOrEmpty(resourceId))
-            {
-                return resourceId;
-            }
-
-            return globalManagedIdentity;
         }
 
         private async Task<List<TesInput>> GetAdditionalCromwellInputsAsync(TesTask task, CancellationToken cancellationToken)

--- a/src/TesApi.Web/Management/Batch/MappingProfilePoolToWsmRequest.cs
+++ b/src/TesApi.Web/Management/Batch/MappingProfilePoolToWsmRequest.cs
@@ -59,7 +59,7 @@ namespace TesApi.Web.Management.Batch
         /// </summary>
         /// <param name="resourceId"></param>
         /// <returns></returns>
-        public static string TryGetManagedIdentityNameFromResourceId(string resourceId)
+        private static string TryGetManagedIdentityNameFromResourceId(string resourceId)
         {
             if (NodeTaskBuilder.IsValidManagedIdentityResourceId(resourceId))
             {

--- a/src/TesApi.Web/Management/Batch/MappingProfilePoolToWsmRequest.cs
+++ b/src/TesApi.Web/Management/Batch/MappingProfilePoolToWsmRequest.cs
@@ -5,7 +5,9 @@ using System;
 using System.Linq;
 using AutoMapper;
 using Microsoft.Azure.Management.Batch.Models;
+using Microsoft.Azure.Management.ContainerRegistry.Fluent.Models;
 using TesApi.Web.Management.Models.Terra;
+using TesApi.Web.Runner;
 
 namespace TesApi.Web.Management.Batch
 {
@@ -48,7 +50,30 @@ namespace TesApi.Web.Management.Batch
                 .ForMember(dest => dest.ResourceGroupName, opt => opt.Ignore())
                 .ForMember(dest => dest.Name, opt => opt.Ignore());
             CreateMap<Pool, ApiAzureBatchPool>()
-               .ForMember(dest => dest.UserAssignedIdentities, opt => opt.MapFrom(src => src.Identity.UserAssignedIdentities.Select(kvp => new ApiUserAssignedIdentity() { Name = kvp.Key, ClientId = kvp.Value.ClientId })));
+               .ForMember(dest => dest.UserAssignedIdentities, opt => opt.MapFrom(src => src.Identity.UserAssignedIdentities.Select(kvp => new ApiUserAssignedIdentity() { Name = TryGetManagedIdentityNameFromResourceId(kvp.Key), ClientId = kvp.Value.ClientId })));
+        }
+
+        /// <summary>
+        /// Gets name of the managed identity if the resource ID is a valid Azure MI resource ID.        
+        /// If the resource ID is not a valid Resource ID, returns the value provided.
+        /// </summary>
+        /// <param name="resourceId"></param>
+        /// <returns></returns>
+        public static string TryGetManagedIdentityNameFromResourceId(string resourceId)
+        {
+            if (NodeTaskBuilder.IsValidManagedIdentityResourceId(resourceId))
+            {
+                var parts = resourceId.Split('/');
+
+                if (parts.Length < 2)
+                {
+                    return string.Empty;
+                }
+
+                return parts[^1];
+            }
+
+            return resourceId;
         }
     }
 }

--- a/src/TesApi.Web/Runner/NodeTaskBuilder.cs
+++ b/src/TesApi.Web/Runner/NodeTaskBuilder.cs
@@ -264,12 +264,17 @@ namespace TesApi.Web.Runner
         }
 
         /// <summary>
-        /// Sets managed identity for the node task
+        /// Sets managed identity for the node task. If the resource ID is empty or null, the property won't be set.
         /// </summary>
-        /// <param name="resourceId"></param>
+        /// <param name="resourceId">A valid managed identity resource ID</param>
         /// <returns></returns>
         public NodeTaskBuilder WithResourceIdManagedIdentity(string resourceId)
         {
+            if (string.IsNullOrEmpty(resourceId))
+            {
+                return this;
+            }
+
             if (!IsValidManagedIdentityResourceId(resourceId))
             {
                 throw new ArgumentException("Invalid resource ID. The ID must be a valid Azure resource ID.", nameof(resourceId));

--- a/src/TesApi.Web/Runner/TaskToNodeTaskConverter.cs
+++ b/src/TesApi.Web/Runner/TaskToNodeTaskConverter.cs
@@ -426,7 +426,6 @@ namespace TesApi.Web.Runner
 
             return inputPath;
         }
-
     }
 
     /// <summary>

--- a/src/TesApi.Web/Runner/TaskToNodeTaskConverter.cs
+++ b/src/TesApi.Web/Runner/TaskToNodeTaskConverter.cs
@@ -433,6 +433,7 @@ namespace TesApi.Web.Runner
     /// </summary>
     /// <param name="AdditionalInputs"></param>
     /// <param name="DefaultStorageAccountName"></param>
+    /// <param name="GlobalManagedIdentity"></param>
     public record NodeTaskConversionOptions(IList<TesInput> AdditionalInputs = default, string DefaultStorageAccountName = default,
         string GlobalManagedIdentity = default);
 }


### PR DESCRIPTION
Fixes: #485 

In this PR:

- If the workflow identity has a value that is not a valid Azure resource ID, `TaskToNodeTaskConverter` creates a resource ID for the runner's managed identity (MI) using the BatchAccount's subscription and resource group.
  - The `TaskToNodeTaskConverter` assumes the value in the workflow identity is the name of the MI resource.  
 
- If the workflow identity has a value that is a valid Azure resource ID for the MI, `TaskToNodeTaskConverter` assigns that value to the runner's MI resource ID.
  - When calling WSM to create a batch pool, the identity name is extracted from the resource ID. 

- If the workflow identity is not specified, the `TaskToNodeTaskConverter` uses the global MI setting as a fallback.

- Added validation to the `NodeTaskBuilder` to ensure that only valid Azure resource IDs are allowed in the runner task.


