### PR TITLE
Add global exception handler that logs unhandled controller exceptions

### DIFF
--- a/src/Tes/Repository/PostgreSqlCachingRepository.cs
+++ b/src/Tes/Repository/PostgreSqlCachingRepository.cs
@@ -57,15 +57,15 @@ namespace Tes.Repository
             writerWorkerTask = Task.Run(() => WriterWorkerAsync(writerWorkerCancellationTokenSource.Token))
                 .ContinueWith(async task =>
                 {
-                    switch (task.Status)
+                    if (task.Status == TaskStatus.Faulted)
                     {
-                        case TaskStatus.Faulted:
-                            Logger.LogCritical("Repository WriterWorkerAsync failed unexpectedly with: {ErrorMessage}.", task.Exception.Message);
-                            break;
-                        case TaskStatus.RanToCompletion:
-                            Logger.LogCritical("Repository WriterWorkerAsync unexpectedly completed.");
-                            break;
+                        Logger.LogCritical("Repository WriterWorkerAsync failed unexpectedly with: {ErrorMessage}.", task.Exception.Message);
                     }
+
+
+                    var errorMessage = $"Repository WriterWorkerAsync unexpectedly ended with TaskStatus: {task.Status}";
+                    Logger.LogCritical(errorMessage);
+                    Console.WriteLine(errorMessage);
 
                     await Task.Delay(50); // Give the logger time to flush.
                     hostApplicationLifetime?.StopApplication();

--- a/src/Tes/Repository/PostgreSqlCachingRepository.cs
+++ b/src/Tes/Repository/PostgreSqlCachingRepository.cs
@@ -62,7 +62,6 @@ namespace Tes.Repository
                         Logger.LogCritical("Repository WriterWorkerAsync failed unexpectedly with: {ErrorMessage}.", task.Exception.Message);
                     }
 
-
                     var errorMessage = $"Critical issue: the repository WriterWorkerAsync unexpectedly ended with TaskStatus: {task.Status}. The TES application will now be stopped.";
                     Logger.LogCritical(errorMessage);
                     Console.WriteLine(errorMessage);

--- a/src/Tes/Repository/PostgreSqlCachingRepository.cs
+++ b/src/Tes/Repository/PostgreSqlCachingRepository.cs
@@ -63,11 +63,11 @@ namespace Tes.Repository
                     }
 
 
-                    var errorMessage = $"Repository WriterWorkerAsync unexpectedly ended with TaskStatus: {task.Status}";
+                    var errorMessage = $"Critical issue: the repository WriterWorkerAsync unexpectedly ended with TaskStatus: {task.Status}. The TES application will now be stopped.";
                     Logger.LogCritical(errorMessage);
                     Console.WriteLine(errorMessage);
 
-                    await Task.Delay(50); // Give the logger time to flush.
+                    await Task.Delay(TimeSpan.FromSeconds(5)); // Give the logger time to flush.
                     hostApplicationLifetime?.StopApplication();
                 },
                 TaskContinuationOptions.NotOnCanceled);

--- a/src/Tes/Repository/PostgreSqlCachingRepository.cs
+++ b/src/Tes/Repository/PostgreSqlCachingRepository.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Polly;
-using Tes.Models;
 
 namespace Tes.Repository
 {

--- a/src/TesApi.Web/Startup.cs
+++ b/src/TesApi.Web/Startup.cs
@@ -365,11 +365,11 @@ namespace TesApi.Web
             {
                 if (e.IsTerminating)
                 {
-                    logger?.LogCritical("A failure is terminating the service: {ExceptionObjectType}:{ExceptionObjectString}", e.ExceptionObject.GetType().FullName, e.ExceptionObject.ToString());
+                    logger?.LogCritical("A failure is terminating the service: {ExceptionObjectType}:{ExceptionObjectString}", e.ExceptionObject?.GetType().FullName ?? "<missing>", e.ExceptionObject?.ToString() ?? "<null>");
                 }
                 else
                 {
-                    logger?.LogCritical("A failure was not processed normally: {ExceptionObjectType}:{ExceptionObjectString}", e.ExceptionObject.GetType().FullName, e.ExceptionObject.ToString());
+                    logger?.LogCritical("A failure was not processed normally: {ExceptionObjectType}:{ExceptionObjectString}", e.ExceptionObject?.GetType().FullName ?? "<missing>", e.ExceptionObject?.ToString() ?? "<null>");
                 }
             }
         }

--- a/src/TesApi.Web/Startup.cs
+++ b/src/TesApi.Web/Startup.cs
@@ -314,7 +314,7 @@ namespace TesApi.Web
                                 if (exceptionHandlerFeature != null)
                                 {
                                     var exception = exceptionHandlerFeature.Error;
-                                    logger.LogError(exception, "An unexpected error occurred");
+                                    logger.LogError(exception, "An unexpected error occurred while processing an API request.");
 
                                     context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
                                     context.Response.ContentType = "application/json";

--- a/src/TesApi.Web/Startup.cs
+++ b/src/TesApi.Web/Startup.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Net;
 using System.Reflection;
+using System.Threading;
 using Azure.Core;
 using Azure.Identity;
 using CommonUtilities;
@@ -147,8 +148,9 @@ namespace TesApi.Web
             }
             catch (Exception exc)
             {
-                logger?.LogCritical(exc, @"TES could not start: {ExceptionMessage}", exc.Message);
-                Console.WriteLine($"TES could not start: {exc}");
+                logger?.LogCritical(exc, @"TES threw an exception in ConfigureServices and could not start: {ExceptionMessage}", exc.Message);
+                Console.WriteLine($"TES threw an exception in ConfigureServices and could not start: {exc}");
+                Thread.Sleep(TimeSpan.FromSeconds(40)); // Give the logger time to flush; default flush is 30s
                 throw;
             }
 
@@ -335,8 +337,9 @@ namespace TesApi.Web
             }
             catch (Exception exc)
             {
-                logger?.LogCritical(exc, @"TES could not start: {ExceptionMessage}", exc.Message);
-                Console.WriteLine($"TES could not start: {exc}");
+                logger?.LogCritical(exc, @"TES threw an exception in Configure(IApplicationBuilder app) and could not start: {ExceptionMessage}", exc.Message);
+                Console.WriteLine($"TES threw an exception in Configure(IApplicationBuilder app) and could not start: {exc}");
+                Thread.Sleep(TimeSpan.FromSeconds(40)); // Give the logger time to flush; default flush is 30s
                 throw;
             }
         }


### PR DESCRIPTION
Resolves #599 
- Add global exception handler that logs unhandled controller exceptions
- Simplify the one instance where the application could be stopped, and log the task state