### PR TITLE
[498] Terra URL transformation strategy caches WSM container resource ID when generating the SAS token

### DIFF
--- a/src/Tes.Runner.Test/Storage/TerraUrlTransformationStrategyTests.cs
+++ b/src/Tes.Runner.Test/Storage/TerraUrlTransformationStrategyTests.cs
@@ -119,6 +119,16 @@ namespace Tes.Runner.Test.Storage
         }
 
         [TestMethod]
+        public async Task TransformUrlWithStrategyAsync_RequestsSasTokenMoreThanOnce_WsmResourceIdIsCached()
+        {
+            var sourceUrl = $"{stubTerraBlobUrl}/blob";
+            await transformationStrategy.TransformUrlWithStrategyAsync(sourceUrl, BlobSasPermissions.Read);
+            await transformationStrategy.TransformUrlWithStrategyAsync(sourceUrl, BlobSasPermissions.Read);
+            await transformationStrategy.TransformUrlWithStrategyAsync(sourceUrl, BlobSasPermissions.Read);
+            mockTerraWsmApiClient.Verify(w => w.GetContainerResourcesAsync(It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
         public async Task TransformUrlWithStrategyAsync_RequestsSasTokenMoreThanOnceAfterExpiration_SasTokenIsRenewed()
         {
             var sourceUrl = $"{stubTerraBlobUrl}/blob";

--- a/src/Tes.Runner.Test/Storage/TerraUrlTransformationStrategyTests.cs
+++ b/src/Tes.Runner.Test/Storage/TerraUrlTransformationStrategyTests.cs
@@ -123,7 +123,7 @@ namespace Tes.Runner.Test.Storage
         }
 
         [TestMethod]
-        public async Task TransformUrlWithStrategyAsync_RequestsSasTokenUsingWithMultipleStrategyInstances_SasTokenIsCachedAcrossInstances()
+        public async Task TransformUrlWithStrategyAsync_RequestsSasTokenUsingMultipleStrategyInstances_SasTokenIsCachedAcrossInstances()
         {
             var sourceUrl = $"{stubTerraBlobUrl}/blob";
             await transformationStrategy.TransformUrlWithStrategyAsync(sourceUrl, BlobSasPermissions.Read);

--- a/src/Tes.Runner/Storage/TerraUrlTransformationStrategy.cs
+++ b/src/Tes.Runner/Storage/TerraUrlTransformationStrategy.cs
@@ -26,7 +26,7 @@ namespace Tes.Runner.Storage
         private readonly TerraWsmApiClient terraWsmApiClient;
         private readonly TerraRuntimeOptions terraRuntimeOptions;
         private readonly ILogger<TerraUrlTransformationStrategy> logger = PipelineLoggerFactory.Create<TerraUrlTransformationStrategy>();
-        private readonly IMemoryCache memoryCache;
+        private static IMemoryCache memoryCache = new MemoryCache(new MemoryCacheOptions());
         private readonly int cacheExpirationInSeconds;
 
         public TerraUrlTransformationStrategy(TerraRuntimeOptions terraRuntimeOptions, TokenCredential tokenCredential, int cacheExpirationInSeconds = CacheExpirationInSeconds)
@@ -36,7 +36,6 @@ namespace Tes.Runner.Storage
 
             terraWsmApiClient = TerraWsmApiClient.CreateTerraWsmApiClient(terraRuntimeOptions.WsmApiHost, tokenCredential);
             this.terraRuntimeOptions = terraRuntimeOptions;
-            memoryCache = new MemoryCache(new MemoryCacheOptions());
             this.cacheExpirationInSeconds = cacheExpirationInSeconds;
         }
 
@@ -48,7 +47,6 @@ namespace Tes.Runner.Storage
 
             this.terraWsmApiClient = terraWsmApiClient;
             this.terraRuntimeOptions = terraRuntimeOptions;
-            memoryCache = new MemoryCache(new MemoryCacheOptions());
             this.cacheExpirationInSeconds = cacheExpirationInSeconds;
         }
 
@@ -66,7 +64,11 @@ namespace Tes.Runner.Storage
 
             return await GetMappedSasUrlFromWsmAsync(blobInfo, blobSasPermissions);
         }
-
+        public void ClearCache()
+        {
+            memoryCache.Dispose();
+            memoryCache = new MemoryCache(new MemoryCacheOptions());
+        }
         /// <summary>
         /// Returns a Url with a SAS token for the given input
         /// </summary>


### PR DESCRIPTION
Fixes: #498 

In this PR:
 - The `TerraUrlTransformationStrategy` caches the WSM resource ID.
- The cache is accessible to all instances of the `TerraUrlTransformationStrategy`.