### PR TITLE
Explicitly set URL TES listens on

### DIFF
--- a/src/TesApi.Web/Program.cs
+++ b/src/TesApi.Web/Program.cs
@@ -32,11 +32,15 @@ namespace TesApi.Web
         /// <returns><see cref="IWebHostBuilder"/></returns>
         public static IWebHostBuilder CreateWebHostBuilder(string[] args)
         {
-            Console.WriteLine($"TES v{Startup.TesVersion} build {System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}");
+            Console.WriteLine($"TES v{Startup.TesVersion}");
 
             Options.ApplicationInsightsOptions applicationInsightsOptions = default;
-            var builder = WebHost.CreateDefaultBuilder<Startup>(args)
-                .UseUrls("http://0.0.0.0:80");
+            var builder = WebHost.CreateDefaultBuilder<Startup>(args);
+
+            if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("ASPNETCORE_URLS")))
+            {
+                builder.UseUrls("http://0.0.0.0:80");
+            }
 
             builder.ConfigureAppConfiguration((context, config) =>
             {

--- a/src/TesApi.Web/Program.cs
+++ b/src/TesApi.Web/Program.cs
@@ -35,11 +35,12 @@ namespace TesApi.Web
             Console.WriteLine($"TES v{Startup.TesVersion} build {System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}");
 
             Options.ApplicationInsightsOptions applicationInsightsOptions = default;
-            var builder = WebHost.CreateDefaultBuilder<Startup>(args);
+            var builder = WebHost.CreateDefaultBuilder<Startup>(args)
+                .UseUrls("http://0.0.0.0:80");
 
             builder.ConfigureAppConfiguration((context, config) =>
             {
-                config.AddEnvironmentVariables(); // For Docker-Compose
+                config.AddEnvironmentVariables();
                 applicationInsightsOptions = GetApplicationInsightsConnectionString(config.Build());
 
                 if (!string.IsNullOrEmpty(applicationInsightsOptions?.ConnectionString))


### PR DESCRIPTION
Resolves #607 

Environment Variable Override: Environment variables are read after the in-code configurations. If an ASPNETCORE_URLS environment variable is set, it overrides the URL specified in the .UseUrls() method due to the environment variable having a higher precedence in the configuration system.