### PR TITLE
[489] Executor sets the number of files for event data

### DIFF
--- a/src/Tes.Runner/Executor.cs
+++ b/src/Tes.Runner/Executor.cs
@@ -20,8 +20,9 @@ namespace Tes.Runner
         private readonly FileOperationResolver operationResolver;
         private readonly VolumeBindingsGenerator volumeBindingsGenerator = new VolumeBindingsGenerator();
         private readonly EventsPublisher eventsPublisher;
+        private readonly ITransferOperationFactory transferOperationFactory;
 
-        public Executor(NodeTask tesNodeTask, EventsPublisher eventsPublisher) : this(tesNodeTask, new FileOperationResolver(tesNodeTask), eventsPublisher)
+        public Executor(NodeTask tesNodeTask, EventsPublisher eventsPublisher) : this(tesNodeTask, new FileOperationResolver(tesNodeTask), eventsPublisher, new TransferOperationFactory())
         {
         }
 
@@ -32,8 +33,9 @@ namespace Tes.Runner
             return new Executor(nodeTask, publisher);
         }
 
-        public Executor(NodeTask tesNodeTask, FileOperationResolver operationResolver, EventsPublisher eventsPublisher)
+        public Executor(NodeTask tesNodeTask, FileOperationResolver operationResolver, EventsPublisher eventsPublisher, ITransferOperationFactory transferOperationFactory)
         {
+            ArgumentNullException.ThrowIfNull(transferOperationFactory);
             ArgumentNullException.ThrowIfNull(tesNodeTask);
             ArgumentNullException.ThrowIfNull(operationResolver);
             ArgumentNullException.ThrowIfNull(eventsPublisher);
@@ -41,6 +43,8 @@ namespace Tes.Runner
             this.tesNodeTask = tesNodeTask;
             this.operationResolver = operationResolver;
             this.eventsPublisher = eventsPublisher;
+            this.transferOperationFactory = transferOperationFactory;
+
         }
 
         public async Task<NodeTaskResult> ExecuteNodeContainerTaskAsync(DockerExecutor dockerExecutor)
@@ -136,9 +140,7 @@ namespace Tes.Runner
 
         private async Task<long> UploadOutputsAsync(BlobPipelineOptions blobPipelineOptions, List<UploadInfo> outputs)
         {
-            var memoryBufferChannel = await MemoryBufferPoolFactory.CreateMemoryBufferPoolAsync(blobPipelineOptions.MemoryBufferCapacity, blobPipelineOptions.BlockSizeBytes);
-
-            var uploader = new BlobUploader(blobPipelineOptions, memoryBufferChannel);
+            var uploader = await transferOperationFactory.CreateBlobUploaderAsync(blobPipelineOptions);
 
             var executionResult = await TimedExecutionAsync(async () => await uploader.UploadAsync(outputs));
 
@@ -204,6 +206,8 @@ namespace Tes.Runner
                     return numberOfInputs;
                 }
 
+                numberOfInputs = inputs.Count;
+
                 var optimizedOptions = OptimizeBlobPipelineOptionsForDownload(blobPipelineOptions);
 
                 bytesTransferred = await DownloadInputsAsync(optimizedOptions, inputs);
@@ -227,9 +231,7 @@ namespace Tes.Runner
 
         private async Task<long> DownloadInputsAsync(BlobPipelineOptions blobPipelineOptions, List<DownloadInfo> inputs)
         {
-            var memoryBufferChannel = await MemoryBufferPoolFactory.CreateMemoryBufferPoolAsync(blobPipelineOptions.MemoryBufferCapacity, blobPipelineOptions.BlockSizeBytes);
-
-            var downloader = new BlobDownloader(blobPipelineOptions, memoryBufferChannel);
+            var downloader = await transferOperationFactory.CreateBlobDownloaderAsync(blobPipelineOptions);
 
             var executionResult = await TimedExecutionAsync(async () => await downloader.DownloadAsync(inputs));
 

--- a/src/Tes.Runner/ITransferOperationFactory.cs
+++ b/src/Tes.Runner/ITransferOperationFactory.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Tes.Runner.Transfer;
+
+namespace Tes.Runner;
+
+/// <summary>
+/// Default implementation of the pipeline transfer operations.
+/// </summary>
+public interface ITransferOperationFactory
+{
+    Task<BlobDownloader> CreateBlobDownloaderAsync(BlobPipelineOptions blobPipelineOptions);
+    Task<BlobUploader> CreateBlobUploaderAsync(BlobPipelineOptions blobPipelineOptions);
+}

--- a/src/Tes.Runner/Transfer/BlobDownloader.cs
+++ b/src/Tes.Runner/Transfer/BlobDownloader.cs
@@ -17,11 +17,18 @@ public class BlobDownloader : BlobOperationPipeline
     }
 
     /// <summary>
