### PR TITLE
Reduce risk of pools outlasting their SAS tokens

### DIFF
--- a/src/TesApi.Tests/BatchPoolTests.cs
+++ b/src/TesApi.Tests/BatchPoolTests.cs
@@ -147,7 +147,7 @@ namespace TesApi.Tests
         }
 
         private static async Task<BatchPool> AddPool(BatchScheduler batchPools, bool isPreemtable)
-            => (BatchPool)await batchPools.GetOrAddPoolAsync("key1", isPreemtable, (id, _1) => ValueTask.FromResult(new Pool(name: id, displayName: "display1", vmSize: "vmSize1")), System.Threading.CancellationToken.None);
+            => (BatchPool)await batchPools.GetOrAddPoolAsync("key1", isPreemtable, (id, _1) => ValueTask.FromResult((new Pool(name: id, displayName: "display1", vmSize: "vmSize1"), DateTimeOffset.UtcNow.AddDays(1))), System.Threading.CancellationToken.None);
 
         private static void TimeShift(TimeSpan shift, BatchPool pool)
             => pool.TimeShift(shift);

--- a/src/TesApi.Tests/BatchSchedulerTests.cs
+++ b/src/TesApi.Tests/BatchSchedulerTests.cs
@@ -43,7 +43,7 @@ namespace TesApi.Tests
             Assert.IsTrue(batchScheduler.RemovePoolFromList(pool));
             Assert.AreEqual(0, batchScheduler.GetPoolGroupKeys().Count());
 
-            pool = (BatchPool)await batchScheduler.GetOrAddPoolAsync(key, false, (id, cancellationToken) => ValueTask.FromResult(new Pool(name: id)), System.Threading.CancellationToken.None);
+            pool = (BatchPool)await batchScheduler.GetOrAddPoolAsync(key, false, (id, cancellationToken) => ValueTask.FromResult((new Pool(name: id), DateTimeOffset.UtcNow.AddDays(1))), System.Threading.CancellationToken.None);
 
             Assert.IsNotNull(pool);
             Assert.AreEqual(1, batchScheduler.GetPoolGroupKeys().Count());
@@ -63,7 +63,7 @@ namespace TesApi.Tests
             var count = batchScheduler.GetPools().Count();
             serviceProvider.AzureProxy.Verify(mock => mock.CreateBatchPoolAsync(It.IsAny<Pool>(), It.IsAny<bool>(), It.IsAny<System.Threading.CancellationToken>()), Times.Once);
 
-            var pool = await batchScheduler.GetOrAddPoolAsync(key, false, (id, cancellationToken) => ValueTask.FromResult(new Pool(name: id)), System.Threading.CancellationToken.None);
+            var pool = await batchScheduler.GetOrAddPoolAsync(key, false, (id, cancellationToken) => ValueTask.FromResult((new Pool(name: id), DateTimeOffset.UtcNow.AddDays(1))), System.Threading.CancellationToken.None);
             await pool.ServicePoolAsync();
 
             Assert.AreEqual(count, batchScheduler.GetPools().Count());
@@ -86,7 +86,7 @@ namespace TesApi.Tests
             var key = batchScheduler.GetPoolGroupKeys().First();
             var count = batchScheduler.GetPools().Count();
 
-            var pool = await batchScheduler.GetOrAddPoolAsync(key, false, (id, cancellationToken) => ValueTask.FromResult(new Pool(name: id)), System.Threading.CancellationToken.None);
+            var pool = await batchScheduler.GetOrAddPoolAsync(key, false, (id, cancellationToken) => ValueTask.FromResult((new Pool(name: id), DateTimeOffset.UtcNow.AddDays(1))), System.Threading.CancellationToken.None);
             await pool.ServicePoolAsync();
 
             Assert.AreNotEqual(count, batchScheduler.GetPools().Count());
@@ -1448,7 +1448,7 @@ namespace TesApi.Tests
         }
 
         private static async Task<BatchPool> AddPool(BatchScheduler batchScheduler)
-            => (BatchPool)await batchScheduler.GetOrAddPoolAsync("key1", false, (id, cancellationToken) => ValueTask.FromResult<Pool>(new(name: id, displayName: "display1", vmSize: "vmSize1")), System.Threading.CancellationToken.None);
+            => (BatchPool)await batchScheduler.GetOrAddPoolAsync("key1", false, (id, cancellationToken) => ValueTask.FromResult<(Pool PoolSpec, DateTimeOffset Expiry)>((new(name: id, displayName: "display1", vmSize: "vmSize1"), DateTimeOffset.UtcNow.AddDays(1))), System.Threading.CancellationToken.None);
 
         internal static void GuardAssertsWithTesTask(TesTask tesTask, Action assertBlock)
         {

--- a/src/TesApi.Web/IBatchPool.cs
+++ b/src/TesApi.Web/IBatchPool.cs
@@ -28,8 +28,9 @@ namespace TesApi.Web
         /// </summary>
         /// <param name="pool"></param>
         /// <param name="isPreemptible"></param>
+        /// <param name="expiry"></param>
         /// <param name="cancellationToken"></param>
-        ValueTask CreatePoolAndJobAsync(Microsoft.Azure.Management.Batch.Models.Pool pool, bool isPreemptible, CancellationToken cancellationToken);
+        ValueTask CreatePoolAndJobAsync(Microsoft.Azure.Management.Batch.Models.Pool pool, bool isPreemptible, DateTimeOffset expiry, CancellationToken cancellationToken);
 
         /// <summary>
         /// Connects to the provided pool and associated job in the Batch Account.

--- a/src/TesApi.Web/IBatchScheduler.cs
+++ b/src/TesApi.Web/IBatchScheduler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -97,7 +98,8 @@ namespace TesApi.Web
         /// <param name="HostName"></param>
         /// <param name="IsDedicated"></param>
         /// <param name="RunnerMD5"></param>
-        record struct PoolMetadata(string HostName, bool IsDedicated, string RunnerMD5)
+        /// <param name="Expiry"></param>
+        record struct PoolMetadata(string HostName, bool IsDedicated, string RunnerMD5, DateTimeOffset Expiry)
         {
             private static readonly System.Text.Json.JsonSerializerOptions Options = new(System.Text.Json.JsonSerializerDefaults.Web);
 


### PR DESCRIPTION
The configuration change is superior to this, but if this is really needed we can look at it more closely.