### PR TITLE
[665] DRSHub API host is kept when the node task builder sets Terra as the runtime environment

### DIFF
--- a/src/TesApi.Tests/Runner/NodeTaskBuilderTests.cs
+++ b/src/TesApi.Tests/Runner/NodeTaskBuilderTests.cs
@@ -213,7 +213,7 @@ namespace TesApi.Tests.Runner
         [TestMethod]
         public void WithDrsHubUrl_CalledThenSetUpTerraRuntimeEnv_DrsApiHostIsKept()
         {
-            var drsHubUrl = "https://drs.hub";
+            var drsHubUrl = "https://drshub.foo";
             nodeTaskBuilder
                 .WithDrsHubUrl(drsHubUrl)
                 .WithTerraAsRuntimeEnvironment("http://wsm.terra.foo", "http://lz.terra.foo", sasAllowedIpRange: null);

--- a/src/TesApi.Tests/Runner/NodeTaskBuilderTests.cs
+++ b/src/TesApi.Tests/Runner/NodeTaskBuilderTests.cs
@@ -209,5 +209,18 @@ namespace TesApi.Tests.Runner
 
             Assert.AreEqual(TransformationStrategy.CombinedTerra, nodeTask.RuntimeOptions.StreamingLogPublisher!.TransformationStrategy);
         }
+
+        [TestMethod]
+        public void WithDrsHubUrl_CalledThenSetUpTerraRuntimeEnv_DrsApiHostIsKept()
+        {
+            var drsHubUrl = "https://drs.hub";
+            nodeTaskBuilder
+                .WithDrsHubUrl(drsHubUrl)
+                .WithTerraAsRuntimeEnvironment("http://wsm.terra.foo", "http://lz.terra.foo", sasAllowedIpRange: null);
+
+            var nodeTask = nodeTaskBuilder.Build();
+
+            Assert.AreEqual(drsHubUrl, nodeTask.RuntimeOptions.Terra!.DrsHubApiHost);
+        }
     }
 }

--- a/src/TesApi.Web/Runner/NodeTaskBuilder.cs
+++ b/src/TesApi.Web/Runner/NodeTaskBuilder.cs
@@ -206,12 +206,12 @@ namespace TesApi.Web.Runner
             ArgumentException.ThrowIfNullOrEmpty(wsmApiHost, nameof(wsmApiHost));
             ArgumentException.ThrowIfNullOrEmpty(landingZoneApiHost, nameof(landingZoneApiHost));
             nodeTask.RuntimeOptions ??= new RuntimeOptions();
-            nodeTask.RuntimeOptions.Terra = new TerraRuntimeOptions()
-            {
-                WsmApiHost = wsmApiHost,
-                LandingZoneApiHost = landingZoneApiHost,
-                SasAllowedIpRange = sasAllowedIpRange
-            };
+
+            nodeTask.RuntimeOptions.Terra ??= new TerraRuntimeOptions();
+
+            nodeTask.RuntimeOptions.Terra.WsmApiHost = wsmApiHost;
+            nodeTask.RuntimeOptions.Terra.LandingZoneApiHost = landingZoneApiHost;
+            nodeTask.RuntimeOptions.Terra.SasAllowedIpRange = sasAllowedIpRange;
 
             SetCombinedTerraTransformationStrategyForAllTransformations();
 


### PR DESCRIPTION
Fixes: #665 

In this PR:
 - Fixed logic that was overriding the DRSHub Host setting when running in Terra, which resulted in the setting not being passed to the runner