### PR TITLE
Remove AppAuthentication library and replace with Azure.Identity

### DIFF
--- a/src/CommonUtilities/CommonUtilities.csproj
+++ b/src/CommonUtilities/CommonUtilities.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.38.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />

--- a/src/CommonUtilities/RefreshableAzureServiceTokenProvider.cs
+++ b/src/CommonUtilities/RefreshableAzureServiceTokenProvider.cs
@@ -14,7 +14,7 @@ namespace CommonUtilities
     {
         private readonly string resource;
         private readonly string? tenantId;
-        private readonly DefaultAzureCredential azureCredential;
+        private readonly AzureCliCredential azureCredential;
 
         /// <summary>
         /// Constructor.
@@ -29,7 +29,7 @@ namespace CommonUtilities
             this.resource = resource;
             this.tenantId = tenantId;
 
-            this.azureCredential = new DefaultAzureCredential();
+            this.azureCredential = new AzureCliCredential();
         }
 
         /// <summary>

--- a/src/TesApi.Tests/Repository/TesTaskPostgreSqlRepositoryIntegrationTests.cs
+++ b/src/TesApi.Tests/Repository/TesTaskPostgreSqlRepositoryIntegrationTests.cs
@@ -351,7 +351,7 @@ namespace Tes.Repository.Tests
         {
             const string postgreSqlVersion = "14";
 
-            var tokenCredentials = new TokenCredentials(new RefreshableAzureServiceTokenProvider("https://management.azure.com/"));
+            var tokenCredentials = new TokenCredentials(new RefreshableAzureServiceTokenProvider("https://management.azure.com//.default"));
             var azureCredentials = new AzureCredentials(tokenCredentials, null, null, AzureEnvironment.AzureGlobalCloud);
             var postgresManagementClient = new FlexibleServer.PostgreSQLManagementClient(azureCredentials) { SubscriptionId = subscriptionId, LongRunningOperationRetryTimeout = 1200 };
             var azureClient = GetAzureClient(azureCredentials);
@@ -404,7 +404,7 @@ namespace Tes.Repository.Tests
 
         public static async Task DeleteResourceGroupAsync(string subscriptionId, string resourceGroupName)
         {
-            var tokenCredentials = new TokenCredentials(new RefreshableAzureServiceTokenProvider("https://management.azure.com/"));
+            var tokenCredentials = new TokenCredentials(new RefreshableAzureServiceTokenProvider("https://management.azure.com//.default"));
             var azureCredentials = new AzureCredentials(tokenCredentials, null, null, AzureEnvironment.AzureGlobalCloud);
             var azureClient = GetAzureClient(azureCredentials);
             var azureSubscriptionClient = azureClient.WithSubscription(subscriptionId);

--- a/src/TesApi.Web/AzureProxy.cs
+++ b/src/TesApi.Web/AzureProxy.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Identity;
 using CommonUtilities;
 using Microsoft.Azure.Batch;
 using Microsoft.Azure.Batch.Auth;
@@ -553,8 +554,8 @@ namespace TesApi.Web
         public string GetArmRegion()
             => location;
 
-        private static Task<string> GetAzureAccessTokenAsync(CancellationToken cancellationToken, string resource = "https://management.azure.com/")
-            => new AzureServiceTokenProvider().GetAccessTokenAsync(resource, cancellationToken: cancellationToken);
+        private static async Task<string> GetAzureAccessTokenAsync(CancellationToken cancellationToken, string scope = "https://management.azure.com//.default")
+            => (await (new DefaultAzureCredential()).GetTokenAsync(new Azure.Core.TokenRequestContext(new string[] { scope }), cancellationToken)).Token;
 
         /// <summary>
         /// Gets an authenticated Azure Client instance

--- a/src/TesApi.Web/Management/AzureManagementClientsFactory.cs
+++ b/src/TesApi.Web/Management/AzureManagementClientsFactory.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Azure.Management.Batch;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
-using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Rest;
 using FluentAzure = Microsoft.Azure.Management.Fluent.Azure;
 
@@ -53,8 +53,8 @@ namespace TesApi.Web.Management
         /// </summary>
         protected AzureManagementClientsFactory() { }
 
-        private static Task<string> GetAzureAccessTokenAsync(CancellationToken cancellationToken, string resource = "https://management.azure.com/")
-            => new AzureServiceTokenProvider().GetAccessTokenAsync(resource, cancellationToken: cancellationToken);
+        private static async Task<string> GetAzureAccessTokenAsync(CancellationToken cancellationToken, string scope = "https://management.azure.com//.default")
+            => (await (new DefaultAzureCredential()).GetTokenAsync(new Azure.Core.TokenRequestContext(new string[] { scope }), cancellationToken)).Token;
 
         /// <summary>
         /// Creates Batch Account management client using AAD authentication.

--- a/src/TesApi.Web/TesApi.Web.csproj
+++ b/src/TesApi.Web/TesApi.Web.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Azure.Batch" Version="16.1.0" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
     <!--Mitigate reported security issues-->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/deploy-tes-on-azure/Deployer.cs
+++ b/src/deploy-tes-on-azure/Deployer.cs
@@ -141,7 +141,7 @@ namespace TesDeployer
 
                 await Execute("Connecting to Azure Services...", async () =>
                 {
-                    tokenProvider = new RefreshableAzureServiceTokenProvider("https://management.azure.com/");
+                    tokenProvider = new RefreshableAzureServiceTokenProvider("https://management.azure.com//.default");
                     tokenCredentials = new(tokenProvider);
                     azureCredentials = new(tokenCredentials, null, null, AzureEnvironment.AzureGlobalCloud);
                     armClient = new ArmClient(new DefaultAzureCredential());

--- a/src/deploy-tes-on-azure/Deployer.cs
+++ b/src/deploy-tes-on-azure/Deployer.cs
@@ -2201,7 +2201,7 @@ namespace TesDeployer
         {
             try
             {
-                _ = await Execute("Retrieving Azure management token...", async () => (await (new DefaultAzureCredential()).GetTokenAsync(new Azure.Core.TokenRequestContext(new string[] { "https://management.azure.com//.default" }))).Token);
+                _ = await Execute("Retrieving Azure management token...", async () => (await (new AzureCliCredential()).GetTokenAsync(new Azure.Core.TokenRequestContext(new string[] { "https://management.azure.com//.default" }))).Token);
             }
             catch (AuthenticationFailedException ex)
             {

--- a/src/deploy-tes-on-azure/deploy-tes-on-azure.csproj
+++ b/src/deploy-tes-on-azure/deploy-tes-on-azure.csproj
@@ -37,7 +37,6 @@
     <PackageReference Include="Microsoft.Azure.Management.PostgreSQL" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ContainerService" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceGraph" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />


### PR DESCRIPTION
Part of https://github.com/microsoft/CromwellOnAzure/issues/532 
Replace AppAuthentication with Azure.Identity to be compatible with AKS workload identity. 