### PR TITLE
MCR's docker mirror for ubuntu does not include "latest"

### DIFF
--- a/src/deploy-tes-on-azure/Configuration.cs
+++ b/src/deploy-tes-on-azure/Configuration.cs
@@ -87,8 +87,8 @@ namespace TesDeployer
         public string DeploymentOrganizationUrl { get; set; }
         public string DeploymentContactUri { get; set; }
         public string DeploymentEnvironment { get; set; }
-        public string PrivateTestUbuntuImage { get; set; } = "mcr.microsoft.com/mirror/docker/library/ubuntu:latest";
-        public string PrivatePSQLUbuntuImage { get; set; } = "mcr.microsoft.com/mirror/docker/library/ubuntu:latest";
+        public string PrivateTestUbuntuImage { get; set; } = "mcr.microsoft.com/mirror/docker/library/ubuntu:24.04"; // mcr's docker mirror does not host "latest"
+        public string PrivatePSQLUbuntuImage { get; set; } = "mcr.microsoft.com/mirror/docker/library/ubuntu:24.04"; // mcr's docker mirror does not host "latest"
 
         public static Configuration BuildConfiguration(string[] args)
         {


### PR DESCRIPTION
Addresses microsoft/CromwellOnAzure#813

```
{
  "name": "mirror/docker/library/ubuntu",
  "tags": [
    "18.04",
    "20.04",
    "22.04",
    "24.04",
    "bionic",
    "focal",
    "jammy",
    "noble"
  ]
}
```