### PR TITLE
Address upgrade failure

### DIFF
--- a/src/CommonUtilities/AzureServicesConnectionStringCredential.cs
+++ b/src/CommonUtilities/AzureServicesConnectionStringCredential.cs
@@ -51,6 +51,7 @@ namespace CommonUtilities
             Configuration = configuration;
             SetInitialState(armEndpoints);
             ConnectionString = GetEnvironmentVariable("AzureServicesAuthConnectionString")!;
+            PrintState();
         }
 
         public AzureServicesConnectionStringCredentialOptions(string connectionString, AzureCloudConfig armEndpoints)
@@ -58,6 +59,19 @@ namespace CommonUtilities
         {
             SetInitialState(armEndpoints);
             ConnectionString = connectionString;
+            PrintState();
+        }
+
+        private void PrintState()
+        {
+            var prefix = nameof(AzureServicesConnectionStringCredential) + ": ";
+            Console.WriteLine(prefix + nameof(AdditionallyAllowedTenants) + $"({AdditionallyAllowedTenants.Count}) =" + string.Join(", ", AdditionallyAllowedTenants));
+            Console.WriteLine(prefix + nameof(Audience) + "=" + Audience ?? "<null>");
+            Console.WriteLine(prefix + nameof(AuthorityHost) + "=" + AuthorityHost ?? "<null>");
+            Console.WriteLine(prefix + nameof(ConnectionString) + "=" + ConnectionString ?? "<null>");
+            Console.WriteLine(prefix + nameof(DisableInstanceDiscovery) + "=" + DisableInstanceDiscovery ?? "<null>");
+            Console.WriteLine(prefix + nameof(Resource) + "=" + Resource ?? "<null>");
+            Console.WriteLine(prefix + nameof(TenantId) + "=" + TenantId ?? "<null>");
         }
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/src/CommonUtilities/CommonUtilities.csproj
+++ b/src/CommonUtilities/CommonUtilities.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.13.0" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Azure.ResourceManager" Version="1.13.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.10" />

--- a/src/CommonUtilities/CommonUtilities.csproj
+++ b/src/CommonUtilities/CommonUtilities.csproj
@@ -16,8 +16,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <!--Mitigate reported security issues-->
-    <PackageReference Include="Azure.Core" Version="1.44.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly" Version="8.4.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/src/GenerateBatchVmSkus/GenerateBatchVmSkus.csproj
+++ b/src/GenerateBatchVmSkus/GenerateBatchVmSkus.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.ResourceManager.Batch" Version="1.5.0" />
     <PackageReference Include="Azure.ResourceManager.Compute" Version="1.6.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Batch" Version="16.3.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />

--- a/src/Tes.SDK.Examples/Tes.SDK.Examples.csproj
+++ b/src/Tes.SDK.Examples/Tes.SDK.Examples.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.1" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.22.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.22.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tes.SDK/Tes.SDK.csproj
+++ b/src/Tes.SDK/Tes.SDK.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.1" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.22.1" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.22.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tes/Tes.csproj
+++ b/src/Tes/Tes.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <!--Mitigate reported security issues-->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
     <PackageReference Include="Polly" Version="8.4.2" />
     <!--Mitigate reported security issues-->
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/src/deploy-tes-on-azure/Deployer.cs
+++ b/src/deploy-tes-on-azure/Deployer.cs
@@ -384,6 +384,12 @@ namespace TesDeployer
 
                     if (installedVersion is null || installedVersion < new Version(5, 4, 7)) // Previous attempt 5.2.2
                     {
+                        var connectionString = settings["AzureServicesAuthConnectionString"];
+                        if (connectionString.Contains("RunAs=App"))
+                        {
+                            settings["AzureServicesAuthConnectionString"] = connectionString.Replace("RunAs=App", "RunAs=Workload");
+                        }
+
                         var pool = aksCluster.Data.AgentPoolProfiles.FirstOrDefault(pool => "nodepool1".Equals(pool.Name, StringComparison.OrdinalIgnoreCase));
 
                         if (!(aksCluster.Data.SecurityProfile.IsWorkloadIdentityEnabled ?? false) ||
@@ -1290,7 +1296,7 @@ namespace TesDeployer
                 UpdateSetting(settings, defaults, "BatchAccountName", configuration.BatchAccountName, ignoreDefaults: true);
                 UpdateSetting(settings, defaults, "ApplicationInsightsAccountName", configuration.ApplicationInsightsAccountName, ignoreDefaults: true);
                 UpdateSetting(settings, defaults, "ManagedIdentityClientId", managedIdentityClientId, ignoreDefaults: true);
-                UpdateSetting(settings, defaults, "AzureServicesAuthConnectionString", $"RunAs=App;AppId={managedIdentityClientId}", ignoreDefaults: true);
+                UpdateSetting(settings, defaults, "AzureServicesAuthConnectionString", $"RunAs=Workload;AppId={managedIdentityClientId}", ignoreDefaults: true);
                 UpdateSetting(settings, defaults, "KeyVaultName", configuration.KeyVaultName, ignoreDefaults: true);
                 UpdateSetting(settings, defaults, "AksCoANamespace", configuration.AksCoANamespace, ignoreDefaults: true);
                 UpdateSetting(settings, defaults, "CrossSubscriptionAKSDeployment", configuration.CrossSubscriptionAKSDeployment);

--- a/src/deploy-tes-on-azure/Deployer.cs
+++ b/src/deploy-tes-on-azure/Deployer.cs
@@ -1576,7 +1576,8 @@ namespace TesDeployer
 
             _ = ConsoleEx.WriteLine($"AadGroupIds: {configuration.AadGroupIds ?? "<null>"}", ConsoleColor.Yellow);
             _ = ConsoleEx.WriteLine($"AdminGroupObjectIds: {string.Join(", ", managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? []):D}", ConsoleColor.Yellow);
-            var adminGroupObjectIds = managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? (string.IsNullOrWhiteSpace(configuration.AadGroupIds) ? [] : configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse).ToList());
+            var adminGroupObjectIds = managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? [];
+            adminGroupObjectIds = adminGroupObjectIds.Count == 0 ? adminGroupObjectIds : (string.IsNullOrWhiteSpace(configuration.AadGroupIds) ? [] : configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse).ToList());
             _ = ConsoleEx.WriteLine($"adminGroupObjectIds: {string.Join(", ", adminGroupObjectIds):D}", ConsoleColor.Yellow);
 
             if (adminGroupObjectIds.Count == 0)

