### PR TITLE
Improved efficiency and reliability of DRS URI support

### DIFF
--- a/src/CommonUtilities.Tests/DrsUriParserTests.cs
+++ b/src/CommonUtilities.Tests/DrsUriParserTests.cs
@@ -16,51 +16,90 @@ namespace CommonUtilities.Tests
         }
 
         [DataTestMethod]
-        [DataRow(@"drs://hostname/abc123", @"hostname", @"abc123")]
-        public void DrsUriParser_CorrectlyParsesDrsNamespaceStyleUrls(string uriString, string host, string path)
+        [DataRow(@"drs://hostname/abc123", @"hostname", @"abc123", true)]
+        [DataRow(@"drs://hostname/abc-123", @"hostname", @"abc-123", true)]
+        [DataRow(@"drs://hostname/abc_123", @"hostname", @"abc_123", true)]
+        [DataRow(@"drs://hostname/abc.123", @"hostname", @"abc.123", true)]
+        [DataRow(@"drs://hostname/abc~123", @"hostname", @"abc~123", true)]
+        [DataRow(@"drs://hostname/abc%3A123", @"hostname", @"abc%3A123", true)]
+        [DataRow(@"drs://hostname/abc%2F123", @"hostname", @"abc%2F123", true)]
+        public void DrsUriParser_CorrectlyParsesDrsNamespaceStyleUrls(string uriString, string host, string path, bool isWellFormed)
         {
             Uri uri = new(uriString);
 
             Assert.IsNotNull(uri);
-            Assert.IsTrue(uri.IsWellFormedOriginalString());
+            Assert.AreEqual(isWellFormed, uri.IsWellFormedOriginalString());
             Assert.AreEqual(host, uri.Host);
             Assert.AreEqual($"/{path}", uri.AbsolutePath);
-            Assert.AreEqual(uriString, uri.AbsoluteUri);
+            Assert.AreEqual(uriString, uri.AbsoluteUri, ignoreCase: !isWellFormed);
+            Assert.AreEqual(uriString, uri.ToString(), ignoreCase: true);
             Assert.AreEqual(path, uri.GetComponents(UriComponents.Path, UriFormat.Unescaped));
         }
 
         [DataTestMethod]
-        [DataRow(@"drs://provider/namespace:abc123", @"provider/namespace", @"abc123")]
-        [DataRow(@"drs://prefix:abc123", @"prefix", @"abc123")]
-        public void DrsUriParser_CorrectlyParsesCompactIdStyleUrls(string uriString, string host, string path)
+        [DataRow(@"drs://provider/namespace:abc123", @"provider/namespace", @"abc123", true)]
+        [DataRow(@"drs://provider/namespace:abc-123", @"provider/namespace", @"abc-123", true)]
+        [DataRow(@"drs://provider/namespace:abc_123", @"provider/namespace", @"abc_123", true)]
+        [DataRow(@"drs://provider/namespace:abc.123", @"provider/namespace", @"abc.123", true)]
+        [DataRow(@"drs://provider/namespace:abc~123", @"provider/namespace", @"abc~123", true)]
+        [DataRow(@"drs://provider/namespace:abc%3A123", @"provider/namespace", @"abc%3A123", true)]
+        [DataRow(@"drs://provider/namespace:abc%2F123", @"provider/namespace", @"abc%2F123", true)]
+        [DataRow(@"drs://Provider/namespace:abc123", @"provider/namespace", @"abc123", false)]
+        [DataRow(@"drs://provider/Namespace:abc123", @"provider/namespace", @"abc123", false)]
+        [DataRow(@"drs://prefix:abc123", @"prefix", @"abc123", true)]
+        [DataRow(@"drs://prefix:abc%3A123", @"prefix", @"abc%3A123", true)]
+        [DataRow(@"drs://prefix:abc%2F123", @"prefix", @"abc%2F123", true)]
+        [DataRow(@"drs://pre_fix:abc123", @"pre_fix", @"abc123", true)]
+        [DataRow(@"drs://pre.fix:abc123", @"pre.fix", @"abc123", true)]
+        public void DrsUriParser_CorrectlyParsesCompactIdStyleUrls(string uriString, string host, string path, bool isWellFormed)
         {
             Uri uri = new(uriString);
 
             Assert.IsNotNull(uri);
-            Assert.IsTrue(uri.IsWellFormedOriginalString());
+            Assert.AreEqual(isWellFormed, uri.IsWellFormedOriginalString());
             Assert.AreEqual(host, uri.Host);
             Assert.AreEqual($":{path}", uri.AbsolutePath);
-            Assert.AreEqual(uriString, uri.AbsoluteUri);
+            Assert.AreEqual(uriString, uri.AbsoluteUri, ignoreCase: !isWellFormed);
+            Assert.AreEqual(uriString, uri.ToString(), ignoreCase: true);
             Assert.AreEqual(path, uri.GetComponents(UriComponents.Path, UriFormat.Unescaped));
         }
 
         [DataTestMethod]
         [DataRow(@"drs://foo")]