+    /// Parameter-less constructor for mocking
+    /// </summary>
+    protected BlobDownloader() : base(new BlobPipelineOptions(), Channel.CreateUnbounded<byte[]>())
+    {
+    }
+
+    /// <summary>
     /// Downloads a list of files from an HTTP source.
     /// </summary>
     /// <param name="downloadList">A list of <see cref="DownloadInfo"/></param>
     /// <returns>Total bytes downloaded</returns>
-    public async ValueTask<long> DownloadAsync(List<DownloadInfo> downloadList)
+    public virtual async ValueTask<long> DownloadAsync(List<DownloadInfo> downloadList)
     {
         ValidateDownloadList(downloadList);
 

--- a/src/Tes.Runner/Transfer/BlobUploader.cs
+++ b/src/Tes.Runner/Transfer/BlobUploader.cs
@@ -19,6 +19,13 @@ namespace Tes.Runner.Transfer
         }
 
         /// <summary>
+        /// Parameter-less constructor for mocking
+        /// </summary>
+        protected BlobUploader() : base(new BlobPipelineOptions(), Channel.CreateUnbounded<byte[]>())
+        {
+        }
+
+        /// <summary>
         /// Configures each part with the put block URL.
         /// </summary>
         /// <param name="buffer">Pipeline buffer to configure</param>
@@ -144,7 +151,7 @@ namespace Tes.Runner.Transfer
         /// </summary>
         /// <param name="uploadList">File upload list.</param>
         /// <returns></returns>
-        public async Task<long> UploadAsync(List<UploadInfo> uploadList)
+        public virtual async Task<long> UploadAsync(List<UploadInfo> uploadList)
         {
             ValidateUploadList(uploadList);
 

--- a/src/Tes.Runner/TransferOperationFactory.cs
+++ b/src/Tes.Runner/TransferOperationFactory.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Tes.Runner.Transfer;
+
+namespace Tes.Runner;
+
+/// <summary>
+/// Factory of the pipeline transfer operations.
+/// </summary>
+public class TransferOperationFactory : ITransferOperationFactory
+{
+    public async Task<BlobDownloader> CreateBlobDownloaderAsync(BlobPipelineOptions blobPipelineOptions)
+    {
+        var memoryBufferChannel = await MemoryBufferPoolFactory.CreateMemoryBufferPoolAsync(blobPipelineOptions.MemoryBufferCapacity, blobPipelineOptions.BlockSizeBytes);
+
+        return new BlobDownloader(blobPipelineOptions, memoryBufferChannel);
+    }
+
+    public async Task<BlobUploader> CreateBlobUploaderAsync(BlobPipelineOptions blobPipelineOptions)
+    {
+        var memoryBufferChannel = await MemoryBufferPoolFactory.CreateMemoryBufferPoolAsync(blobPipelineOptions.MemoryBufferCapacity, blobPipelineOptions.BlockSizeBytes);
+
+        return new BlobUploader(blobPipelineOptions, memoryBufferChannel);
+    }
+}

--- a/src/TesApi.Web/BatchPool.cs
+++ b/src/TesApi.Web/BatchPool.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -311,7 +311,7 @@ namespace TesApi.Web
         {
             // This method implememts a state machine to disable/enable autoscaling as needed to clear certain conditions that can be observed
             // Inputs are _resetAutoScalingRequired, compute nodes in ejectable states, and the current _scalingMode, along with the pool's
-	    // allocation state and autoscale enablement.
+            // allocation state and autoscale enablement.
             // This method must noop whenthe  allocation state is not Steady
 
             var (allocationState, _, autoScaleEnabled, _, _, _, _) = await _azureProxy.GetFullAllocationStateAsync(Pool.PoolId, cancellationToken);


### PR DESCRIPTION
Fixes: #489 

In this PR:
 - The executor sets the number of files for the event data correctly.
 - Added factory abstraction for the creation of uploader and downloaders inside executor, to faciliate testing. 
 - The test validates the correction.