--- a/src/deploy-tes-on-azure/Deployer.cs
+++ b/src/deploy-tes-on-azure/Deployer.cs
@@ -353,6 +353,8 @@ namespace TesDeployer
 
                     var settings = ConfigureSettings(managedIdentity.Data.ClientId?.ToString("D"), aksValues, installedVersion);
                     var waitForRoleAssignmentPropagation = false;
+                    IEnumerable<string> manualPrecommands = null;
+                    Func<IKubernetes, Task> asyncTask = null;
 
                     if (installedVersion is null || installedVersion < new Version(4, 4))
                     {
@@ -380,10 +382,39 @@ namespace TesDeployer
                         }
                     }
 
-                    if (installedVersion is null || installedVersion < new Version(5, 2, 2))
+                    if (installedVersion is null || installedVersion < new Version(5, 4, 7)) // Previous attempt 5.2.2
                     {
-                        await operationNotAllowedConflictRetryPolicy.ExecuteAsync(() => EnableWorkloadIdentity(aksCluster, managedIdentity, resourceGroup));
-                        await kubernetesManager.RemovePodAadChart();
+                        var pool = aksCluster.Data.AgentPoolProfiles.FirstOrDefault(pool => "nodepool1".Equals(pool.Name, StringComparison.OrdinalIgnoreCase));
+
+                        if (!(aksCluster.Data.SecurityProfile.IsWorkloadIdentityEnabled ?? false) ||
+                            !(aksCluster.Data.OidcIssuerProfile.IsEnabled ?? false) ||
+                            pool?.OSSku == ContainerServiceOSSku.Ubuntu ||
+                            !(pool?.EnableEncryptionAtHost ?? false) ||
+                            "Standard_D3_v2".Equals(pool?.VmSize, StringComparison.OrdinalIgnoreCase) ||
+                            !(aksCluster.Data.AadProfile?.IsAzureRbacEnabled ?? false) ||
+                            (await managedIdentity.GetFederatedIdentityCredentials()
+                                .SingleOrDefaultAsync(r => "toaFederatedIdentity".Equals(r.Id.Name, StringComparison.OrdinalIgnoreCase), cts.Token)) is null)
+                        {
+                            await AssignMeAsRbacClusterAdminToManagedClusterAsync(aksCluster);
+                            waitForRoleAssignmentPropagation = true;
+                            ManagedClusterEnableManagedAad(aksCluster.Data);
+
+                            if (pool?.OSSku == ContainerServiceOSSku.Ubuntu || !(pool?.EnableEncryptionAtHost ?? false))
+                            {
+                                pool.EnableEncryptionAtHost = true;
+                                pool.OSSku = ContainerServiceOSSku.AzureLinux;
+                                pool.VmSize = "Standard_D4s_v3";
+                            }
+
+                            aksCluster = await EnableWorkloadIdentity(aksCluster, managedIdentity, resourceGroup);
+                            await Task.Delay(TimeSpan.FromMinutes(2), cts.Token);
+
+                            if (installedVersion is null || installedVersion < new Version(5, 2, 3))
+                            {
+                                manualPrecommands = (manualPrecommands ?? []).Append("Include the following HELM command: uninstall aad-pod-identity --namespace kube-system");
+                                asyncTask = _ => kubernetesManager.RemovePodAadChart();
+                            }
+                        }
                     }
 
                     if (installedVersion is null || installedVersion < new Version(5, 3, 1))
@@ -402,18 +433,23 @@ namespace TesDeployer
                         }
                     }
 
