### PR TITLE
[728-1] Runner calculates MD5 checksum for uploads. 

### DIFF
--- a/src/CommonUtilities/Models/NodeTask.cs
+++ b/src/CommonUtilities/Models/NodeTask.cs
@@ -50,6 +50,8 @@ namespace Tes.Runner.Models
         public StorageTargetLocation? StreamingLogPublisher { get; set; }
 
         public AzureEnvironmentConfig? AzureEnvironmentConfig { get; set; }
+
+        public bool? SetContentMd5OnUpload { get; set; }
     }
 
     public class StorageTargetLocation

--- a/src/Tes.Runner.Test/BlobPipelineTests.cs
+++ b/src/Tes.Runner.Test/BlobPipelineTests.cs
@@ -89,6 +89,40 @@ namespace Tes.Runner.Test
             await pipeline.ExecuteAsync(blobOps);
         }
 
+        [TestMethod]
+        public async Task CalculateFileMd5HashAsync_PipelineCalculateFileContentMd5IsFalse_ReturnsNull()
+        {
+
+            var pipelineOptions = new BlobPipelineOptions(blockSize, 10, 10, 10, FileHandlerPoolCapacity: 1)
+            {
+                CalculateFileContentMd5 = false
+            };
+
+            var pipeline = new BlobOperationPipelineTestImpl(pipelineOptions, memoryBuffer, sourceSize);
+
+            var result = await pipeline.CalculateFileMd5HashAsync(tempFile1);
+
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public async Task CalculateFileMd5HashAsync_PipelineCalculateFileContentMd5IsTrue_ReturnsMd5Hash()
+        {
+
+            var pipelineOptions = new BlobPipelineOptions(blockSize, 10, 10, 10, FileHandlerPoolCapacity: 1)
+            {
+                CalculateFileContentMd5 = true
+            };
+
+            var pipeline = new BlobOperationPipelineTestImpl(pipelineOptions, memoryBuffer, sourceSize);
+
+            var result = await pipeline.CalculateFileMd5HashAsync(tempFile1);
+
+            var expectedHash = RunnerTestUtils.CalculateMd5Hash(await File.ReadAllBytesAsync(tempFile1));
+
+            Assert.AreEqual(expectedHash, result);
+        }
+
         private static void AssertReaderWriterAndCompleteMethodsAreCalled(BlobOperationPipelineTestImpl operationPipeline, long numberOfWriterReaderCalls, int numberOfCompleteCalls)
         {
             var executeWriteInfo = operationPipeline.MethodCalls["ExecuteWriteAsync"];
@@ -166,10 +200,10 @@ namespace Tes.Runner.Test
             return Task.FromResult(sourceLength);
         }
 
-        public override Task OnCompletionAsync(long length, Uri? blobUrl, string fileName, string? rootHash)
+        public override Task OnCompletionAsync(long length, Uri? blobUrl, string fileName, string? rootHash, string? contentMd5)
         {
             Debug.Assert(blobUrl != null, nameof(blobUrl) + " != null");
-            AddMethodCall(nameof(OnCompletionAsync), length, blobUrl, fileName, rootHash!);
+            AddMethodCall(nameof(OnCompletionAsync), length, blobUrl, fileName, rootHash!, contentMd5!);
             return Task.CompletedTask;
         }
 

--- a/src/Tes.Runner.Test/BlobUploaderTests.cs
+++ b/src/Tes.Runner.Test/BlobUploaderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
@@ -14,12 +15,10 @@ namespace Tes.Runner.Test
     [Ignore]
     public class BlobUploaderTests
     {
-#pragma warning disable CS8618
-        private BlobContainerClient blobContainerClient;
+        private BlobContainerClient blobContainerClient = null!;
         private Guid containerId;
-        private BlobUploader blobUploader;
-        private readonly BlobPipelineOptions blobPipelineOptions = new();
-#pragma warning restore CS8618
+        private BlobUploader blobUploader = null!;
+        private readonly BlobPipelineOptions blobPipelineOptions = new(CalculateFileContentMd5: true);
 
         [TestInitialize]
         public async Task Init()
@@ -63,6 +62,30 @@ namespace Tes.Runner.Test
             var fileSize = (numberOfMiB * BlobSizeUtils.MiB) + extraBytes;
             Assert.IsNotNull(blobProperties);
             Assert.AreEqual(fileSize, blobProperties.Value.ContentLength);
+        }
+
+        [TestMethod]
+        public async Task UploadFile_ContentMD5IsSet()
+        {
+            var file = await RunnerTestUtils.CreateTempFileWithContentAsync(numberOfMiB: 1, extraBytes: 0);
+            var blobClient = blobContainerClient.GetBlobClient(file);
+
+            // Create a SAS token that's valid for one hour.
+            var url = CreateSasUrl(blobClient, file);
+
+            await blobUploader.UploadAsync([new(file, url)]);
+
+            var blobProperties = await blobClient.GetPropertiesAsync();
+
+            Assert.IsNotNull(blobProperties);
+            Assert.IsNotNull(blobProperties.Value.ContentHash);
+
+            var contentHashBytes = Convert.FromBase64String(Convert.ToBase64String(blobProperties.Value.ContentHash));
+            var contentHash = Encoding.UTF8.GetString(contentHashBytes);
+
+            var fileHash = RunnerTestUtils.CalculateMd5(file);
+
+            Assert.AreEqual(fileHash, contentHash);
         }
 
         private Uri CreateSasUrl(BlobClient blobClient, string file)

--- a/src/Tes.Runner.Test/ProcessedPartsProcessorTests.cs
+++ b/src/Tes.Runner.Test/ProcessedPartsProcessorTests.cs
@@ -37,13 +37,13 @@ namespace Tes.Runner.Test
             {
                 await RunnerTestUtils.AddProcessedBufferAsync(processedBuffer!, $"file{f}", numberOfPartsPerFile,
                     fileSize);
-            };
+            }
 
             await processedPartsProcessor!.StartProcessedPartsProcessorAsync(expectedNumberOfFiles, processedBuffer!, readBuffer!);
 
             processedBuffer!.Writer.Complete();
 
