### PR TITLE
Send expected cloudPlatform with DRS requests

### DIFF
--- a/src/Tes.ApiClients/DrsHubApiClient.cs
+++ b/src/Tes.ApiClients/DrsHubApiClient.cs
@@ -81,8 +81,8 @@ namespace Tes.ApiClients
             var drsResolveApiRequestBody = new DrsResolveRequestContent
             {
                 Url = drsUri.AbsoluteUri,
-                CloudPlatform = CloudPlatform.azure,
-                Fields = new List<string> { "accessUrl" }
+                CloudPlatform = CloudPlatform.Azure,
+                Fields = ["accessUrl"]
             };
 
             return CreateJsonStringContent(drsResolveApiRequestBody, DrsResolveRequestContentContext.Default.DrsResolveRequestContent);

--- a/src/Tes.ApiClients/DrsHubApiClient.cs
+++ b/src/Tes.ApiClients/DrsHubApiClient.cs
@@ -81,7 +81,7 @@ namespace Tes.ApiClients
             var drsResolveApiRequestBody = new DrsResolveRequestContent
             {
                 Url = drsUri.AbsoluteUri,
-                CloudPlatform = CloudPlatform.Azure,
+                CloudPlatform = CloudPlatform.azure,
                 Fields = new List<string> { "accessUrl" }
             };
 

--- a/src/Tes.ApiClients/Models/Terra/DrsResolveApiRequest.cs
+++ b/src/Tes.ApiClients/Models/Terra/DrsResolveApiRequest.cs
@@ -21,10 +21,9 @@ namespace Tes.ApiClients.Models.Terra
 
     public enum CloudPlatform
     {
-        [JsonPropertyName("azure")]
-        Azure,
-        [JsonPropertyName("google")]
-        Google
+        // Lowercase to support required JSON serialization
+        azure,
+        gs // google storage
     }
 
     [JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Tes.ApiClients/Models/Terra/DrsResolveApiRequest.cs
+++ b/src/Tes.ApiClients/Models/Terra/DrsResolveApiRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
 namespace Tes.ApiClients.Models.Terra
@@ -12,18 +13,19 @@ namespace Tes.ApiClients.Models.Terra
         public string Url { get; set; }
 
         [JsonPropertyName("cloudPlatform")]
-        [JsonConverter(typeof(JsonStringEnumConverter<CloudPlatform>))]
         public CloudPlatform CloudPlatform { get; set; }
 
         [JsonPropertyName("fields")]
         public List<string> Fields { get; set; }
     }
 
+    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
     public enum CloudPlatform
     {
-        // Lowercase to support required JSON serialization
-        azure,
-        gs // google storage
+        [EnumMember(Value = "azure")]
+        Azure,
+        [EnumMember(Value = "gs")]
+        Google
     }
 
     [JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Tes.ApiClients/Tes.ApiClients.csproj
+++ b/src/Tes.ApiClients/Tes.ApiClients.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.39.0" />
     <PackageReference Include="Azure.Identity" Version="1.11.2" />
+    <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />


### PR DESCRIPTION
DRSHub was receiving `cloudPlatform: Azure` rather than `cloudPlatform: azure` as expected. I tried to do this in a less gross way, but it looks like support for varying enum names and JSON serialized values is not great with this library: https://github.com/dotnet/runtime/issues/74385 Happy for alternate recommendations.