### PR TITLE
Add test node debugging aid

### DIFF
--- a/src/CommonUtilities/AzureServicesConnectionStringCredential.cs
+++ b/src/CommonUtilities/AzureServicesConnectionStringCredential.cs
@@ -71,7 +71,7 @@ namespace CommonUtilities
 
         private void SetInitialState(AzureCloudConfig armEndpoints)
         {
-            (GetEnvironmentVariable("AZURE_ADDITIONALLY_ALLOWED_TENANTS") ?? string.Empty).Split([';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ForEach(AdditionallyAllowedTenants.Add);
+            (GetEnvironmentVariable("AZURE_ADDITIONALLY_ALLOWED_TENANTS") ?? string.Empty).Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ForEach(AdditionallyAllowedTenants.Add);
             TenantId = GetEnvironmentVariable("AZURE_TENANT_ID")!;
             AuthorityHost = armEndpoints.AuthorityHost ?? new(armEndpoints.Authentication?.LoginEndpointUrl ?? throw new ArgumentException("AuthorityHost is missing", nameof(armEndpoints)));
             Audience = armEndpoints.ArmEnvironment?.Audience ?? armEndpoints.Authentication?.Audiences?.LastOrDefault() ?? throw new ArgumentException("Audience is missing", nameof(armEndpoints));

--- a/src/Tes.RunnerCLI/Program.cs
+++ b/src/Tes.RunnerCLI/Program.cs
@@ -30,6 +30,7 @@ static async Task<int> StartUpAsync(string[] args)
 
         if (exitCode != 0 && TimeSpan.TryParseExact(delayOnFailureStr, "c", System.Globalization.CultureInfo.InvariantCulture, out var delayOnFailure))
         {
+            Console.WriteLine($"Delaying for {delayOnFailure} due to DEBUG_DELAY environment variable.");
             await Task.Delay(delayOnFailure);
         }
 

--- a/src/Tes.RunnerCLI/Program.cs
+++ b/src/Tes.RunnerCLI/Program.cs
@@ -16,11 +16,23 @@ static async Task<int> StartUpAsync(string[] args)
 
     try
     {
-        return await rootCommand.InvokeAsync(args);
+        return await Return(await rootCommand.InvokeAsync(args));
     }
     catch (Exception ex)
     {
         Console.WriteLine(ex.ToString());
-        return (int)ProcessExitCode.UncategorizedError;
+        return await Return((int)ProcessExitCode.UncategorizedError);
+    }
+
+    static async ValueTask<int> Return(int exitCode)
+    {
+        var delayOnFailureStr = Environment.GetEnvironmentVariable("DEBUG_DELAY");
+
+        if (exitCode != 0 && TimeSpan.TryParseExact(delayOnFailureStr, "c", System.Globalization.CultureInfo.InvariantCulture, out var delayOnFailure))
+        {
+            await Task.Delay(delayOnFailure);
+        }
+
+        return exitCode;
     }
 }

--- a/src/Tes.RunnerCLI/Tes.RunnerCLI.csproj
+++ b/src/Tes.RunnerCLI/Tes.RunnerCLI.csproj
@@ -73,7 +73,7 @@
     </GenerateMD5>
     <WriteLinesToFile Lines="$(__RunnerMD5Hash)" File="$(IntermediateOutputPath)$(AssemblyName).md5" WriteOnlyWhenDifferent="true" Overwrite="true" />
     <ItemGroup>
-    <FileWrites Include="$(IntermediateOutputPath)$(AssemblyName).md5" />
+      <FileWrites Include="$(IntermediateOutputPath)$(AssemblyName).md5" />
       <ResolvedFileToPublish Include="$(IntermediateOutputPath)$(AssemblyName).md5">
         <RelativePath>$(AssemblyName).md5</RelativePath>
       </ResolvedFileToPublish>

--- a/src/TesApi.Web/Options/BatchNodesOptions.cs
+++ b/src/TesApi.Web/Options/BatchNodesOptions.cs
@@ -13,25 +13,35 @@ namespace TesApi.Web.Options
         /// </summary>
         public const string SectionName = "BatchNodes";
 
+
         /// <summary>
         /// True to disable providing compute nodes a public ip address, False otherwise.
         /// </summary>
         public bool DisablePublicIpAddress { get; set; } = false;
+
         /// <summary>
         /// Full resource id to the subnet all batch nodes will be attached to.
         /// </summary>
         public string SubnetId { get; set; } = string.Empty;
+
         /// <summary>
         /// Full resource id to the global managed identity.
         /// </summary>
         public string GlobalManagedIdentity { get; set; } = string.Empty;
+
         /// <summary>
         /// Path to the global start task script.
         /// </summary>
         public string GlobalStartTask { get; set; } = string.Empty;
+
         /// <summary>
         /// True to have the runner calculate and provide the blob content MD5 to the storage account, False otherwise.
         /// </summary>
         public bool ContentMD5 { get; set; } = false;
+
+        /// <summary>
+        /// Debug mode delay in minutes. Used to help diagnose issues with the runner.
+        /// </summary>
+        public double? DebugDelayInMinutes { get; set; }
     }
 }

--- a/src/TesApi.Web/Storage/DefaultStorageAccessProvider.cs
+++ b/src/TesApi.Web/Storage/DefaultStorageAccessProvider.cs
@@ -43,7 +43,7 @@ namespace TesApi.Web.Storage
             this.storageOptions = storageOptions.Value;
             this.azureEnvironmentConfig = azureEnvironmentConfig;
 
-            externalStorageContainers = storageOptions.Value.ExternalStorageContainers?.Split([',', ';', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            externalStorageContainers = storageOptions.Value.ExternalStorageContainers?.Split((char[])[',', ';', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
                 .Select(uri =>
                 {
                     if (StorageAccountUrlSegments.TryCreate(uri, out var s))


### PR DESCRIPTION
fixes: #823

This is currently implemented as an opt-in. For the `tes` workflow in the k8s cluster, add the `BatchNodes__DebugDelayInMinutes` environment variable with a value that is a decimal number of minutes to delay the task ending when the task runner is returning a non-zero exit code.

Note that updating the deployment with the deployer may remove this variable.