### PR TITLE
[656] Empty parts don't make HTTP requests

### DIFF
--- a/src/Tes.Runner.Test/BlobDownloaderIntegrationTests.cs
+++ b/src/Tes.Runner.Test/BlobDownloaderIntegrationTests.cs
@@ -11,7 +11,7 @@ namespace Tes.Runner.Test
     [TestClass]
     [TestCategory("Integration")]
     [Ignore]
-    public class BlobDownloaderTest
+    public class BlobDownloaderIntegrationTests
     {
 #pragma warning disable CS8618
         private BlobContainerClient blobContainerClient;

--- a/src/Tes.Runner.Test/Transfer/BlobDownloaderTests.cs
+++ b/src/Tes.Runner.Test/Transfer/BlobDownloaderTests.cs
@@ -25,7 +25,7 @@ namespace Tes.Runner.Transfer.Tests
 
             var part = new PipelineBuffer()
             {
-                BlobPartUrl = new Uri("https://foo.com"), //This invalid on purpose, as we don't want to make a real request
+                BlobPartUrl = new Uri("https://foo.com"), //This is invalid on purpose, as we don't want to make a real request
                 FileName = "emptyFile",
                 Length = 0,
                 Offset = 0,

--- a/src/Tes.Runner.Test/Transfer/BlobDownloaderTests.cs
+++ b/src/Tes.Runner.Test/Transfer/BlobDownloaderTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Storage.Blobs;
+
+namespace Tes.Runner.Transfer.Tests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class BlobDownloaderTests
+    {
+        private BlobDownloader blobDownloader = null!;
+        private readonly BlobPipelineOptions blobPipelineOptions = new();
+
+        [TestInitialize]
+        public async Task Init()
+        {
+            blobDownloader = new BlobDownloader(blobPipelineOptions,
+                await MemoryBufferPoolFactory.CreateMemoryBufferPoolAsync(10, blobPipelineOptions.BlockSizeBytes));
+        }
+
+        [TestMethod]
+        public async Task ExecuteReadAsync_EmptyPartIsProvided_SucceedsWithoutMakingHttpRequest()
+        {
+
+            var part = new PipelineBuffer()
+            {
+                BlobPartUrl = new Uri("https://foo.com"), //This invalid on purpose, as we don't want to make a real request
+                FileName = "emptyFile",
+                Length = 0,
+                Offset = 0,
+                Ordinal = 0,
+                NumberOfParts = 1,
+                FileSize = 0,
+                Data = new byte[BlobSizeUtils.DefaultBlockSizeBytes]
+            };
+
+            var length = await blobDownloader.ExecuteReadAsync(part, CancellationToken.None);
+
+            Assert.AreEqual(0, length);
+        }
+    }
+}

--- a/src/Tes.Runner/Transfer/BlobDownloader.cs
+++ b/src/Tes.Runner/Transfer/BlobDownloader.cs
@@ -67,6 +67,12 @@ public class BlobDownloader : BlobOperationPipeline
     /// <returns>Part's length in bytes</returns>
     public override async ValueTask<int> ExecuteReadAsync(PipelineBuffer buffer, CancellationToken cancellationToken)
     {
+
+        if (buffer.Length == 0)
+        {
+            return 0;
+        }
+
         return await BlobApiHttpUtils.ExecuteHttpRequestAndReadBodyResponseAsync(buffer, () => BlobApiHttpUtils.CreateReadByRangeHttpRequest(buffer), cancellationToken);
     }
 


### PR DESCRIPTION
Fixes: #656 

In this PR:
 - If a part is empty, the HTTP byte range request is not made. 