+        [DataRow(@"drs://foo:b%az")]
         [DataRow(@"drs://foo-bar:baz")]
         [DataRow(@"drs://hostname/abc&123")]
         [DataRow(@"drs://hostname/abc/123")]
-        [DataRow(@"drs://preFix:abc123")]
         [DataRow(@"drs://prefix:abc&123")]
         [DataRow(@"drs://prefix:abc/123")]
         [DataRow(@"drs://prefix:abc:123")]
-        [DataRow(@"drs://Provider/namespace:abc123")]
-        [DataRow(@"drs://provider/Namespace:abc123")]
         [DataRow(@"drs://provider/namespace:abc&123")]
         [DataRow(@"drs://provider/namespace:abc/123")]
         [DataRow(@"drs://provider/namespace:abc:123")]
         public void DrsUriParser_CorrectlyFailsToCreateMalformedUris(string uriString)
         {
             Assert.ThrowsException<UriFormatException>(() => _ = new Uri(uriString));
+        }
+
+        [DataTestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void DrsUriParser_CorrectlyFailsUsingRelativeUrisWhenRelativeUriIsNotDrsId(bool compact)
+        {
+            Assert.IsTrue(Uri.TryCreate(compact ? @"drs://prefix:abc123" : @"drs://hostname/abc123", UriKind.Absolute, out var uri));
+            Assert.IsFalse(Uri.TryCreate(uri, @"abc/123", out var result));
+        }
+
+        [DataTestMethod]
+        [DataRow(@"drs://hostname/abc123", @"abc%3A123", @"drs://hostname/abc%3A123")]
+        [DataRow(@"drs://prefix:abc123", @"abc%3A123", @"drs://prefix:abc%3A123")]
+        public void DrsUriParser_CorrectlyCreatesUsingRelativeUris(string uriString, string relativeUri, string absoluteUri)
+        {
+            Assert.IsTrue(Uri.TryCreate(uriString, UriKind.Absolute, out var uri));
+            Assert.IsTrue(Uri.TryCreate(uri, relativeUri, out var result));
+            Assert.AreEqual(absoluteUri, result.AbsoluteUri);
+            Assert.IsTrue(result.IsBaseOf(uri));
+            Assert.IsTrue(uri.IsBaseOf(result));
         }
     }
 }

--- a/src/CommonUtilities/DrsUriParser.cs
+++ b/src/CommonUtilities/DrsUriParser.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Reflection;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace CommonUtilities
@@ -11,13 +9,19 @@ namespace CommonUtilities
     /// Uri parser for DRS scheme
     /// </summary>
     /// <seealso cref="GenericUriParser" />