+                    //if (installedVersion is null || installedVersion < new Version(5, 4, 7))
+                    //{
+                    //}
+
                     //if (installedVersion is null || installedVersion < new Version(x, y, z))
                     //{
                     //}
 
                     if (waitForRoleAssignmentPropagation)
                     {
-                        await Execute("Waiting 5 minutes for role assignment propagation...",
-                            () => Task.Delay(TimeSpan.FromMinutes(5), cts.Token));
+                        // 10 minutes for propagation https://learn.microsoft.com/azure/role-based-access-control/troubleshooting
+                        await Execute("Waiting 10 minutes for role assignment propagation...",
+                            () => Task.Delay(TimeSpan.FromMinutes(10), cts.Token));
                     }
 
                     await kubernetesManager.UpgradeValuesYamlAsync(storageAccountData, settings);
-                    await PerformHelmDeploymentAsync(aksCluster);
+                    await PerformHelmDeploymentAsync(aksCluster, manualPrecommands, asyncTask);
                 }
 
                 if (!configuration.Update)
@@ -597,7 +633,8 @@ namespace TesDeployer
                             if (aksCluster is null && !configuration.ManualHelmDeployment)
                             {
                                 aksCluster = await ProvisionManagedClusterAsync(managedIdentity, logAnalyticsWorkspace, vnetAndSubnet?.vmSubnet.Id, configuration.PrivateNetworking.GetValueOrDefault());
-                                await EnableWorkloadIdentity(aksCluster, managedIdentity, resourceGroup);
+                                await AssignMeAsRbacClusterAdminToManagedClusterAsync(aksCluster);
+                                aksCluster = await EnableWorkloadIdentity(aksCluster, managedIdentity, resourceGroup);
                             }
                         }),
                         Task.Run(async () =>
@@ -791,7 +828,7 @@ namespace TesDeployer
                 if (!(exc is OperationCanceledException && cts.Token.IsCancellationRequested))
                 {
                     ConsoleEx.WriteLine();
-                    ConsoleEx.WriteLine($"{exc.GetType().Name}: {exc.Message}", ConsoleColor.Red);
+                    ConsoleEx.WriteLine($"{exc.GetType().FullName}: {exc.Message}", ConsoleColor.Red);
 
                     if (configuration.DebugLogging)
                     {
@@ -1112,6 +1149,15 @@ namespace TesDeployer
             }
         }
 
+        private static void ManagedClusterEnableManagedAad(ContainerServiceManagedClusterData managedCluster)
+        {
+            managedCluster.EnableRbac = true;
+            managedCluster.AadProfile ??= new();
+            managedCluster.AadProfile.IsAzureRbacEnabled = true;
+            managedCluster.AadProfile.IsManagedAadEnabled = true;
+            managedCluster.AadProfile.AdminGroupObjectIds.ToList().ForEach(item => _ = managedCluster.AadProfile.AdminGroupObjectIds.Remove(item));
+        }
+
         private async Task<ContainerServiceManagedClusterResource> ProvisionManagedClusterAsync(UserAssignedIdentityResource managedIdentity, OperationalInsightsWorkspaceResource logAnalyticsWorkspace, ResourceIdentifier subnetId, bool privateNetworking)
         {
             var uami = await EnsureResourceDataAsync(managedIdentity, r => r.HasData, r => r.GetAsync, cts.Token);
@@ -1132,19 +1178,7 @@ namespace TesDeployer
             ManagedClusterAddonProfile clusterAddonProfile = new(isEnabled: true);
             clusterAddonProfile.Config.Add("logAnalyticsWorkspaceResourceID", logAnalyticsWorkspace.Id);
             cluster.AddonProfiles.Add("omsagent", clusterAddonProfile);
-
-            if (!string.IsNullOrWhiteSpace(configuration.AadGroupIds))
-            {
-                cluster.EnableRbac = true;
-                cluster.AadProfile = new()
-                {
-                    IsAzureRbacEnabled = false,
-                    IsManagedAadEnabled = true
-                };
-
-                configuration.AadGroupIds.Split(",", StringSplitOptions.RemoveEmptyEntries).Select(Guid.Parse).ForEach(cluster.AadProfile.AdminGroupObjectIds.Add);
-            }
-
+            ManagedClusterEnableManagedAad(cluster);
             Azure.ResourceManager.Models.ManagedServiceIdentity identity = new(Azure.ResourceManager.Models.ManagedServiceIdentityType.UserAssigned);
             identity.UserAssignedIdentities.Add(uami.Id, new());
             cluster.Identity = identity;
@@ -1182,23 +1216,33 @@ namespace TesDeployer
                 async () => (await resourceGroup.GetContainerServiceManagedClusters().CreateOrUpdateAsync(Azure.WaitUntil.Completed, configuration.AksClusterName, cluster, cts.Token)).Value);
         }
 
