### PR TITLE
Successfully don't add SAS token on blob storage URLs with no permissions

### DIFF
--- a/src/Tes.Runner.Test/Storage/ArmUrlTransformationStrategyTests.cs
+++ b/src/Tes.Runner.Test/Storage/ArmUrlTransformationStrategyTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Net;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;

--- a/src/Tes.Runner.Test/Storage/ArmUrlTransformationStrategyTests.cs
+++ b/src/Tes.Runner.Test/Storage/ArmUrlTransformationStrategyTests.cs
@@ -16,6 +16,7 @@ namespace Tes.Runner.Test.Storage
     public class ArmUrlTransformationStrategyTests
     {
         private Mock<BlobServiceClient> mockBlobServiceClient = null!;
+        private Mock<Runner.Transfer.BlobApiHttpUtils> mockBlobApiHttpUtils = null!;
         private ArmUrlTransformationStrategy armUrlTransformationStrategy = null!;
         private UserDelegationKey userDelegationKey = null!;
         const string StorageAccountName = "foo";
@@ -30,54 +31,42 @@ namespace Tes.Runner.Test.Storage
                 AzureEnvironmentConfig = AzureEnvironmentConfig.FromArmEnvironmentEndpoints(CommonUtilities.AzureCloud.AzureCloudConfig.FromKnownCloudNameAsync().Result)
             };
 
-            armUrlTransformationStrategy = new ArmUrlTransformationStrategy(_ => mockBlobServiceClient.Object, options);
+            mockBlobApiHttpUtils = new();
+            mockBlobApiHttpUtils.Setup(x => x.IsEndPointPublic(It.IsAny<Uri>()))
+                .ReturnsAsync(false);
+
+            armUrlTransformationStrategy = new ArmUrlTransformationStrategy(_ => mockBlobServiceClient.Object, options, mockBlobApiHttpUtils.Object);
             userDelegationKey = BlobsModelFactory.UserDelegationKey(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), DateTimeOffset.UtcNow,
                 DateTimeOffset.UtcNow.AddHours(1), "SIGNED_SERVICE", "V1_0", RunnerTestUtils.GenerateRandomTestAzureStorageKey());