-            pipeline!.Verify(p => p.OnCompletionAsync(It.IsAny<long>(), It.IsAny<Uri?>(), It.IsAny<string>(), It.IsAny<string>()), Times.Exactly(expectedNumberOfFiles));
+            pipeline!.Verify(p => p.OnCompletionAsync(It.IsAny<long>(), It.IsAny<Uri?>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Exactly(expectedNumberOfFiles));
 
             var parts = await RunnerTestUtils.ReadAllPipelineBuffersAsync(processedBuffer!.Reader.ReadAllAsync());
 

--- a/src/Tes.Runner.Test/RunnerTestUtils.cs
+++ b/src/Tes.Runner.Test/RunnerTestUtils.cs
@@ -49,7 +49,7 @@ public class RunnerTestUtils
         using var md5 = MD5.Create();
         using var stream = File.OpenRead(file);
         var hash = md5.ComputeHash(stream);
-        return Convert.ToBase64String(hash);
+        return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
     }
 
     public static void DeleteFileIfExists(string file)

--- a/src/Tes.Runner/Transfer/BlobDownloader.cs
+++ b/src/Tes.Runner/Transfer/BlobDownloader.cs
@@ -104,8 +104,9 @@ public class BlobDownloader : BlobOperationPipeline
     /// <param name="blobUrl"></param>
     /// <param name="fileName"></param>
     /// <param name="rootHash"></param>
+    /// <param name="contentMd5"></param>
     /// <returns></returns>
