### PR TITLE
Fix Content-MD5

### DIFF
--- a/src/Tes.Runner.Test/BlobPipelineTests.cs
+++ b/src/Tes.Runner.Test/BlobPipelineTests.cs
@@ -118,7 +118,7 @@ namespace Tes.Runner.Test
 
             var result = await pipeline.CalculateFileMd5HashAsync(tempFile1);
 
-            var expectedHash = RunnerTestUtils.CalculateMd5Hash(await File.ReadAllBytesAsync(tempFile1));
+            var expectedHash = RunnerTestUtils.CalculateBase64Md5Hash(await File.ReadAllBytesAsync(tempFile1));
 
             Assert.AreEqual(expectedHash, result);
         }

--- a/src/Tes.Runner.Test/RunnerTestUtils.cs
+++ b/src/Tes.Runner.Test/RunnerTestUtils.cs
@@ -89,6 +89,12 @@ public class RunnerTestUtils
         return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
     }
 
+    public static string CalculateBase64Md5Hash(byte[] data)
+    {
+        var hash = MD5.HashData(data);
+        return Convert.ToBase64String(hash);
+    }
+
     public static string GetRootHashFromSortedHashList(List<string> hashList)
     {
         var hashListContent = string.Join("", hashList);

--- a/src/Tes.Runner.Test/Transfer/BlobApiHttpUtilsTests.cs
+++ b/src/Tes.Runner.Test/Transfer/BlobApiHttpUtilsTests.cs
@@ -144,15 +144,14 @@ namespace Tes.Runner.Test.Transfer
         [TestMethod]
         public void CreatePutBlockRequestAsyncTest_ContentMd5IsSet_IncludesContentMd5HeaderBase64Encoded()
         {
-            var contentMd5 = "1234567890";
-            var base64StringContentMd5 = Convert.ToBase64String(Encoding.UTF8.GetBytes(contentMd5));
+            var contentMd5 = "iXMWkpF2Rk68mtCF8x5yhA==";
             var request = BlobApiHttpUtils.CreateBlobBlockListRequest(
                 BlobSizeUtils.MiB * 10, new Uri(blobUrlWithSasToken),
                 BlobSizeUtils.DefaultBlockSizeBytes, BlobPipelineOptions.DefaultApiVersion, default, contentMd5);
 
             Assert.IsTrue(request.Headers.Contains("x-ms-blob-content-md5"));
             Assert.IsTrue(request.Headers.TryGetValues("x-ms-blob-content-md5", out var values));
-            Assert.IsTrue(values.Contains(base64StringContentMd5));
+            Assert.IsTrue(values.Contains(contentMd5));
         }
 
         [TestMethod]

--- a/src/Tes.Runner/Transfer/BlobApiHttpUtils.cs
+++ b/src/Tes.Runner/Transfer/BlobApiHttpUtils.cs
@@ -130,6 +130,7 @@ public class BlobApiHttpUtils(HttpClient httpClient, AsyncRetryPolicy retryPolic
         }
         request.Headers.Add($"x-ms-meta-{name}", value);
     }
+
     private static void AddContentMd5HeaderIfValueIsSet(HttpRequestMessage request, string? value)
     {
         if (string.IsNullOrEmpty(value))
@@ -137,7 +138,7 @@ public class BlobApiHttpUtils(HttpClient httpClient, AsyncRetryPolicy retryPolic
             return;
         }
 
-        request.Headers.Add($"x-ms-blob-content-md5", Convert.ToBase64String(Encoding.UTF8.GetBytes(value)));
+        request.Headers.Add($"x-ms-blob-content-md5", value);
     }
 
     public static void AddBlobServiceHeaders(HttpRequestMessage request, string apiVersion)

--- a/src/Tes.Runner/Transfer/BlobOperationPipeline.cs
+++ b/src/Tes.Runner/Transfer/BlobOperationPipeline.cs
@@ -72,7 +72,7 @@ public abstract class BlobOperationPipeline : IBlobPipeline
 
         Logger.LogInformation("MD5 hash calculated for file: {filePath}.", filePath);
 
-        return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
+        return Convert.ToBase64String(hash);
     }
 
     protected async Task<long> ExecutePipelineAsync(List<BlobOperationInfo> operations)

--- a/src/Tes.Runner/Transfer/PipelineOptionsOptimizer.cs
+++ b/src/Tes.Runner/Transfer/PipelineOptionsOptimizer.cs
@@ -120,7 +120,8 @@ namespace Tes.Runner.Transfer
                 NumberOfReaders: readers,
                 FileHandlerPoolCapacity: options.FileHandlerPoolCapacity,
                 ApiVersion: options.ApiVersion,
-                MemoryBufferCapacity: memoryBufferCapacity);
+                MemoryBufferCapacity: memoryBufferCapacity,
+                CalculateFileContentMd5: options.CalculateFileContentMd5);
         }
 
         private int GetOptimizedWorkers()


### PR DESCRIPTION
fixes #728

Two issues discovered in the implementation
* Optimizing `PipelineOptions` loses its `CalculateFileContentMd5` value.
* The storage account rejects the value of the `x-ms-blob-content-md5` header.

This addresses both issues.

This was diagnosed and tested using `build-runner-create-vm-run.sh`. Thank you.