-        }
-
-        private void SetupSuccess()
-        {
             mockBlobServiceClient.Setup(c => c.GetUserDelegationKeyAsync(It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Azure.Response.FromValue(userDelegationKey, null!));
-        }
-
-        private void SetupFailure()
-        {
-            mockBlobServiceClient.Setup(c => c.GetUserDelegationKeyAsync(It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new Azure.RequestFailedException((int)HttpStatusCode.Forbidden, "Error message.", BlobErrorCode.AuthorizationPermissionMismatch.ToString(), default));
         }
 
         [TestMethod]
         public async Task TransformUrlWithStrategyAsync_BlobStorageUrlWithOutPermissions_WhenRequestingRead_UrlIsReturnAsIs()
         {
-            SetupFailure();
+            mockBlobApiHttpUtils.Setup(x => x.IsEndPointPublic(It.IsAny<Uri>()))
+                .ReturnsAsync(true);
 
             var sourceUrl = $"https://{StorageAccountName}.blob.core.windows.net/cont/blob";
             var transformedUrl = await armUrlTransformationStrategy.TransformUrlWithStrategyAsync(sourceUrl, BlobSasPermissions.Read);
 
+            Assert.AreEqual(1, mockBlobApiHttpUtils.Invocations.Count);
             Assert.IsNotNull(transformedUrl);
             var blobUri = new Uri(sourceUrl);
             Assert.AreEqual(blobUri.AbsoluteUri, transformedUrl.AbsoluteUri);
         }
 
         [TestMethod]
-        public async Task TransformUrlWithStrategyAsync_BlobStorageUrlWithOutPermissions_WhenRequestingWrite_FailureIsThrown()
+        public async Task TransformUrlWithStrategyAsync_BlobStorageUrlWithOutPermissions_WhenRequestingWrite_IsEndPointPublicIsNotCalled()
         {
-            SetupFailure();
+            mockBlobApiHttpUtils.Setup(x => x.IsEndPointPublic(It.IsAny<Uri>()))
+                .ReturnsAsync(true);
 
             var sourceUrl = $"https://{StorageAccountName}.blob.core.windows.net/cont/blob";
+            var transformedUrl = await armUrlTransformationStrategy.TransformUrlWithStrategyAsync(sourceUrl, BlobSasPermissions.Create);
 
-            try
-            {
-                var transformedUrl = await armUrlTransformationStrategy.TransformUrlWithStrategyAsync(sourceUrl, BlobSasPermissions.Create);
-                Assert.Fail("Exception was not thrown");
-            }
-            catch (Azure.RequestFailedException e) when (e.Status == (int)HttpStatusCode.Forbidden && BlobErrorCode.AuthorizationPermissionMismatch.ToString().Equals(e.ErrorCode, StringComparison.InvariantCultureIgnoreCase))
-            { }
-            catch (Exception)
-            {
-                Assert.Fail("Incorrect exception was thrown.");
-            }
+            Assert.IsFalse(mockBlobApiHttpUtils.Invocations.Any());
         }
 
         [TestMethod]
@@ -86,8 +75,6 @@ namespace Tes.Runner.Test.Storage
         [DataRow($"https://{StorageAccountName}.blob.core.windows.net/cont/blob")]
         public async Task TransformUrlWithStrategyAsync_ValidBlobStorageUrl_SasTokenIsGenerated(string sourceUrl)
         {
-            SetupSuccess();
-
             var sasTokenUrl = await armUrlTransformationStrategy.TransformUrlWithStrategyAsync(sourceUrl, BlobSasPermissions.Read);
 
             Assert.IsNotNull(sasTokenUrl);
@@ -102,8 +89,6 @@ namespace Tes.Runner.Test.Storage
         [DataRow($"s3://foo.s3.bar")]
         public async Task TransformUrlWithStrategyAsync_InvalidBlobStorageUrl_UrlIsReturnAsIs(string sourceUrl)
         {
-            SetupSuccess();
-
             var transformedUrl = await armUrlTransformationStrategy.TransformUrlWithStrategyAsync(sourceUrl, BlobSasPermissions.Read);
 
             Assert.IsNotNull(transformedUrl);
@@ -118,8 +103,6 @@ namespace Tes.Runner.Test.Storage
         [DataRow($"https://{StorageAccountName}.blob.core.windows.net/cont/blob?{SasToken}")]
         public async Task TransformUrlWithStrategyAsync_BlobStorageUrlWithSasToken_UrlIsReturnAsIs(string sourceUrl)
         {
-            SetupSuccess();
-
             var transformedUrl = await armUrlTransformationStrategy.TransformUrlWithStrategyAsync(sourceUrl, BlobSasPermissions.Read);
 
             Assert.IsNotNull(transformedUrl);
@@ -130,8 +113,6 @@ namespace Tes.Runner.Test.Storage
         [TestMethod]
         public async Task TransformUrlWithStrategyAsync_CallTwiceForSameStorageAccount_CachesKey()
         {
-            SetupSuccess();
-
             var sourceUrl = $"https://{StorageAccountName}.blob.core.windows.net";
 
             var sasTokenUrl1 = await armUrlTransformationStrategy.TransformUrlWithStrategyAsync(sourceUrl, BlobSasPermissions.Read);

--- a/src/Tes.Runner/Transfer/BlobApiHttpUtils.cs
+++ b/src/Tes.Runner/Transfer/BlobApiHttpUtils.cs
@@ -191,12 +191,14 @@ public class BlobApiHttpUtils(HttpClient httpClient, AsyncRetryPolicy retryPolic
 
         }
         catch (HttpRequestException e) when (e.StatusCode switch
-            {
-                HttpStatusCode.Unauthorized => true,
-                HttpStatusCode.Forbidden => true, // Because not everyone understands the difference between 401 & 403
-                HttpStatusCode.Conflict => true, // Blob Storage returns this instead of 401
-                _ => false,
-            })
+        {
+            HttpStatusCode.Unauthorized => true,
+            // Because not everyone understands the difference between 401 & 403
+            HttpStatusCode.Forbidden => true,
+            // Blob Storage returns 409 instead of 401
+            HttpStatusCode.Conflict => true,
+            _ => false,
+        })
         {
             return false;
         }

--- a/src/Tes.Runner/Transfer/BlobApiHttpUtils.cs
+++ b/src/Tes.Runner/Transfer/BlobApiHttpUtils.cs
@@ -190,7 +190,13 @@ public class BlobApiHttpUtils(HttpClient httpClient, AsyncRetryPolicy retryPolic
             return true;
 
         }
-        catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.Unauthorized)
+        catch (HttpRequestException e) when (e.StatusCode switch
+            {
+                HttpStatusCode.Unauthorized => true,
+                HttpStatusCode.Forbidden => true, // Because not everyone understands the difference between 401 & 403
+                HttpStatusCode.Conflict => true, // Blob Storage returns this instead of 401
+                _ => false,
+            })
         {
             return false;
         }

--- a/src/Tes.Runner/Transfer/BlobApiHttpUtils.cs
+++ b/src/Tes.Runner/Transfer/BlobApiHttpUtils.cs
@@ -193,9 +193,9 @@ public class BlobApiHttpUtils(HttpClient httpClient, AsyncRetryPolicy retryPolic
         catch (HttpRequestException e) when (e.StatusCode switch
         {
             HttpStatusCode.Unauthorized => true,
-            // Because not everyone understands the difference between 401 & 403
+            // Because some servers confuse the difference between 401 & 403
             HttpStatusCode.Forbidden => true,
-            // Blob Storage returns 409 instead of 401
+            // Azure Blob Storage returns 409 instead of 401
             HttpStatusCode.Conflict => true,
             _ => false,
         })

--- a/src/Tes.Runner/Transfer/BlobApiHttpUtils.cs
+++ b/src/Tes.Runner/Transfer/BlobApiHttpUtils.cs
@@ -93,6 +93,7 @@ public class BlobApiHttpUtils(HttpClient httpClient, AsyncRetryPolicy retryPolic
     {
         return new Uri($"{baseUri?.AbsoluteUri}&comp=block&blockid={ToBlockId(ordinal)}");
     }
+
     public static Uri ParsePutAppendBlockUrl(Uri? baseUri)
     {
         ArgumentNullException.ThrowIfNull(baseUri);
@@ -180,6 +181,21 @@ public class BlobApiHttpUtils(HttpClient httpClient, AsyncRetryPolicy retryPolic
 
         return !string.IsNullOrWhiteSpace(blobBuilder.Sas?.Signature);
     }
+
+    public virtual async Task<bool> IsEndPointPublic(Uri uri)
+    {
+        try
+        {
+            using var _ = await ExecuteHttpRequestAsync(() => new HttpRequestMessage(HttpMethod.Head, uri));
+            return true;
+
+        }
+        catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            return false;
+        }
+    }
+
     private async Task<HttpResponseMessage> ExecuteHttpRequestImplAsync(Func<HttpRequestMessage> request, CancellationToken cancellationToken)
     {
         HttpResponseMessage? response = null;


### PR DESCRIPTION
This is due to `datasettestinputs` no longer accepting SAS tokens.