-        private async Task EnableWorkloadIdentity(ContainerServiceManagedClusterResource aksCluster, UserAssignedIdentityResource managedIdentity, ResourceGroupResource resourceGroup)
+        private async Task<ContainerServiceManagedClusterResource> EnableWorkloadIdentity(ContainerServiceManagedClusterResource aksCluster, UserAssignedIdentityResource managedIdentity, ResourceGroupResource resourceGroup)
         {
             aksCluster.Data.SecurityProfile.IsWorkloadIdentityEnabled = true;
             aksCluster.Data.OidcIssuerProfile.IsEnabled = true;
             var aksClusterCollection = resourceGroup.GetContainerServiceManagedClusters();
-            var cluster = await aksClusterCollection.CreateOrUpdateAsync(Azure.WaitUntil.Completed, aksCluster.Data.Name, aksCluster.Data, cts.Token);
+
+            var cluster = await Execute("Updating AKS cluster...",
+                async () => await operationNotAllowedConflictRetryPolicy.ExecuteAsync(token => aksClusterCollection.CreateOrUpdateAsync(WaitUntil.Completed, aksCluster.Data.Name, aksCluster.Data, token), cts.Token));
+
             var aksOidcIssuer = cluster.Value.Data.OidcIssuerProfile.IssuerUriInfo;
 
             var federatedCredentialsCollection = managedIdentity.GetFederatedIdentityCredentials();
-            var data = new FederatedIdentityCredentialData()
-            {
-                IssuerUri = new Uri(aksOidcIssuer),
-                Subject = $"system:serviceaccount:{configuration.AksCoANamespace}:{managedIdentity.Id.Name}-sa"
-            };
-            data.Audiences.Add("api://AzureADTokenExchange");
 
-            await federatedCredentialsCollection.CreateOrUpdateAsync(Azure.WaitUntil.Completed, "toaFederatedIdentity", data, cts.Token);
+            if ((await federatedCredentialsCollection.SingleOrDefaultAsync(r => "coaFederatedIdentity".Equals(r.Id.Name, StringComparison.OrdinalIgnoreCase), cts.Token)) is null)
+            {
+                var data = new FederatedIdentityCredentialData()
+                {
+                    IssuerUri = new Uri(aksOidcIssuer),
+                    Subject = $"system:serviceaccount:{configuration.AksCoANamespace}:{managedIdentity.Id.Name}-sa"
+                };
+                data.Audiences.Add("api://AzureADTokenExchange");
+
+                await Execute("Enabling workload identity...",
+                    async () => _ = await operationNotAllowedConflictRetryPolicy.ExecuteAsync(token => federatedCredentialsCollection.CreateOrUpdateAsync(WaitUntil.Completed, "toaFederatedIdentity", data, token), cts.Token));
+            }
+
+            return cluster.Value;
         }
 
         private static Dictionary<string, string> GetDefaultValues(string[] files)
@@ -1525,6 +1569,38 @@ namespace TesDeployer
             => AssignRoleToResourceAsync(managedIdentity, storageAccount, GetSubscriptionRoleDefinition(RoleDefinitions.General.Contributor),
                 $"Assigning '{RoleDefinitions.GetDisplayName(RoleDefinitions.General.Contributor)}' role for user-managed identity to Storage Account resource scope...");
 