-    public override Task OnCompletionAsync(long length, Uri? blobUrl, string fileName, string? rootHash)
+    public override Task OnCompletionAsync(long length, Uri? blobUrl, string fileName, string? rootHash, string? contentMd5)
     {
         Logger.LogInformation($"Completed download. Total bytes: {length:n0} Filename: {fileName}");
 

--- a/src/Tes.Runner/Transfer/BlobPipelineOptions.cs
+++ b/src/Tes.Runner/Transfer/BlobPipelineOptions.cs
@@ -4,7 +4,7 @@
 namespace Tes.Runner.Transfer
 {
     public record BlobPipelineOptions(int BlockSizeBytes = BlobSizeUtils.DefaultBlockSizeBytes, int ReadWriteBuffersCapacity = BlobPipelineOptions.DefaultReadWriteBuffersCapacity, int NumberOfWriters = BlobPipelineOptions.DefaultNumberOfWriters, int NumberOfReaders = BlobPipelineOptions.DefaultNumberOfReaders,
-        int FileHandlerPoolCapacity = BlobPipelineOptions.DefaultFileHandlerPoolCapacity, int MemoryBufferCapacity = BlobPipelineOptions.DefaultMemoryBufferCapacity, string ApiVersion = BlobPipelineOptions.DefaultApiVersion)
+        int FileHandlerPoolCapacity = BlobPipelineOptions.DefaultFileHandlerPoolCapacity, int MemoryBufferCapacity = BlobPipelineOptions.DefaultMemoryBufferCapacity, string ApiVersion = BlobPipelineOptions.DefaultApiVersion, bool CalculateFileContentMd5 = false)
     {
         public const int DefaultNumberOfWriters = 10;
         public const int DefaultNumberOfReaders = 10;

--- a/src/Tes.Runner/Transfer/BlobUploader.cs
+++ b/src/Tes.Runner/Transfer/BlobUploader.cs
@@ -121,8 +121,9 @@ namespace Tes.Runner.Transfer
         /// <param name="blobUrl">Target Blob URL</param>
         /// <param name="fileName">Source file name</param>
         /// <param name="rootHash">Root hash of the file</param>
+        /// <param name="contentMd5">Content MD5 hash</param>
         /// <returns></returns>
-        public override async Task OnCompletionAsync(long length, Uri? blobUrl, string fileName, string? rootHash)
+        public override async Task OnCompletionAsync(long length, Uri? blobUrl, string fileName, string? rootHash, string? contentMd5)
         {
             ArgumentNullException.ThrowIfNull(blobUrl, nameof(blobUrl));
             ArgumentException.ThrowIfNullOrEmpty(fileName, nameof(fileName));
@@ -132,7 +133,7 @@ namespace Tes.Runner.Transfer
             {
                 response = await BlobApiHttpUtils.ExecuteHttpRequestAsync(() =>
                     BlobApiHttpUtils.CreateBlobBlockListRequest(length, blobUrl, PipelineOptions.BlockSizeBytes,
-                        PipelineOptions.ApiVersion, rootHash));
+                        PipelineOptions.ApiVersion, rootHash, contentMd5));
             }
             catch (Exception e)
             {

--- a/src/Tes.Runner/Transfer/IBlobPipeline.cs
+++ b/src/Tes.Runner/Transfer/IBlobPipeline.cs
@@ -37,13 +37,16 @@ public interface IBlobPipeline
     /// <param name="length">Blob length in bytes</param>
     /// <param name="blobUrl">Url to the blob in azure storage</param>
     /// <param name="fileName">Path to the file</param>
-    /// <param name="rootHash"></param>
+    /// <param name="rootHash">Root hash</param>
+    /// <param name="contentMd5">File content MD5 hash</param>
     /// <returns></returns>
-    Task OnCompletionAsync(long length, Uri? blobUrl, string fileName, string? rootHash);
+    Task OnCompletionAsync(long length, Uri? blobUrl, string fileName, string? rootHash, string? contentMd5);
 
     /// <summary>
     /// Called when a buffer is created. This is used to configure the buffer with additional information.
     /// </summary>
     /// <param name="buffer"><see cref="PipelineBuffer"/></param>
     void ConfigurePipelineBuffer(PipelineBuffer buffer);
+
+    Task<string?> CalculateFileMd5HashAsync(string filePath);
 }

--- a/src/Tes.Runner/Transfer/ProcessedPartsProcessor.cs
+++ b/src/Tes.Runner/Transfer/ProcessedPartsProcessor.cs
@@ -86,7 +86,10 @@ public class ProcessedPartsProcessor
                 rootHash = GetRootHash(buffer.HashListProvider);
             }
 