-    public partial class DrsUriParser : GenericUriParser
-    {
-        /// <summary>
-        /// The URI scheme DRS
-        /// </summary>
-        public const string UriSchemeDrs = "drs";
+    // -------------------------------------------------------------------------------------------------------------
+    // DRS URI style |          Host          |    Path    | Description
+    // -------------------------------------------------------------------------------------------------------------
+    // Compact       | Prefix                 | Accession  | If prefix contains a '/', it is provider_code/namespace.
+    // Hostname      | [UserInfo@]Host[:Port] | ID         | Per the spec, ID and Accession are the same thing.
+    // -------------------------------------------------------------------------------------------------------------
 
+    // Hostname style are like HTTP, except they don't have fragments and the Path is limited to one level.
+    // Spec is silent on Query, it's not currently implemented here.
+
+    // Compact style are not IETL-valid, which is the raison d'être of this implementation.
+    public sealed partial class DrsUriParser : GenericUriParser
+    {
         private static readonly int _prefixLength = UriSchemeDrs.Length + Uri.SchemeDelimiter.Length;
         private static readonly string _prefix = UriSchemeDrs + Uri.SchemeDelimiter;
         private static readonly char[] _allowedAccessionOthers = ['-', '.', '_', '~'];
@@ -25,11 +29,19 @@ namespace CommonUtilities
         private static readonly Regex _drsCompactId = DrsCompactId();
 
         /// <summary>
+        /// The URI scheme DRS
+        /// </summary>
+        public const string UriSchemeDrs = "drs";
+
+        /// <summary>
         /// Registers this parser with the runtime.
         /// </summary>
         public static void Register()
         {
-            Register(new DrsUriParser(), UriSchemeDrs, defaultPort: -1);
+            if (!IsKnownScheme(UriSchemeDrs))
+            {
+                Register(new DrsUriParser(), UriSchemeDrs, defaultPort: -1);
+            }
         }
 
         /// <summary>
@@ -38,42 +50,48 @@ namespace CommonUtilities
         public DrsUriParser() : base(
             GenericUriParserOptions.GenericAuthority |
             GenericUriParserOptions.NoFragment |
+            GenericUriParserOptions.DontCompressPath |
             GenericUriParserOptions.Idn |
             GenericUriParserOptions.IriParsing)
-        {
-        }
+        { }
 
-        /// <inheritdoc/>
-        protected override bool IsWellFormedOriginalString(Uri uri)
+        private static bool IsWellFormedSchemeAndDelimiter(Uri uri)
+            => _prefix.AsSpan().Equals(uri.OriginalString.AsSpan(0, _prefixLength), StringComparison.Ordinal);
+
+        private static bool IsWellFormedNamespaceOriginalString(Uri uri, IDrsParser parser)
         {
-            if (!_prefix.AsSpan().Equals(uri.OriginalString.AsSpan(0, _prefixLength), StringComparison.Ordinal))
+            if (!IsWellFormedSchemeAndDelimiter(uri))
             {
                 return false;
             }
 
-            if (IsCompactIdUri(uri))
+            UriBuilder builder = new(new Uri($"{Uri.UriSchemeHttps}{uri.OriginalString[UriSchemeDrs.Length..]}"));
+
+            var path = builder.Path ?? string.Empty;
+            builder.Path = string.Empty;
+
+            if (!parser.IsWellFormedOriginalString(builder.Uri))
             {
-                return _drsCompactId.IsMatch(uri.OriginalString.AsSpan(_prefixLength));
+                return false;
             }
-            else
+
+            if (path.StartsWith('/'))
             {
-                // This is a hostname id
-                if (!base.IsWellFormedOriginalString(uri))
-                {
-                    return false;
-                }
-
-                var path = base.GetComponents(uri, UriComponents.Path, UriFormat.Unescaped);
-
-                var segments = path?.Split('/') ?? [];
-
-                if (segments.Length != 1)
-                {
-                    return false;
-                }
-
-                return IsAccessionValid(segments.Last());
+                path = path[1..];
             }
+
+            return IsAccessionValid(path);
+        }
+
+        private static bool IsWellFormedCompactIdOriginalString(Uri uri)
+        {
+            if (!IsWellFormedSchemeAndDelimiter(uri))
+            {
+                return false;
+            }
+
+            return _drsCompactId.IsMatch(uri.OriginalString.AsSpan(_prefixLength)) &&
+                IsAccessionValid(uri.OriginalString.AsSpan(uri.OriginalString.LastIndexOf(':') + 1).ToString());
         }
 
         /// <summary>
@@ -83,206 +101,279 @@ namespace CommonUtilities
         /// <returns>
         ///   <c>true</c> if the value matches the spec; otherwise, <c>false</c>.
         /// </returns>
-        private static bool IsAccessionValid(ReadOnlySpan<char> accession)
+        private static bool IsAccessionValid(string accession)
         {
-            foreach (var ch in accession)
+            for (var i = 0; i < accession.Length; ++i)
             {
-                if (char.IsAsciiLetterOrDigit(ch))
-                    continue;
+                var ch = accession[i];
 
-                if (_allowedAccessionOthers.Contains(ch))
+                if (char.IsAsciiLetterOrDigit(ch) || _allowedAccessionOthers.Contains(ch))
+                {
                     continue;
+                }
 
-                return false;
+                var start = i;
+                _ = Uri.HexUnescape(accession, ref i);
+
+                if (--i == start)
+                {
+                    return false;
+                }
             }
 
             return true;
         }
 
-        /// <inheritdoc/>
-        protected override string GetComponents(Uri uri, UriComponents components, UriFormat format)
+        protected override UriParser OnNewUri() => new DrsParser();
+
+        private interface IDrsParser
         {
-            // -------------------------------------------------------------------------------------------------------------
-            // DRS URI style |     Host     |    Path    | Description
-            // -------------------------------------------------------------------------------------------------------------
-            // Compact       | Prefix       | Accession  | If prefix contains a '/', it is provider_code/namespace.
-            // Hostname      | Host[:Port]  | ID         | Per the spec, ID and Accession are the same thing.
-            // -------------------------------------------------------------------------------------------------------------
+            bool IsWellFormedOriginalString(Uri uri);
+        }
 
-            // Hostname style are like HTTP, except they don't have fragments and the Path is limited to one level.
-            // Spec is silent on Query, it's not currently implemented here.
+        private sealed partial class DrsParser : UriParser, IDrsParser
+        {
+            private static readonly Regex _parseDrsCompactId = ParseDrsCompactId();
 
-            // Compact style are not IETL-valid, which is the raison d'être of this implementation.
+            // These objects hold the following parts of the URI as applicable according to uri style: UserInfo, Host, Port, Path, & Query.
+            // Only one of them should ever be non null.
+            private Uri? _namespaceAsHttp;
+            private Match? _compactId;
 
-            var keepDelimiter = IsComponentIn(UriComponents.KeepDelimiter, components);
-
-            if (IsCompactIdUri(uri))
+            /// <summary>
+            /// Gets a value indicating whether this instance is compact identifier.
+            /// </summary>
+            /// <value>
+            ///   <c>true</c> if the associated Uri is a drs compact identifier uri; otherwise, <c>false</c>.
+            /// </value>
+            /// <exception cref="System.InvalidOperationException">Uri initialization and validation is not complete.</exception>
+            private bool IsCompactId
             {
-                // This is a compact id
-                StringBuilder builder = new();
-                var match = _drsCompactId.Match(uri.OriginalString[(_prefixLength)..]);
-
-                if (match.Success)
+                get
                 {
-                    if (IsComponentIn(UriComponents.Scheme, components))
+                    if (_namespaceAsHttp is null && _compactId is null)
                     {
-                        builder.Append(UriSchemeDrs);
+                        throw new InvalidOperationException("Uri initialization and validation is not complete.");
                     }
 
-                    if (IsComponentIn(UriComponents.Host, components))
-                    {
-                        if (builder.Length > 0)
-                        {
-                            builder.Append(Uri.SchemeDelimiter);
-                        }
-
-                        // "provider_code" includes the separating '/' if a provider code was found due to the regex.
-                        builder.Append(match.Groups["provider_code"].Value + match.Groups["namespace"].Value);
-                    }
-
-                    if (IsComponentIn(UriComponents.Path, components))
-                    {
-                        if (builder.Length > 0 || keepDelimiter)
-                        {
-                            builder.Append(':');
-                        }
-
-                        builder.Append(match.Groups["accession"].Value);
-                    }
+                    return _compactId is not null;
                 }
-
-                return builder.ToString();
             }
-            else
+
+            /// <inheritdoc/> 
+            protected override bool IsBaseOf(Uri baseUri, Uri relativeUri)
+                => UriSchemeDrs.Equals(baseUri.Scheme, StringComparison.OrdinalIgnoreCase) && UriSchemeDrs.Equals(relativeUri.Scheme, StringComparison.OrdinalIgnoreCase)
+                ? baseUri.Host.Equals(relativeUri.Host, StringComparison.OrdinalIgnoreCase) &&
+                    baseUri.Port.Equals(relativeUri.Port) &&
+                    baseUri.Query.Equals(relativeUri.Query, StringComparison.Ordinal) // TODO: review
+                : base.IsBaseOf(baseUri, relativeUri);
+
+            /// <inheritdoc/>
+            protected override bool IsWellFormedOriginalString(Uri uri)
+                => IsCompactId
+                ? IsWellFormedCompactIdOriginalString(uri)
+                : IsWellFormedNamespaceOriginalString(uri, this);
+
+            /// <inheritdoc/>
+            protected override string? Resolve(Uri baseUri, Uri? relativeUri, out UriFormatException? parsingError)
             {
-                // This is a hostname id
-                if (components == UriComponents.Host)
+                if (relativeUri is null || string.IsNullOrWhiteSpace(relativeUri.OriginalString) || !IsAccessionValid(relativeUri.OriginalString))
                 {
-                    return GetModel(uri).Host;
+                    parsingError = new("relativeUri is not a valid DRS ID");
+                    return null;
                 }
 
-                if (components == UriComponents.StrongPort)
-                {
-                    var model = GetModel(uri);
-                    return model.IsDefaultPort ? string.Empty : model.Port.ToString(System.Globalization.CultureInfo.InvariantCulture);
-                }
+                return IsCompactId
+                    ? ResolveCompactId(baseUri, relativeUri, out parsingError)
+                    : base.Resolve(baseUri, relativeUri, out parsingError);
+            }
 
-                if (components == UriComponents.Path || components == (UriComponents.Path | UriComponents.KeepDelimiter))
-                {
-                    var path = GetModel(uri).LocalPath;
+            private static string? ResolveCompactId(Uri baseUri, Uri relativeUri, out UriFormatException? parsingError)
+            {
+                parsingError = null;
+                return $"{_prefix}{baseUri.Host}:{relativeUri.OriginalString}";
+            }
 
-                    if (path[0] == '/' && !keepDelimiter)
+            /// <inheritdoc/>
+            protected override string GetComponents(Uri uri, UriComponents components, UriFormat format)
+            {
+                return IsCompactId
+                    ? GetCompactIdComponents(uri, components, format)
+                    : GetNamespaceComponents(uri, components, format);
+            }
+
+            private string GetCompactIdComponents(Uri uri, UriComponents components, UriFormat format) => components switch
+            {
+                // UriBuilder
+                UriComponents.AbsoluteUri => _prefix + GetCompactIdComponents(uri, UriComponents.Host, UriFormat.UriEscaped) + GetCompactIdComponents(uri, UriComponents.Path | UriComponents.KeepDelimiter, UriFormat.UriEscaped),
+
+                // "provider_code" includes the separating '/' if a provider code was found due to the regex.
+                UriComponents.Host => _compactId!.Groups["provider_code"].Value.ToLowerInvariant() + _compactId!.Groups["namespace"].Value.ToLowerInvariant(),
+
+                var c when c.AreComponentExactly(UriComponents.Path, UriComponents.KeepDelimiter) =>
+                    (components.AreComponentsIn(UriComponents.KeepDelimiter) ? ":" : string.Empty) + _compactId!.Groups["accession"].Value,
+
+                // Base class implementation will call back here for (some of) the individual elements.
+                _ => base.GetComponents(uri, components, format),
+            };
+
+            private string GetNamespaceComponents(Uri uri, UriComponents components, UriFormat format) => components switch
+            {
+                UriComponents.Host => _namespaceAsHttp!.Host,
+
+                UriComponents.StrongPort => _namespaceAsHttp!.IsDefaultPort ? string.Empty : _namespaceAsHttp!.Port.ToString(System.Globalization.CultureInfo.InvariantCulture),
+
+                var c when c.AreComponentExactly(UriComponents.Path, UriComponents.KeepDelimiter) => new Func<string>(() =>
+                {
+                    var path = _namespaceAsHttp!.AbsolutePath;
+
+                    if (path[0] == '/' && !components.AreComponentsIn(UriComponents.KeepDelimiter))
                     {
                         path = path[1..];
                     }
 
                     return path;
-                }
+                })(),
 
-                return base.GetComponents(uri, components, format);
-            }
+                // Base class implementation will call back here for (some of) the individual elements.
+                _ => base.GetComponents(uri, components, format),
+            };
 
-            // Gets an https version of the drs uri. Used to parse out the escaped Host, Port, and Path uri properties.
-            static Uri GetModel(Uri uri)
-                => new($"{Uri.UriSchemeHttps}{uri.OriginalString[UriSchemeDrs.Length..]}");
-        }
-
-        /// <summary>
-        /// Determines whether the specified components are included in the mask.
-        /// </summary>
-        /// <param name="mask">The mask.</param>
-        /// <param name="components">The components.</param>
-        /// <returns>
-        ///   <c>true</c> if any of the specified components is included in the mask; otherwise, <c>false</c>.
-        /// </returns>
-        private static bool IsComponentIn(UriComponents mask, UriComponents components)
-            => (components & mask) != 0;
-
-        /// <inheritdoc/>
-        protected override string? Resolve(Uri baseUri, Uri? relativeUri, out UriFormatException? parsingError)
-        {
-            // DRS relative URLs are simply not supported. Force an error.
-            return base.Resolve(new Uri(".", UriKind.Relative), relativeUri, out parsingError);
-        }
-
-        /// <inheritdoc/>
-        protected override void InitializeAndValidate(Uri uri, out UriFormatException? parsingError)
-        {
-            // Hostname URIs are adequately processed by GenericUriParser.
-            base.InitializeAndValidate(uri, out parsingError);
-
-            // Validate accessions/ids
-            if (parsingError is null && !IsCompactIdUriValid(uri))
+            /// <inheritdoc/>
+            protected override void InitializeAndValidate(Uri uri, out UriFormatException? parsingError)
             {
-                // This is a hostname URI. However we turned off the host uri parsing in base.InitializeAndValidate (to prevent file-based URIs), so we'll do it here.
-                if (!IsHostnameUriValid(uri))
+                if (!uri.OriginalString.StartsWith(_prefix, StringComparison.OrdinalIgnoreCase))
                 {
-                    parsingError = new UriFormatException("Malformed DRS URI: slashes are not allowed in the DRS ID.");
+                    parsingError = new("Invalid DRS URI: Unexpected schema in Uri.");
+                    return;
                 }
-                else
-                {
-                    switch (Uri.CheckHostName(uri.Host))
-                    {
-                        case UriHostNameType.Dns:
-                        case UriHostNameType.IPv4:
-                        case UriHostNameType.IPv6:
-                            break;
 
-                        case UriHostNameType.Basic:
-                        default:
-                            parsingError = new("Invalid URI: The Authority/Host could not be parsed.");
-                            break;
+                // Hostname URIs are mostly processed by GenericUriParser.
+                base.InitializeAndValidate(uri, out parsingError);
+
+                if (parsingError is not null)
+                {
+                    return;
+                }
+
+                var uriWithoutPrefix = uri.OriginalString.AsSpan(_prefixLength);
+
+                var idxOfEndOfPath = uriWithoutPrefix.IndexOfAny(['?', '#']);
+                var authorityAndPath = idxOfEndOfPath == -1 ? uriWithoutPrefix : uriWithoutPrefix[..idxOfEndOfPath];
+
+                if (authorityAndPath.Count('@') == 0 && authorityAndPath.Count(':') == 1 && authorityAndPath.Count('/') < 2) // zero '@', one ':' and zero or one '/'
+                {
+                    // compact Id style
+                    _compactId = _parseDrsCompactId.Match(uriWithoutPrefix.ToString());
+
+                    if (!_compactId.Success)
+                    {
+                        parsingError = new("Invalid DRS URI: Malformed Compact ID URI");
                     }
                 }
-            }
 
-            static bool IsHostnameUriValid(Uri uri)
-            {
-                if (!uri.IsAbsoluteUri || uri.IsUnc)
+                if (_compactId is null)
                 {
-                    return false;
+                    // hostname style
+                    // This https uri is used to parse out the escaped Host, Port, and Path uri properties because GenericUriParser is unable to do it correctly with our settings.
+                    _namespaceAsHttp = new(Uri.UriSchemeHttps + Uri.SchemeDelimiter + uriWithoutPrefix.ToString());
+
+                    if (!IsHostnameUriValid(uri))
+                    {
+                        parsingError = new UriFormatException("Invalid DRS URI: Malformed Hostname URI");
+                    }
+                    else
+                    {
+                        // This is a hostname URI. However we turned off the host uri parsing in base.InitializeAndValidate (to prevent forming filesystem style URIs), so we'll validate it here.
+                        switch (Uri.CheckHostName(uri.Host))
+                        {
+                            case UriHostNameType.Dns:
+                            case UriHostNameType.IPv4:
+                            case UriHostNameType.IPv6:
+                                break;
+
+                            case UriHostNameType.Basic:
+                            default:
+                                parsingError = new("Invalid DRS URI: The Authority/Host could not be parsed.");
+                                break;
+                        }
+                    }
                 }
 
-                if (new Uri($"{Uri.UriSchemeHttps}{uri.OriginalString[UriSchemeDrs.Length..]}").HostNameType == UriHostNameType.Basic)
+                if (!(parsingError is null && IsDrsIdValid(uri)))
                 {
-                    return false;
+                    parsingError = new("Invalid DRS URI: Invalid DSR ID/Accession.");
                 }
 
-                return IsDrsIdValid(uri);
-            }
-
-            static bool IsCompactIdUriValid(Uri uri)
-            {
-                if (!IsCompactIdUri(uri))
+                static bool IsHostnameUriValid(Uri uri)
                 {
-                    return false;
+                    if (!uri.IsAbsoluteUri)
+                    {
+                        return false;
+                    }
+
+                    // If this was parsed as ither a UNC or a local-file style path, reject it.
+                    if (uri.IsUnc || new Uri($"{Uri.UriSchemeHttps}{uri.OriginalString[UriSchemeDrs.Length..]}").HostNameType == UriHostNameType.Basic)
+                    {
+                        return false;
+                    }
+
+                    return true;
                 }
 
-                return IsDrsIdValid(uri);
+                static bool IsDrsIdValid(Uri uri)
+                {
+                    var path = uri.AbsolutePath;
+
+                    if (path.IndexOfAny(['/', ':']) == 0)
+                    {
+                        path = path[1..];
+                    }
+
+                    if (string.IsNullOrEmpty(path))
+                    {
+                        return false;
+                    }
+
+                    // Return false if it appears a compact id URI with provider_code was parsed. Note that hostname Uris don't allow unescaped embedded slashes in the path.
+                    return !path.Any(c => c == '/') && !path.Any(c => c == ':') && IsAccessionValid(path);
+                }
             }
 
-            static bool IsDrsIdValid(Uri uri)
-            {
-                var path = uri.AbsolutePath;
+            bool IDrsParser.IsWellFormedOriginalString(Uri uri) => base.IsWellFormedOriginalString(uri);
 
-                // Return false if it appears a compact id URI with provider_code was parsed. Note that hostname Uris don't allow unescaped embedded slashes in the path.
-                return !path.TrimStart('/').Any(c => c == '/') && !path.TrimStart(':').Any(c => c == ':') && IsAccessionValid(uri.Segments.Last().TrimStart(':'));
-            }
+            // Same as DrsCompactId(), except with RegexOptions.IgnoreCase to allow case insensitive comparisons.
+            [GeneratedRegex(@"\A(?<provider_code>[\.0-9_a-z]+?/)?(?<namespace>[\.0-9_a-z]+?):(?<accession>[%-\.0-9A-Z_a-z~]+?)\Z", RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)]
+            private static partial Regex ParseDrsCompactId();
         }
-
-        /// <summary>
-        /// Determines whether a URI is a DRS compact identifier URI.
-        /// </summary>
-        /// <param name="uri">The URI.</param>
-        /// <returns>
-        ///   <c>true</c> if the URI is a DRS compact id URI; otherwise, <c>false</c>.
-        /// </returns>
-        private static bool IsCompactIdUri(Uri uri)
-            => uri.OriginalString.StartsWith(_prefix, StringComparison.OrdinalIgnoreCase) && _drsCompactId.IsMatch(uri.OriginalString.AsSpan(_prefixLength));
 
         // https://ga4gh.github.io/data-repository-service-schemas/docs/#tag/DRS-API-Principles/DRS-IDs
         // https://ga4gh.github.io/data-repository-service-schemas/docs/more-background-on-compact-identifiers.html#tag/Background-on-Compact-Identifier-Based-URIs
-        [GeneratedRegex("\\A(?<provider_code>[\\._a-z]+?/)?(?<namespace>[\\._a-z]+?):(?<accession>[%-\\.0-9A-Z_a-z~]+?)\\Z", RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant)]
+        [GeneratedRegex(@"\A(?<provider_code>[\.0-9_a-z]+?/)?(?<namespace>[\.0-9_a-z]+?):(?<accession>[%-\.0-9A-Z_a-z~]+?)\Z", RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant)]
         private static partial Regex DrsCompactId();
+    }
+
+    internal static partial class UriComponentExtensions
+    {
+        /// <summary>
+        /// Determines whether any of the specified components are included in the mask.
+        /// </summary>
+        /// <param name="components">The components to consider.</param>
+        /// <param name="mask">The desired components.</param>
+        /// <returns>
+        ///   <c>true</c> if any of the specified components is included in the mask; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool AreComponentsIn(this UriComponents components, UriComponents mask) => (components & mask) != 0;
+
+        /// <summary>
+        /// Determines whether the specified components are all included components, except for those in the mask.
+        /// </summary>
+        /// <param name="components">The components to consider.</param>
+        /// <param name="value">The remaining components.</param>
+        /// <param name="ignore">The components to ignore.</param>
+        /// <returns>
+        ///   <c>true</c> if all and only the components in <paramref name="value"/> are found in <paramref name="components"/>, excluding the components in <paramref name="ignore"/>; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool AreComponentExactly(this UriComponents components, UriComponents value, UriComponents ignore = 0) => (components & ~ignore) == value;
     }
 }


### PR DESCRIPTION
fixes #768

* Processing of each of the two styles of URI are now separated, and logic associated with the various different operations are now grouped together, making the code easier to reason with
* Improved error messages. If providing a malformed compact id style URI, you are more likely to get an error related to that style instead of a nonactionable error related to the hostname style
* Now runs Regex only once per Compact Id URI, rather 1-7 times for every single DRS URI
* Relative URIs now work
* Embedded escapes in DRS IDs are now verified AND no longer cause later parsing errors
* Lots more testing (along all known edges)
* URIs that violate case sensitivity per spec now parse correctly (and are perfectly usable). Parts of the URI that are supposed to be lowercase are lowercased for the user (since those are treated as case insensitive by other systems there is no issue here)
* Parsing is now more robust and much more efficient