+        private async Task AssignMeAsRbacClusterAdminToManagedClusterAsync(ContainerServiceManagedClusterResource managedCluster)
+        {
+            var message = $"Assigning '{RoleDefinitions.GetDisplayName(RoleDefinitions.Containers.RbacClusterAdmin)}' role for {{Admins}} to AKS cluster resource scope...";
+            var roleDefinitionId = GetSubscriptionRoleDefinition(RoleDefinitions.Containers.RbacClusterAdmin);
+
+            var adminGroupObjectIds = managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? (string.IsNullOrWhiteSpace(configuration.AadGroupIds) ? [] : configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse).ToList());
+
+            if (adminGroupObjectIds.Count == 0)
+            {
+                var user = await GetUserObjectAsync();
+
+                if (user is not null)
+                {
+                    await AssignRoleToResourceAsync(
+                        [new Guid(user.Id)],
+                        Azure.ResourceManager.Authorization.Models.RoleManagementPrincipalType.User,
+                        managedCluster,
+                        roleDefinitionId,
+                        message.Replace(@"{Admins}", "deployer user"));
+                }
+            }
+            else
+            {
+                await AssignRoleToResourceAsync(
+                    configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse),
+                    Azure.ResourceManager.Authorization.Models.RoleManagementPrincipalType.Group,
+                    managedCluster,
+                    roleDefinitionId,
+                    message.Replace(@"{Admins}", "designated group"));
+            }
+        }
+
         private Task<StorageAccountResource> CreateStorageAccountAsync()
             => Execute(
                 $"Creating Storage Account: {configuration.StorageAccountName}...",
@@ -1673,28 +1749,37 @@ namespace TesDeployer
         private ResourceIdentifier GetSubscriptionRoleDefinition(Guid roleDefinition)
             => AuthorizationRoleDefinitionResource.CreateResourceIdentifier(SubscriptionResource.CreateResourceIdentifier(configuration.SubscriptionId), new(roleDefinition.ToString("D")));
 
-        private async Task<bool> AssignRoleToResourceAsync(UserAssignedIdentityResource managedIdentity, ArmResource resource, ResourceIdentifier roleDefinitionId, string message)
+        private Task<bool> AssignRoleToResourceAsync(UserAssignedIdentityResource managedIdentity, ArmResource resource, ResourceIdentifier roleDefinitionId, string message)
+            => AssignRoleToResourceAsync([managedIdentity.Data.PrincipalId.Value], Azure.ResourceManager.Authorization.Models.RoleManagementPrincipalType.ServicePrincipal, resource, roleDefinitionId, message);
+
+        private async Task<bool> AssignRoleToResourceAsync(IEnumerable<Guid> principalIds, Azure.ResourceManager.Authorization.Models.RoleManagementPrincipalType principalType, ArmResource resource, ResourceIdentifier roleDefinitionId, string message)
         {
-            if (await resource.GetRoleAssignments().GetAllAsync(filter: "atScope()", cancellationToken: cts.Token)
-                .SelectAwaitWithCancellation(async (a, ct) => await EnsureResourceDataAsync(a, r => r.HasData, CallGetAsync, ct))
-                .Where(a => a?.HasData ?? false)
-                .Where(a => managedIdentity.Data.PrincipalId.Value.Equals(a.Data.PrincipalId.Value))
-                .Where(a => roleDefinitionId.Equals(a.Data.RoleDefinitionId))
-                .AnyAsync(cts.Token))
+            var changed = false;
+
+            foreach (var principal in principalIds)
             {
-                return false;
+                if (await resource.GetRoleAssignments().GetAllAsync(filter: "atScope()", cancellationToken: cts.Token)
+                    .SelectAwaitWithCancellation(async (a, ct) => await EnsureResourceDataAsync(a, r => r.HasData, CallGetAsync, ct))
+                    .Where(a => a?.HasData ?? false)
+                    .Where(a => principal.Equals(a.Data.PrincipalId.Value))
+                    .Where(a => roleDefinitionId.Equals(a.Data.RoleDefinitionId))
+                    .AnyAsync(cts.Token))
+                {
+                    continue;
+                }
+
+                changed = true;
+                await Execute(message, () => roleAssignmentHashConflictRetryPolicy.ExecuteAsync(token =>
+                    (Task)resource.GetRoleAssignments().CreateOrUpdateAsync(WaitUntil.Completed, Guid.NewGuid().ToString(),
+                        new(roleDefinitionId, principal)
+                        {
+                            PrincipalType = Azure.ResourceManager.Authorization.Models.RoleManagementPrincipalType.ServicePrincipal
+                        },
+                        token),
+                    cts.Token));
             }
 
-            await Execute(message, () => roleAssignmentHashConflictRetryPolicy.ExecuteAsync(token =>
-                (Task)resource.GetRoleAssignments().CreateOrUpdateAsync(WaitUntil.Completed, Guid.NewGuid().ToString(),
-                    new(roleDefinitionId, managedIdentity.Data.PrincipalId.Value)
-                    {
-                        PrincipalType = Azure.ResourceManager.Authorization.Models.RoleManagementPrincipalType.ServicePrincipal
-                    },
-                    token),
-                cts.Token));
-
-            return true;
+            return changed;
 
             static Func<CancellationToken, Task<Response<RoleAssignmentResource>>> CallGetAsync(RoleAssignmentResource resource)
             {
@@ -1865,7 +1950,7 @@ namespace TesDeployer
 
                     properties.AccessPolicies.AddRange(
                     [
-                        new(tenantId.Value, await GetUserObjectId(), permissions),
+                        new(tenantId.Value, (await GetUserObjectAsync()).Id, permissions),
                         new(tenantId.Value, managedIdentity.Data.PrincipalId.Value.ToString("D"), permissions),
                     ]);
 
@@ -1907,41 +1992,48 @@ namespace TesDeployer
                     }
 
                     return vault;
-
-                    async ValueTask<string> GetUserObjectId()
-                    {
-                        string baseUrl;
-                        {
-                            using var client = GraphClientFactory.Create(nationalCloud: NationalCloud());
-                            baseUrl = client.BaseAddress.AbsoluteUri;
-                        }
-                        {
-                            using var client = new GraphServiceClient(tokenCredential, baseUrl: baseUrl);
-                            return (await client.Me.GetAsync(cancellationToken: cts.Token)).Id;
-                        }
-                    }
-
-                    // Note that there are two different values for USGovernment.
-                    string NationalCloud()
-                    {
-                        if (cloudEnvironment.ArmEnvironment.Endpoint == ArmEnvironment.AzurePublicCloud.Endpoint)
-                        {
-                            return GraphClientFactory.Global_Cloud;
-                        }
-
-                        if (cloudEnvironment.ArmEnvironment.Endpoint == ArmEnvironment.AzureChina.Endpoint)
-                        {
-                            return GraphClientFactory.China_Cloud;
-                        }
-
-                        if (cloudEnvironment.ArmEnvironment.Endpoint == ArmEnvironment.AzureGovernment.Endpoint)
-                        {
-                            return GraphClientFactory.USGOV_Cloud; // TODO: when should we return GraphClientFactory.USGOV_DOD_Cloud?
-                        }
-
-                        return GraphClientFactory.Global_Cloud;
-                    }
                 });
