### PR TITLE
[491] Node task builder sets the correct transformation strategy for log streaming when running on Terra

### DIFF
--- a/src/TesApi.Tests/Runner/NodeTaskBuilderTests.cs
+++ b/src/TesApi.Tests/Runner/NodeTaskBuilderTests.cs
@@ -166,5 +166,16 @@ namespace TesApi.Tests.Runner
             Assert.AreEqual(url, nodeTask.RuntimeOptions.StreamingLogPublisher!.TargetUrl);
             Assert.AreEqual(TransformationStrategy.CombinedAzureResourceManager, nodeTask.RuntimeOptions.StreamingLogPublisher.TransformationStrategy);
         }
+
+        [TestMethod]
+        public void WithLogPublisher_CalledThenSetUpTerraRuntimeEnv_LogTargetUrlTransformationStrategyIsTerra()
+        {
+            var url = "https://foo.blob.core.windows.net/cont/log";
+            nodeTaskBuilder.WithLogPublisher(url)
+                .WithTerraAsRuntimeEnvironment("http://wsm.terra.foo", "http://lz.terra.foo", sasAllowedIpRange: null);
+            var nodeTask = nodeTaskBuilder.Build();
+
+            Assert.AreEqual(TransformationStrategy.CombinedTerra, nodeTask.RuntimeOptions.StreamingLogPublisher!.TransformationStrategy);
+        }
     }
 }

--- a/src/TesApi.Web/Runner/NodeTaskBuilder.cs
+++ b/src/TesApi.Web/Runner/NodeTaskBuilder.cs
@@ -192,7 +192,7 @@ namespace TesApi.Web.Runner
                 SasAllowedIpRange = sasAllowedIpRange
             };
 
-            SetCombinedTerraTransformationStrategyForInputsAndOutputs();
+            SetCombinedTerraTransformationStrategyForAllTransformations();
 
             return this;
         }
@@ -207,7 +207,7 @@ namespace TesApi.Web.Runner
             return nodeTask;
         }
 
-        private void SetCombinedTerraTransformationStrategyForInputsAndOutputs()
+        private void SetCombinedTerraTransformationStrategyForAllTransformations()
         {
             if (nodeTask.Inputs != null)
             {
@@ -228,6 +228,11 @@ namespace TesApi.Web.Runner
             if (nodeTask.RuntimeOptions.StorageEventSink is not null)
             {
                 nodeTask.RuntimeOptions.StorageEventSink.TransformationStrategy = TransformationStrategy.CombinedTerra;
+            }
+
+            if (nodeTask.RuntimeOptions.StreamingLogPublisher is not null)
+            {
+                nodeTask.RuntimeOptions.StreamingLogPublisher.TransformationStrategy = TransformationStrategy.CombinedTerra;
             }
         }
 


### PR DESCRIPTION
Fixes: #491

In this PR:
 - The `NodeTaskBuilder` sets the correct UrlTransformation strategy when running on Terra, for the log publisher. 