### PR TITLE
[507] Disable nullable settings in project

### DIFF
--- a/src/Tes.ApiClients/Tes.ApiClients.csproj
+++ b/src/Tes.ApiClients/Tes.ApiClients.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tes.Runner.Test/Commands/ProcessLauncherTests.cs
+++ b/src/Tes.Runner.Test/Commands/ProcessLauncherTests.cs
@@ -12,7 +12,7 @@ namespace Tes.Runner.Test.Commands
     public class ProcessLauncherTests
     {
         private ProcessLauncher processLauncher = null!;
-        private Mock<IStreamLogReader> streamLogReaderMock;
+        private Mock<IStreamLogReader> streamLogReaderMock = null!;
 
         [TestInitialize]
         public void SetUp()

--- a/src/Tes.Runner.Test/Transfer/BlobApiHttpUtilsTests.cs
+++ b/src/Tes.Runner.Test/Transfer/BlobApiHttpUtilsTests.cs
@@ -246,7 +246,7 @@ namespace Tes.Runner.Test.Transfer
             }
             else
             {
-                Assert.AreEqual(expectedContent, await request?.Content?.ReadAsStringAsync());
+                Assert.AreEqual(expectedContent, await request?.Content?.ReadAsStringAsync()!);
             }
 
 


### PR DESCRIPTION
Fixes: #507 

In this PR:
 - Disable nullable setting in the API clients project.
 - Minor factoring to remove warnings and static code analysis issues in test files. 