### PR TITLE
[671] DrsHub URL setting supports a full DRS URL and the API host endpoint as valid values. 

### DIFF
--- a/src/TesApi.Tests/Runner/NodeTaskBuilderTests.cs
+++ b/src/TesApi.Tests/Runner/NodeTaskBuilderTests.cs
@@ -222,5 +222,17 @@ namespace TesApi.Tests.Runner
 
             Assert.AreEqual(drsHubUrl, nodeTask.RuntimeOptions.Terra!.DrsHubApiHost);
         }
+
+        [DataTestMethod]
+        [DataRow("https://drshub.foo", "https://drshub.foo")]
+        [DataRow("https://drshub.foo/", "https://drshub.foo")]
+        [DataRow("https://drshub.foo/api/v4/drs/resolve", "https://drshub.foo")]
+        public void WithDrsHubUrl_DrsHubUrlIsProvided_DrsHubApiHostIsSet(string drsHubUrl, string drsExpectedDrsApiHost)
+        {
+            var nodeTask = nodeTaskBuilder
+                .WithDrsHubUrl(drsHubUrl)
+                .Build();
+            Assert.AreEqual(drsExpectedDrsApiHost, nodeTask.RuntimeOptions.Terra!.DrsHubApiHost);
+        }
     }
 }

--- a/src/TesApi.Web/Runner/NodeTaskBuilder.cs
+++ b/src/TesApi.Web/Runner/NodeTaskBuilder.cs
@@ -381,21 +381,30 @@ namespace TesApi.Web.Runner
         /// <summary>
         /// Adds DRS Hub URL to the node task, if the DRS Hub URL is not set, the property won't be set.
         /// </summary>
-        /// <param name="drsHubApiHost"></param>
+        /// <param name="drsHubUrl"></param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
-        public NodeTaskBuilder WithDrsHubUrl(string drsHubApiHost)
+        public NodeTaskBuilder WithDrsHubUrl(string drsHubUrl)
         {
-            if (String.IsNullOrWhiteSpace(drsHubApiHost))
+            if (String.IsNullOrWhiteSpace(drsHubUrl))
             {
                 return this;
             }
 
+            var apiHost = GetApiHostFromUrl(drsHubUrl);
+
             nodeTask.RuntimeOptions ??= new RuntimeOptions();
             nodeTask.RuntimeOptions.Terra ??= new TerraRuntimeOptions();
-            nodeTask.RuntimeOptions.Terra.DrsHubApiHost = drsHubApiHost;
+            nodeTask.RuntimeOptions.Terra.DrsHubApiHost = apiHost;
 
             return this;
+        }
+
+        private string GetApiHostFromUrl(string drsHubUrl)
+        {
+            var uri = new Uri(drsHubUrl);
+
+            return $"{uri.Scheme}://{uri.Host}";
         }
     }
 }


### PR DESCRIPTION
Closes: #671 

In this PR:
 - TES server removes all URL segments from the URL when creating the runner json task. 