+
+        private Microsoft.Graph.Models.User _me = null;
+
+        async Task<Microsoft.Graph.Models.User> GetUserObjectAsync()
+        {
+            if (_me is null)
+            {
+                Dictionary<Uri, string> nationalClouds = new(
+                [
+                    new(ArmEnvironment.AzurePublicCloud.Endpoint, GraphClientFactory.Global_Cloud),
+                    new(ArmEnvironment.AzureChina.Endpoint, GraphClientFactory.China_Cloud),
+                    // Note that there are two different values for USGovernment.
+                    new(ArmEnvironment.AzureGovernment.Endpoint, GraphClientFactory.USGOV_Cloud), // TODO: when should we return GraphClientFactory.USGOV_DOD_Cloud?
+                ]);
+
+                string baseUrl;
+                {
+                    using var client = GraphClientFactory.Create(nationalCloud: nationalClouds.TryGetValue(cloudEnvironment.ArmEnvironment.Endpoint, out var value) ? value : GraphClientFactory.Global_Cloud);
+                    baseUrl = client.BaseAddress.AbsoluteUri;
+                }
+                {
+                    using var client = new GraphServiceClient(tokenCredential, baseUrl: baseUrl);
+
+                    try
+                    {
+                        _me = await client.Me.GetAsync(cancellationToken: cts.Token);
+                    }
+                    catch (AuthenticationFailedException)
+                    {
+                        _me = null;
+                    }
+                    catch (Microsoft.Graph.Models.ODataErrors.ODataError ex) when ("BadRequest".Equals(ex.Error?.Code, StringComparison.OrdinalIgnoreCase) && ex.Message.Contains("/me", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // "/me request is only valid with delegated authentication flow."
+                        _me = null;
+                    }
+                }
+            }
+
+            return _me;
+        }
 
         private Task<OperationalInsightsWorkspaceResource> CreateLogAnalyticsWorkspaceResourceAsync(string workspaceName)
             => Execute(
@@ -2421,6 +2513,7 @@ namespace TesDeployer
             ThrowIfProvidedForUpdate(configuration.VnetResourceGroupName, nameof(configuration.VnetResourceGroupName));
             ThrowIfProvidedForUpdate(configuration.SubnetName, nameof(configuration.SubnetName));
             ThrowIfProvidedForUpdate(configuration.Tags, nameof(configuration.Tags));
+            ThrowIfProvidedForUpdate(configuration.AadGroupIds, nameof(configuration.AadGroupIds));
 
             ThrowIfTagsFormatIsUnacceptable(configuration.Tags, nameof(configuration.Tags));
 
@@ -2452,6 +2545,21 @@ namespace TesDeployer
             if (!new[] { "AzureCloud", "AzureUSGovernment", "AzureChinaCloud" }.Contains(configuration.AzureCloudName, StringComparer.OrdinalIgnoreCase))
             {
                 throw new ValidationException("AzureCloudName must be either 'AzureCloud','AzureUSGovernment', or 'AzureChinaCloud'");
+            }
+
+            if (!string.IsNullOrWhiteSpace(configuration.AadGroupIds))
+            {
+                try
+                {
+                    if (!configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse).Any())
+                    {
+                        throw new FormatException();
+                    }
+                }
+                catch (FormatException)
+                {
+                    throw new ValidationException("Invalid configuration option AadGroupIds is not formatted correctly.");
+                }
             }
         }
 

--- a/src/deploy-tes-on-azure/Deployer.cs
+++ b/src/deploy-tes-on-azure/Deployer.cs
@@ -439,10 +439,6 @@ namespace TesDeployer
                         }
                     }
 
-                    //if (installedVersion is null || installedVersion < new Version(5, 4, 7))
-                    //{
-                    //}
-
                     //if (installedVersion is null || installedVersion < new Version(x, y, z))
                     //{
                     //}
@@ -1235,7 +1231,7 @@ namespace TesDeployer
 
             var federatedCredentialsCollection = managedIdentity.GetFederatedIdentityCredentials();
 