-            await blobPipeline.OnCompletionAsync(buffer.FileSize, buffer.BlobUrl, buffer.FileName, rootHash);
+            //calculate the content md5 hash, if the pipeline is configured to perform the operation
+            var contentMd5 = await blobPipeline.CalculateFileMd5HashAsync(buffer.FileName);
+
+            await blobPipeline.OnCompletionAsync(buffer.FileSize, buffer.BlobUrl, buffer.FileName, rootHash, contentMd5);
 
             await CloseFileHandlerPoolAsync(buffer.FileHandlerPool, cancellationTokenSource.Token);
         }

--- a/src/Tes.RunnerCLI/Commands/CommandHandlers.cs
+++ b/src/Tes.RunnerCLI/Commands/CommandHandlers.cs
@@ -145,11 +145,13 @@ namespace Tes.RunnerCLI.Commands
             int bufferCapacity,
             string apiVersion)
         {
-            var options = CommandLauncher.CreateBlobPipelineOptions(blockSize, writers, readers, bufferCapacity, apiVersion);
 
             Logger.LogDebug("Starting upload operation.");
 
             var nodeTask = await nodeTaskUtils.ResolveNodeTaskAsync(file, fileUri, apiVersion);
+
+            //TODO: Eventually all the options should come from the node runner task and we should remove the CLI flags as they are not used            
+            var options = CommandLauncher.CreateBlobPipelineOptions(blockSize, writers, readers, bufferCapacity, apiVersion, nodeTask.RuntimeOptions?.SetContentMd5OnUpload ?? false);
 
             return await ExecuteTransferTaskAsync(nodeTask, exec => exec.UploadOutputsAsync(options), apiVersion);
         }
@@ -174,7 +176,7 @@ namespace Tes.RunnerCLI.Commands
             int bufferCapacity,
             string apiVersion)
         {
-            var options = CommandLauncher.CreateBlobPipelineOptions(blockSize, writers, readers, bufferCapacity, apiVersion);
+            var options = CommandLauncher.CreateBlobPipelineOptions(blockSize, writers, readers, bufferCapacity, apiVersion, setContentMd5OnUploads: false);
 
             Logger.LogDebug("Starting download operation.");
 

--- a/src/Tes.RunnerCLI/Commands/CommandLauncher.cs
+++ b/src/Tes.RunnerCLI/Commands/CommandLauncher.cs
@@ -12,7 +12,7 @@ namespace Tes.RunnerCLI.Commands
     public class CommandLauncher
     {
         public static BlobPipelineOptions CreateBlobPipelineOptions(int blockSize, int writers, int readers,
-            int bufferCapacity, string apiVersion)
+            int bufferCapacity, string apiVersion, bool setContentMd5OnUploads)
         {
             var options = new BlobPipelineOptions(
                 BlockSizeBytes: blockSize,
@@ -20,7 +20,8 @@ namespace Tes.RunnerCLI.Commands
                 NumberOfReaders: readers,
                 ReadWriteBuffersCapacity: bufferCapacity,
                 MemoryBufferCapacity: bufferCapacity,
-                ApiVersion: apiVersion);
+                ApiVersion: apiVersion,
+                CalculateFileContentMd5: setContentMd5OnUploads);
 
             return options;
         }


### PR DESCRIPTION
Applies to #728 

In this PR:
 - Added a new property to the node task: `RuntimeOptions.SetContentMd5OnUpload`. When set to `true`, the runner will compute the MD5 for the files before the block list is committed.
 - This change lays the groundwork for implementing hash validation when downloading data using DRS.
 - By default, the setting is false since calculating the MD5 has a performance impact.
 
Pending Work (to complete: #728):
 - Expose this option in the TES server as a runtime configuration, with a default value of `false`.
 - Modify the CoA deployer to include this new configuration option.