### PR TITLE
Surface start task failures correctly

### DIFF
--- a/src/TesApi.Web/BatchScheduler.cs
+++ b/src/TesApi.Web/BatchScheduler.cs
@@ -773,6 +773,17 @@ namespace TesApi.Web
                             };
                         }
 
+                        if (azureBatchJobAndTaskState.NodeState == ComputeNodeState.StartTaskFailed)
+                        {
+                            return new CombinedBatchTaskInfo
+                            {
+                                BatchTaskState = BatchTaskState.NodeFailedDuringStartupOrExecution,
+                                FailureReason = azureBatchJobAndTaskState.NodeState.ToString(),
+                                SystemLogItems = ConvertNodeErrorsToSystemLogItems(azureBatchJobAndTaskState),
+                                Pool = azureBatchJobAndTaskState.PoolId
+                            };
+                        }
+
                         if (azureBatchJobAndTaskState.NodeErrorCode is not null && !TaskState.Completed.Equals(azureBatchJobAndTaskState.TaskState))
                         {
                             return new CombinedBatchTaskInfo


### PR DESCRIPTION
It turns out that start task exit codes are not returned by batch but do cause a `FailureExitCode` node error code. We aren't surfacing that in a way that leads to understanding the true source of the error. In this scenario, FailureExitCode will be replaced with `StartTaskFailed` in the task system logs.