-            if ((await federatedCredentialsCollection.SingleOrDefaultAsync(r => "coaFederatedIdentity".Equals(r.Id.Name, StringComparison.OrdinalIgnoreCase), cts.Token)) is null)
+            if ((await federatedCredentialsCollection.SingleOrDefaultAsync(r => "toaFederatedIdentity".Equals(r.Id.Name, StringComparison.OrdinalIgnoreCase), cts.Token)) is null)
             {
                 var data = new FederatedIdentityCredentialData()
                 {
@@ -1580,16 +1576,12 @@ namespace TesDeployer
             var message = $"Assigning '{RoleDefinitions.GetDisplayName(RoleDefinitions.Containers.RbacClusterAdmin)}' role for {{Admins}} to AKS cluster resource scope...";
             var roleDefinitionId = GetSubscriptionRoleDefinition(RoleDefinitions.Containers.RbacClusterAdmin);
 
-            _ = ConsoleEx.WriteLine($"AadGroupIds: {configuration.AadGroupIds ?? "<null>"}", ConsoleColor.Yellow);
-            _ = ConsoleEx.WriteLine($"AdminGroupObjectIds: {string.Join(", ", managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? []):D}", ConsoleColor.Yellow);
             var adminGroupObjectIds = managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? [];
             adminGroupObjectIds = adminGroupObjectIds.Count != 0 ? adminGroupObjectIds : (string.IsNullOrWhiteSpace(configuration.AadGroupIds) ? [] : configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse).ToList());
-            _ = ConsoleEx.WriteLine($"adminGroupObjectIds: {string.Join(", ", adminGroupObjectIds):D}", ConsoleColor.Yellow);
 
             if (adminGroupObjectIds.Count == 0)
             {
                 var user = await GetUserObjectAsync();
-                _ = ConsoleEx.WriteLine($"User: {user?.Id ?? "<null>"}", ConsoleColor.Yellow);
 
                 if (user is not null)
                 {

--- a/src/deploy-tes-on-azure/Deployer.cs
+++ b/src/deploy-tes-on-azure/Deployer.cs
@@ -1574,11 +1574,15 @@ namespace TesDeployer
             var message = $"Assigning '{RoleDefinitions.GetDisplayName(RoleDefinitions.Containers.RbacClusterAdmin)}' role for {{Admins}} to AKS cluster resource scope...";
             var roleDefinitionId = GetSubscriptionRoleDefinition(RoleDefinitions.Containers.RbacClusterAdmin);
 
+            _ = ConsoleEx.WriteLine($"AadGroupIds: {configuration.AadGroupIds ?? "<null>"}", ConsoleColor.Yellow);
+            _ = ConsoleEx.WriteLine($"AdminGroupObjectIds: {string.Join(", ", managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? []):D}", ConsoleColor.Yellow);
             var adminGroupObjectIds = managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? (string.IsNullOrWhiteSpace(configuration.AadGroupIds) ? [] : configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse).ToList());
+            _ = ConsoleEx.WriteLine($"adminGroupObjectIds: {string.Join(", ", adminGroupObjectIds):D}", ConsoleColor.Yellow);
 
             if (adminGroupObjectIds.Count == 0)
             {
                 var user = await GetUserObjectAsync();
+                _ = ConsoleEx.WriteLine($"User: {user?.Id ?? "<null>"}", ConsoleColor.Yellow);
 
                 if (user is not null)
                 {
@@ -1593,7 +1597,7 @@ namespace TesDeployer
             else
             {
                 await AssignRoleToResourceAsync(
-                    configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse),
+                    adminGroupObjectIds,
                     Azure.ResourceManager.Authorization.Models.RoleManagementPrincipalType.Group,
                     managedCluster,
                     roleDefinitionId,

--- a/src/deploy-tes-on-azure/Deployer.cs
+++ b/src/deploy-tes-on-azure/Deployer.cs
@@ -1577,7 +1577,7 @@ namespace TesDeployer
             _ = ConsoleEx.WriteLine($"AadGroupIds: {configuration.AadGroupIds ?? "<null>"}", ConsoleColor.Yellow);
             _ = ConsoleEx.WriteLine($"AdminGroupObjectIds: {string.Join(", ", managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? []):D}", ConsoleColor.Yellow);
             var adminGroupObjectIds = managedCluster.Data.AadProfile?.AdminGroupObjectIds ?? [];
-            adminGroupObjectIds = adminGroupObjectIds.Count == 0 ? adminGroupObjectIds : (string.IsNullOrWhiteSpace(configuration.AadGroupIds) ? [] : configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse).ToList());
+            adminGroupObjectIds = adminGroupObjectIds.Count != 0 ? adminGroupObjectIds : (string.IsNullOrWhiteSpace(configuration.AadGroupIds) ? [] : configuration.AadGroupIds.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse).ToList());
             _ = ConsoleEx.WriteLine($"adminGroupObjectIds: {string.Join(", ", adminGroupObjectIds):D}", ConsoleColor.Yellow);
 
             if (adminGroupObjectIds.Count == 0)

--- a/src/deploy-tes-on-azure/Deployer.cs
+++ b/src/deploy-tes-on-azure/Deployer.cs
@@ -1778,7 +1778,7 @@ namespace TesDeployer
                     (Task)resource.GetRoleAssignments().CreateOrUpdateAsync(WaitUntil.Completed, Guid.NewGuid().ToString(),
                         new(roleDefinitionId, principal)
                         {
-                            PrincipalType = Azure.ResourceManager.Authorization.Models.RoleManagementPrincipalType.ServicePrincipal
+                            PrincipalType = principalType
                         },
                         token),
                     cts.Token));

--- a/src/deploy-tes-on-azure/RoleDefinitions.cs
+++ b/src/deploy-tes-on-azure/RoleDefinitions.cs
@@ -27,6 +27,9 @@ namespace TesDeployer
                     // https://learn.microsoft.com/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-owner
                     new($"{nameof(Storage)}.{nameof(Storage.StorageBlobDataOwner)}", new(new("b7e6dc6d-f1e8-4753-8033-0f276bb0955b"), "Storage Blob Data Owner")),
 
+                    // https://learn.microsoft.com/azure/role-based-access-control/built-in-roles/containers#azure-kubernetes-service-rbac-cluster-admin
+                    new($"{nameof(Containers)}.{nameof(Containers.RbacClusterAdmin)}", new(new("b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b"), "Azure Kubernetes Service RBAC Cluster Admin")),
+
                     // https://learn.microsoft.com/azure/role-based-access-control/built-in-roles/identity#managed-identity-operator
                     new($"{nameof(Identity)}.{nameof(Identity.ManagedIdentityOperator)}", new(new("f1a07417-d97a-45cb-824c-7a7467783830"), "Managed Identity Operator")),
                 ]);
