### PR TITLE
[797] Adds Azure Gov to the list of valid suffixes for ACR authentication.

### DIFF
--- a/src/Tes.Runner.Test/Docker/ContainerRegistryAuthorizationManagerTests.cs
+++ b/src/Tes.Runner.Test/Docker/ContainerRegistryAuthorizationManagerTests.cs
@@ -40,6 +40,8 @@ public class ContainerRegistryAuthorizationManagerTests
     }
 
     [DataTestMethod]
+    [DataRow("test.azurecr.us/azure-cli", true, new[] { "test.azurecr.us", "azure-cli" })]  // Test case for Azure Government ACRs
+    [DataRow("test.azurecr.cn/azure-cli", true, new[] { "test.azurecr.cn", "azure-cli" })]  // Test case for Azure China ACRs
     [DataRow("test.azurecr.io/azure-cli", true, new[] { "test.azurecr.io", "azure-cli" })]
     [DataRow("mcr.microsoft.com/azure-cli", false, new[] { "mcr.microsoft.com", "azure-cli" })]
     [DataRow("azure-cli", false, new[] { "azure-cli" })]

--- a/src/Tes.Runner/Docker/ContainerRegistryAuthorizationManager.cs
+++ b/src/Tes.Runner/Docker/ContainerRegistryAuthorizationManager.cs
@@ -3,11 +3,8 @@
 
 using Azure.Containers.ContainerRegistry;
 using Azure.Core;
-using CommonUtilities;
-using CommonUtilities.AzureCloud;
 using Docker.DotNet.Models;
 using Microsoft.Extensions.Logging;
-using Tes.ApiClients;
 using Tes.Runner.Authentication;
 using Tes.Runner.Models;
 using Tes.Runner.Transfer;
@@ -16,7 +13,11 @@ namespace Tes.Runner.Docker
 {
     public class ContainerRegistryAuthorizationManager
     {
-        const string AzureContainerRegistryHostSuffix = ".azurecr.io";
+        private static readonly HashSet<string> AzureContainerRegistryHostSuffixes =
+                                [".azurecr.io",
+                                    ".azurecr.cn",
+                                    ".azurecr.us"];
+
         public static readonly string NullGuid = Guid.Empty.ToString("D");
 
         private readonly ILogger logger = PipelineLoggerFactory.Create<ContainerRegistryAuthorizationManager>();
@@ -73,7 +74,7 @@ namespace Tes.Runner.Docker
             imageParts = imageName.Split('/', 2);
             var registry = imageParts.FirstOrDefault();
 
-            return registry?.EndsWith(AzureContainerRegistryHostSuffix, StringComparison.OrdinalIgnoreCase) ?? false;
+            return AzureContainerRegistryHostSuffixes.Any(suffix => registry?.EndsWith(suffix, StringComparison.OrdinalIgnoreCase) ?? false);
         }
 
 


### PR DESCRIPTION
Closes: #797 

In this PR:
- Added ACR suffixes for Azure Gov and China (for completeness), making them valid ACR endpoints for authentication attempts when public pull fails. 
- Included tests to validate this scenario.