### PR TITLE
Attempt revival of Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+registries:
+  public:
+    type: nuget-feed
+    url: https://api.nuget.org/v3/index.json
+updates:
+  - package-ecosystem: nuget
+    directory: "/"
+    registries: "*"
+    schedule:
+      interval: daily


### PR DESCRIPTION
Based on [this section](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/removing-dependabot-access-to-public-registries#nuget) of the docs