@@ -61,6 +64,14 @@ namespace TesDeployer
             /// Provides full access to Azure Storage blob containers and data, including assigning POSIX access control. To learn which actions are required for a given data operation, see [Permissions for calling data operations](https://learn.microsoft.com/rest/api/storageservices/authorize-with-azure-active-directory#permissions-for-calling-data-operations)/>.
             /// </summary>
             internal static Guid StorageBlobDataOwner { get; } = _roleDefinitions[$"{nameof(Storage)}.{nameof(StorageBlobDataOwner)}"].Name;
+        }
+
+        internal static class Containers
+        {
+            /// <summary>
+            /// Azure Kubernetes Fleet Manager RBAC Cluster Admin.
+            /// </summary>
+            internal static Guid RbacClusterAdmin { get; } = _roleDefinitions[$"{nameof(Containers)}.{nameof(RbacClusterAdmin)}"].Name;
         }
 
         internal static class Identity

--- a/src/deploy-tes-on-azure/deploy-tes-on-azure.csproj
+++ b/src/deploy-tes-on-azure/deploy-tes-on-azure.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Azure.ResourceManager.PrivateDns" Version="1.2.0" />
     <PackageReference Include="Azure.ResourceManager.ResourceGraph" Version="1.0.1" />
     <PackageReference Include="Azure.ResourceManager.Storage" Version="1.3.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
     <PackageReference Include="KubernetesClient" Version="15.0.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.22.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Graph" Version="5.60.0" />
+    <PackageReference Include="Microsoft.Graph" Version="5.61.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.2" />
   </ItemGroup>
   

--- a/src/deploy-tes-on-azure/scripts/helm/templates/identity.yaml
+++ b/src/deploy-tes-on-azure/scripts/helm/templates/identity.yaml
@@ -4,3 +4,4 @@ metadata:
   annotations:
     azure.workload.identity/client-id: {{ .Values.identity.clientId }}
   name: {{ .Values.identity.name }}-sa
+  namespace: {{ .Values.config.coaNamespace }}

--- a/src/deploy-tes-on-azure/scripts/helm/templates/tes-deployment.yaml
+++ b/src/deploy-tes-on-azure/scripts/helm/templates/tes-deployment.yaml
@@ -52,6 +52,8 @@ spec:
               value: {{ .Values.persistence.executionsContainerName }}
             - name: AzureServicesAuthConnectionString
               value: {{ .Values.config.azureServicesAuthConnectionString }}
+            - name: AZURE_ADDITIONALLY_ALLOWED_TENANTS
+              value: "*"
             - name: ApplicationInsights__AccountName
               value: {{ .Values.config.applicationInsightsAccountName }}
             - name: BatchAccount__AccountName

--- a/src/deploy-tes-on-azure/scripts/helm/templates/tes-deployment.yaml
+++ b/src/deploy-tes-on-azure/scripts/helm/templates/tes-deployment.yaml
@@ -52,8 +52,6 @@ spec:
               value: {{ .Values.persistence.executionsContainerName }}
             - name: AzureServicesAuthConnectionString
               value: {{ .Values.config.azureServicesAuthConnectionString }}
-            - name: AZURE_ADDITIONALLY_ALLOWED_TENANTS
-              value: "*"
             - name: ApplicationInsights__AccountName
               value: {{ .Values.config.applicationInsightsAccountName }}
             - name: BatchAccount__AccountName


### PR DESCRIPTION
This changes Azure Kubernetes authentication integration to use `Azure RBAC for Kubernetes` authorization, which may require adding an azure role similar to `Azure Kubernetes Service RBAC Cluster Admin` in order to troubleshoot Kubernetes.